### PR TITLE
feat: 完善示例插件并新增待办复盘记录池

### DIFF
--- a/.github/workflows/plugin-samples.yml
+++ b/.github/workflows/plugin-samples.yml
@@ -1,0 +1,42 @@
+name: Plugin samples
+
+on:
+  pull_request:
+    paths:
+      - "PaperTodo.Plugin.Abstractions/**"
+      - "plugin-samples/**"
+      - ".github/workflows/plugin-samples.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "PaperTodo.Plugin.Abstractions/**"
+      - "plugin-samples/**"
+      - ".github/workflows/plugin-samples.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-native-samples:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+      - name: Build native plugin samples
+        shell: pwsh
+        run: |
+          $projects = Get-ChildItem -Path plugin-samples -Recurse -Filter *.csproj |
+            Sort-Object FullName
+          if (-not $projects) {
+            throw "No native plugin sample projects were found."
+          }
+          foreach ($project in $projects) {
+            Write-Host "Building $($project.FullName)"
+            dotnet build $project.FullName -c Release
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
+          }

--- a/plugin-samples/PaperTodo.Plugin.FocusTimer/FocusTimerPlugin.cs
+++ b/plugin-samples/PaperTodo.Plugin.FocusTimer/FocusTimerPlugin.cs
@@ -1,3 +1,4 @@
+using System.Media;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Controls;
@@ -11,8 +12,8 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
 {
     public string Id => "sample.focus-timer.native";
     public string DisplayName => "专注计时器";
-    public string Description => "完全使用 WPF 控件实现，支持折叠后台计时和状态恢复。";
-    public Version Version => new(1, 1, 0);
+    public string Description => "完整的 WPF 番茄钟示例，支持自动轮转、声音、每日目标和折叠后台计时。";
+    public Version Version => new(1, 2, 0);
     public string ApiVersion => "1.2";
     public int StateVersion => 1;
     public PaperBodyCapabilities Capabilities => PaperBodyCapabilities.TextZoom;
@@ -29,10 +30,7 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
 
     private sealed class State
     {
-        public State()
-        {
-        }
-
+        public bool Initialized { get; set; }
         public TimerMode Mode { get; set; } = TimerMode.Focus;
         public int FocusMinutes { get; set; } = 25;
         public int BreakMinutes { get; set; } = 5;
@@ -40,7 +38,21 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
         public bool IsRunning { get; set; }
         public DateTimeOffset? EndsAtUtc { get; set; }
         public int CompletedFocusSessions { get; set; }
+        public int CompletedToday { get; set; }
+        public string CompletionDate { get; set; } = "";
     }
+
+    private sealed record Settings(
+        int FocusMinutes,
+        int BreakMinutes,
+        int AdjustStep,
+        int DailyGoal,
+        bool AutoStartNext,
+        bool ShowProgress,
+        bool ShowCompleted,
+        bool ConfirmReset,
+        string Sound,
+        string TitleStyle);
 
     private sealed class Session : IPaperBodySession
     {
@@ -60,10 +72,12 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
         private readonly TextBlock _durationText;
         private readonly Button _plusButton;
         private readonly Button _startButton;
+        private readonly Button _skipButton;
         private readonly Button _resetButton;
         private readonly Button[] _buttons;
         private readonly DispatcherTimer _timer;
 
+        private Settings _settings;
         private PaperBodyTheme _theme;
         private bool _runtimeVisible;
         private bool _disposed;
@@ -73,8 +87,9 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
         {
             _context = context;
             _theme = context.Theme;
+            _settings = ReadSettings(context.SettingsJson);
             _state = ReadState(context.StateJson);
-            var stateChanged = NormalizeState() | CompleteExpiredPhase();
+            var stateChanged = InitializeAndNormalizeState();
 
             _focusButton = MakeButton("专注");
             _breakButton = MakeButton("休息");
@@ -122,15 +137,15 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
             center.Children.Add(_statusText);
             center.Children.Add(_progress);
 
-            _minusButton = MakeButton("−5");
+            _minusButton = MakeButton("−");
             _durationText = new TextBlock
             {
-                MinWidth = 86,
+                MinWidth = 100,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
                 TextAlignment = TextAlignment.Center
             };
-            _plusButton = MakeButton("+5");
+            _plusButton = MakeButton("+");
 
             var durationRow = new StackPanel
             {
@@ -143,9 +158,11 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
             durationRow.Children.Add(_plusButton);
 
             _startButton = MakeButton("开始");
-            _startButton.MinWidth = 112;
+            _startButton.MinWidth = 102;
+            _skipButton = MakeButton("跳过");
+            _skipButton.MinWidth = 68;
             _resetButton = MakeButton("重置");
-            _resetButton.MinWidth = 78;
+            _resetButton.MinWidth = 68;
 
             var actionRow = new StackPanel
             {
@@ -153,6 +170,7 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
                 HorizontalAlignment = HorizontalAlignment.Center
             };
             actionRow.Children.Add(_startButton);
+            actionRow.Children.Add(_skipButton);
             actionRow.Children.Add(_resetButton);
 
             var footer = new StackPanel();
@@ -176,28 +194,32 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
 
             _buttons =
             [
-                _focusButton, _breakButton, _minusButton,
-                _plusButton, _startButton, _resetButton
+                _focusButton, _breakButton, _minusButton, _plusButton,
+                _startButton, _skipButton, _resetButton
             ];
 
             _focusButton.Click += (_, _) => SelectMode(TimerMode.Focus);
             _breakButton.Click += (_, _) => SelectMode(TimerMode.Break);
-            _minusButton.Click += (_, _) => ChangeDuration(-5);
-            _plusButton.Click += (_, _) => ChangeDuration(5);
+            _minusButton.Click += (_, _) => ChangeDuration(-_settings.AdjustStep);
+            _plusButton.Click += (_, _) => ChangeDuration(_settings.AdjustStep);
             _startButton.Click += (_, _) => ToggleRunning();
-            _resetButton.Click += (_, _) => Reset();
+            _skipButton.Click += (_, _) => CompletePhase(skipped: true);
+            _resetButton.Click += (_, _) => ResetWithConfirmation();
 
             _timer = new DispatcherTimer(DispatcherPriority.Background)
             {
-                Interval = TimeSpan.FromSeconds(1)
+                Interval = TimeSpan.FromMilliseconds(500)
             };
             _timer.Tick += OnTick;
 
             ApplyTheme(context.Theme);
-            UpdateView();
-            if (stateChanged)
+            if (!CompleteExpiredPhase())
             {
-                SaveState();
+                UpdateView();
+                if (stateChanged)
+                {
+                    SaveState();
+                }
             }
         }
 
@@ -206,7 +228,7 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
         private static Button MakeButton(string text) => new()
         {
             Content = text,
-            Padding = new Thickness(12, 5, 12, 5),
+            Padding = new Thickness(11, 5, 11, 5),
             Margin = new Thickness(3, 0, 3, 0),
             MinHeight = 30,
             BorderThickness = new Thickness(1),
@@ -225,17 +247,27 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
             }
         }
 
-        private bool NormalizeState()
+        private bool InitializeAndNormalizeState()
         {
             var old = JsonSerializer.Serialize(_state, JsonOptions);
+            if (!_state.Initialized)
+            {
+                _state.Initialized = true;
+                _state.FocusMinutes = _settings.FocusMinutes;
+                _state.BreakMinutes = _settings.BreakMinutes;
+                _state.RemainingSeconds = _state.FocusMinutes * 60;
+            }
+
             _state.FocusMinutes = Math.Clamp(_state.FocusMinutes, 1, 180);
             _state.BreakMinutes = Math.Clamp(_state.BreakMinutes, 1, 180);
             _state.CompletedFocusSessions = Math.Max(0, _state.CompletedFocusSessions);
+            _state.CompletedToday = Math.Max(0, _state.CompletedToday);
             if (!Enum.IsDefined(_state.Mode))
             {
                 _state.Mode = TimerMode.Focus;
             }
 
+            RefreshDailyCounter();
             _state.RemainingSeconds =
                 Math.Clamp(_state.RemainingSeconds, 0, DurationSeconds());
             if (!_state.IsRunning && _state.RemainingSeconds == 0)
@@ -256,6 +288,17 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
                 old,
                 JsonSerializer.Serialize(_state, JsonOptions),
                 StringComparison.Ordinal);
+        }
+
+        private void RefreshDailyCounter()
+        {
+            var today = DateTime.Now.ToString("yyyy-MM-dd");
+            if (string.Equals(_state.CompletionDate, today, StringComparison.Ordinal))
+            {
+                return;
+            }
+            _state.CompletionDate = today;
+            _state.CompletedToday = 0;
         }
 
         private int DurationMinutes() =>
@@ -283,21 +326,65 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
             {
                 return false;
             }
+            CompletePhase(skipped: false);
+            return true;
+        }
 
-            if (_state.Mode == TimerMode.Focus)
+        private void CompletePhase(bool skipped)
+        {
+            var completedFocus = _state.Mode == TimerMode.Focus && !skipped;
+            if (completedFocus)
             {
+                RefreshDailyCounter();
                 _state.CompletedFocusSessions++;
-                _state.Mode = TimerMode.Break;
+                _state.CompletedToday++;
+            }
+
+            _state.Mode = _state.Mode == TimerMode.Focus
+                ? TimerMode.Break
+                : TimerMode.Focus;
+            _state.RemainingSeconds = DurationSeconds();
+            _state.EndsAtUtc = null;
+            _state.IsRunning = _settings.AutoStartNext;
+            if (_state.IsRunning)
+            {
+                _state.EndsAtUtc =
+                    DateTimeOffset.UtcNow.AddSeconds(_state.RemainingSeconds);
+                StartTimer();
             }
             else
             {
-                _state.Mode = TimerMode.Focus;
+                _timer.Stop();
             }
 
-            _state.IsRunning = false;
-            _state.EndsAtUtc = null;
-            _state.RemainingSeconds = DurationSeconds();
-            return true;
+            if (!skipped)
+            {
+                PlayCompletionSound();
+            }
+            SaveState();
+            UpdateView();
+        }
+
+        private void PlayCompletionSound()
+        {
+            try
+            {
+                switch (_settings.Sound)
+                {
+                    case "asterisk":
+                        SystemSounds.Asterisk.Play();
+                        break;
+                    case "exclamation":
+                        SystemSounds.Exclamation.Play();
+                        break;
+                    case "beep":
+                        SystemSounds.Beep.Play();
+                        break;
+                }
+            }
+            catch
+            {
+            }
         }
 
         private void SelectMode(TimerMode mode)
@@ -306,7 +393,6 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
             {
                 return;
             }
-
             _state.Mode = mode;
             Reset(save: true);
         }
@@ -357,16 +443,28 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
             UpdateView();
         }
 
-        private void Reset(bool save = true)
+        private void ResetWithConfirmation()
+        {
+            if (_settings.ConfirmReset &&
+                (_state.IsRunning || RemainingSeconds() < DurationSeconds()) &&
+                MessageBox.Show(
+                    "重置当前计时？",
+                    "专注计时器",
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Question) != MessageBoxResult.Yes)
+            {
+                return;
+            }
+            Reset(save: true);
+        }
+
+        private void Reset(bool save)
         {
             _state.IsRunning = false;
             _state.EndsAtUtc = null;
             _state.RemainingSeconds = DurationSeconds();
             _timer.Stop();
-            if (save)
-            {
-                SaveState();
-            }
+            if (save) SaveState();
             UpdateView();
         }
 
@@ -374,14 +472,14 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
         {
             if (CompleteExpiredPhase())
             {
-                _timer.Stop();
-                SaveState();
+                return;
             }
             UpdateView();
         }
 
         private void UpdateView()
         {
+            RefreshDailyCounter();
             var remaining = RemainingSeconds();
             var full = DurationSeconds();
             var minutes = remaining / 60;
@@ -392,8 +490,16 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
             _statusText.Text = _state.Mode == TimerMode.Focus
                 ? (_state.IsRunning ? "保持专注" : "准备开始")
                 : (_state.IsRunning ? "放松一下" : "休息计时已暂停");
-            _completedText.Text = $"完成 {_state.CompletedFocusSessions} 轮";
-            _durationText.Text = $"{DurationMinutes()} 分钟";
+            _completedText.Text = _settings.DailyGoal > 0
+                ? $"今日 {_state.CompletedToday}/{_settings.DailyGoal} · 总计 {_state.CompletedFocusSessions}"
+                : $"今日 {_state.CompletedToday} · 总计 {_state.CompletedFocusSessions}";
+            _completedText.Visibility = _settings.ShowCompleted
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+            _durationText.Text = $"{DurationMinutes()} 分钟 · ±{_settings.AdjustStep}";
+            _progress.Visibility = _settings.ShowProgress
+                ? Visibility.Visible
+                : Visibility.Collapsed;
             _progress.Maximum = Math.Max(1, full);
             _progress.Value = Math.Clamp(full - remaining, 0, full);
             _startButton.Content = _state.IsRunning
@@ -403,7 +509,12 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
             _plusButton.IsEnabled = !_state.IsRunning && DurationMinutes() < 180;
 
             UpdateModeButtons();
-            SetDisplayTitle($"{modeName} · {minutes:00}:{seconds:00}");
+            SetDisplayTitle(_settings.TitleStyle switch
+            {
+                "status" => _state.IsRunning ? $"{modeName}中" : $"{modeName}已暂停",
+                "fixed" => "专注计时器",
+                _ => $"{modeName} · {minutes:00}:{seconds:00}"
+            });
         }
 
         private void ApplyTheme(PaperBodyTheme theme)
@@ -424,8 +535,8 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
             _durationText.FontFamily = fontFamily;
             _timeText.FontSize = 46 * scale;
             _statusText.FontSize = 12 * scale;
-            _completedText.FontSize = 11 * scale;
-            _durationText.FontSize = 12 * scale;
+            _completedText.FontSize = 10.5 * scale;
+            _durationText.FontSize = 11.5 * scale;
             _timeText.Foreground = text;
             _statusText.Foreground = weak;
             _completedText.Foreground = weak;
@@ -492,6 +603,78 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
             }
         }
 
+        private static Settings ReadSettings(string json)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(
+                    string.IsNullOrWhiteSpace(json) ? "{}" : json);
+                var root = document.RootElement;
+                return new Settings(
+                    Integer(root, "focusMinutes", 25, 1, 180),
+                    Integer(root, "breakMinutes", 5, 1, 180),
+                    Integer(root, "adjustStep", 5, 1, 30),
+                    Integer(root, "dailyGoal", 4, 0, 24),
+                    Boolean(root, "autoStartNext", false),
+                    Boolean(root, "showProgress", true),
+                    Boolean(root, "showCompleted", true),
+                    Boolean(root, "confirmReset", true),
+                    String(root, "sound", "asterisk"),
+                    String(root, "titleStyle", "countdown"));
+            }
+            catch
+            {
+                return new Settings(
+                    25, 5, 5, 4, false, true, true, true, "asterisk", "countdown");
+            }
+        }
+
+        private static int Integer(
+            JsonElement root,
+            string name,
+            int fallback,
+            int min,
+            int max) =>
+            root.TryGetProperty(name, out var value) &&
+            value.ValueKind == JsonValueKind.Number &&
+            value.TryGetInt32(out var number)
+                ? Math.Clamp(number, min, max)
+                : fallback;
+
+        private static bool Boolean(JsonElement root, string name, bool fallback) =>
+            root.TryGetProperty(name, out var value) &&
+            value.ValueKind is JsonValueKind.True or JsonValueKind.False
+                ? value.GetBoolean()
+                : fallback;
+
+        private static string String(JsonElement root, string name, string fallback) =>
+            root.TryGetProperty(name, out var value) &&
+            value.ValueKind == JsonValueKind.String
+                ? value.GetString() ?? fallback
+                : fallback;
+
+        private void ApplySettings(Settings settings)
+        {
+            var previousDuration = DurationSeconds();
+            var remaining = RemainingSeconds();
+            var wasAtStart = !_state.IsRunning && remaining == previousDuration;
+
+            _settings = settings;
+            _state.FocusMinutes = settings.FocusMinutes;
+            _state.BreakMinutes = settings.BreakMinutes;
+            _state.RemainingSeconds = wasAtStart
+                ? DurationSeconds()
+                : Math.Clamp(remaining, 1, DurationSeconds());
+            if (_state.IsRunning)
+            {
+                _state.EndsAtUtc =
+                    DateTimeOffset.UtcNow.AddSeconds(_state.RemainingSeconds);
+            }
+
+            SaveState();
+            UpdateView();
+        }
+
         private void SetDisplayTitle(string title)
         {
             if (_lastDisplayTitle == title)
@@ -523,6 +706,9 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
             SaveState();
         }
 
+        public void OnSettingsChanged(string settingsJson) =>
+            ApplySettings(ReadSettings(settingsJson));
+
         public void OnVisibilityChanged(bool visible)
         {
             _runtimeVisible = visible;
@@ -543,11 +729,8 @@ public sealed class FocusTimerPlugin : IPaperBodyPlugin
         public void OnPresentationChanged(bool visible) =>
             _root.IsHitTestVisible = visible;
 
-        public void OnThemeChanged(PaperBodyTheme theme) =>
-            ApplyTheme(theme);
-
-        public void OnTypographyChanged(PaperBodyTheme theme) =>
-            ApplyTheme(theme);
+        public void OnThemeChanged(PaperBodyTheme theme) => ApplyTheme(theme);
+        public void OnTypographyChanged(PaperBodyTheme theme) => ApplyTheme(theme);
 
         public void Dispose()
         {

--- a/plugin-samples/PaperTodo.Plugin.FocusTimer/PaperTodo.Plugin.FocusTimer.csproj
+++ b/plugin-samples/PaperTodo.Plugin.FocusTimer/PaperTodo.Plugin.FocusTimer.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/plugin-samples/PaperTodo.Plugin.FocusTimer/README.md
+++ b/plugin-samples/PaperTodo.Plugin.FocusTimer/README.md
@@ -1,14 +1,15 @@
 # WPF 原生专注计时器
 
-这是一个不依赖 WebView2、完全由 WPF 控件构成的 PaperTodo 正文插件示例。它展示了：
+这是一个不依赖 WebView2、完全由 WPF 控件构成的完整番茄钟示例。它展示了：
 
-- 原生按钮、文本和进度条；
-- `SaveStateJson` 状态持久化；
-- 折叠成胶囊后继续计时；
-- 重新打开 PaperTodo 后按 UTC 截止时间恢复；
+- 专注 / 休息阶段切换、暂停、继续、跳过和重置；
+- 可设置默认时长、加减步长、每日目标和结束提示音；
+- 可选自动开始下一阶段；
+- 今日与累计完成轮数；
+- `SaveStateJson` 持久化和 UTC 截止时间恢复；
+- 折叠成胶囊后继续计时，隐藏后暂停运行时刷新；
 - `SetDisplayTitle` 同步纸片标题和胶囊；
-- 主题、字体与正文缩放适配；
-- `Commit`、可见性和销毁生命周期处理。
+- 主题、字体、正文缩放和完整会话生命周期。
 
 ## 构建并安装
 
@@ -26,4 +27,4 @@ powershell -ExecutionPolicy Bypass -File `
 plugins\sample.focus-timer.native\
 ```
 
-启动 PaperTodo 后，在纸片正文类型菜单中选择“专注计时器”。原生 DLL 已在当前进程加载后不能热替换；重新构建插件后需要重启 PaperTodo。
+启动 PaperTodo 后，在笔记纸正文类型菜单中选择“专注计时器”。原生 DLL 已在当前进程加载后不能热替换；重新构建后需要重启 PaperTodo。

--- a/plugin-samples/PaperTodo.Plugin.FocusTimer/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.FocusTimer/plugin.json
@@ -2,11 +2,105 @@
   "kind": "native",
   "id": "sample.focus-timer.native",
   "name": "专注计时器",
-  "description": "完全使用 WPF 控件实现，支持折叠后台计时和状态恢复。",
-  "version": "1.1.0",
+  "description": "完整的 WPF 番茄钟示例，支持自动轮转、声音、每日目标和折叠后台计时。",
+  "version": "1.2.0",
   "apiVersion": "1.2",
   "stateVersion": 1,
   "entry": "PaperTodo.Plugin.FocusTimer.dll",
   "capabilities": ["textZoom"],
-  "requires": ["backgroundUpdates"]
+  "requires": ["backgroundUpdates"],
+  "settings": [
+    {
+      "id": "autoStartNext",
+      "type": "boolean",
+      "name": "自动开始下一阶段",
+      "description": "专注结束后自动开始休息，休息结束后自动开始专注。",
+      "default": false,
+      "quick": true
+    },
+    {
+      "id": "showProgress",
+      "type": "boolean",
+      "name": "显示进度条",
+      "default": true,
+      "quick": true
+    },
+    {
+      "id": "showCompleted",
+      "type": "boolean",
+      "name": "显示完成统计",
+      "default": true,
+      "quick": true
+    },
+    {
+      "id": "focusMinutes",
+      "type": "number",
+      "name": "默认专注时长",
+      "default": 25,
+      "min": 1,
+      "max": 180,
+      "step": 1,
+      "suffix": "分钟"
+    },
+    {
+      "id": "breakMinutes",
+      "type": "number",
+      "name": "默认休息时长",
+      "default": 5,
+      "min": 1,
+      "max": 180,
+      "step": 1,
+      "suffix": "分钟"
+    },
+    {
+      "id": "adjustStep",
+      "type": "number",
+      "name": "加减步长",
+      "default": 5,
+      "min": 1,
+      "max": 30,
+      "step": 1,
+      "suffix": "分钟"
+    },
+    {
+      "id": "dailyGoal",
+      "type": "number",
+      "name": "每日目标",
+      "description": "0 表示只显示完成数，不显示目标。",
+      "default": 4,
+      "min": 0,
+      "max": 24,
+      "step": 1,
+      "suffix": "轮"
+    },
+    {
+      "id": "sound",
+      "type": "select",
+      "name": "结束提示音",
+      "default": "asterisk",
+      "options": [
+        { "value": "none", "name": "静音" },
+        { "value": "beep", "name": "蜂鸣" },
+        { "value": "asterisk", "name": "提示" },
+        { "value": "exclamation", "name": "警示" }
+      ]
+    },
+    {
+      "id": "titleStyle",
+      "type": "select",
+      "name": "胶囊标题",
+      "default": "countdown",
+      "options": [
+        { "value": "countdown", "name": "阶段与倒计时" },
+        { "value": "status", "name": "仅阶段状态" },
+        { "value": "fixed", "name": "固定标题" }
+      ]
+    },
+    {
+      "id": "confirmReset",
+      "type": "boolean",
+      "name": "重置前确认",
+      "default": true
+    }
+  ]
 }

--- a/plugin-samples/PaperTodo.Plugin.OfficialClockWeb/README.md
+++ b/plugin-samples/PaperTodo.Plugin.OfficialClockWeb/README.md
@@ -1,9 +1,17 @@
 # 官方 Web 时钟插件源码
 
-这个目录保存 `official.clock.web` 的源码。Web 插件不需要编译，部署产物是 `plugin.json` 和 `web/` 的原样副本，仓库中的可加载副本位于：
+这个目录保存 `official.clock.web` 的源码。它与原生时钟提供接近的功能，用于对照同一产品如何分别使用 Web 与 WPF 实现：
+
+- 12 / 24 小时制、秒数、日期、星期、周数和日进度；
+- 本地、UTC 和多个常用城市时区；
+- 多种日期格式、标题模式和显示缩放；
+- `initialize`、`settingsChanged`、`themeChanged`、`visibilityChanged` 生命周期；
+- `setDisplayTitle` 同步纸片与胶囊标题。
+
+Web 插件不需要编译，部署产物是 `plugin.json` 和 `web/` 的原样副本。仓库中的可加载副本位于：
 
 ```text
 plugins\official.clock.web\
 ```
 
-PaperTodo 的本地发布和 GitHub Release 不携带该插件。
+修改源码后，将本目录的 `plugin.json` 和 `web/` 同步到上述目录即可重载。PaperTodo 的本地发布和 GitHub Release 不携带该插件。

--- a/plugin-samples/PaperTodo.Plugin.OfficialClockWeb/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.OfficialClockWeb/plugin.json
@@ -2,20 +2,59 @@
   "kind": "web",
   "id": "official.clock.web",
   "name": "Web 时钟",
-  "description": "PaperTodo 官方 Web 正文插件示例。",
-  "version": "1.2.0",
+  "description": "完整的 Web 插件示例：主题、时区、日期格式、标题和日进度均可配置。",
+  "version": "1.3.0",
   "apiVersion": "1.2",
   "stateVersion": 1,
   "entry": "web/index.html",
-  "capabilities": [],
+  "capabilities": ["textZoom"],
   "requires": ["backgroundUpdates"],
   "settings": [
+    { "id": "showSeconds", "type": "boolean", "name": "显示秒数", "default": true, "quick": true },
+    { "id": "showDate", "type": "boolean", "name": "显示日期", "default": true, "quick": true },
+    { "id": "showDayProgress", "type": "boolean", "name": "显示日进度", "description": "在底部显示今天已经过去的比例。", "default": true, "quick": true },
+    { "id": "showWeekday", "type": "boolean", "name": "显示星期", "default": true },
     {
-      "id": "showSeconds",
-      "type": "boolean",
-      "name": "显示秒数",
-      "default": true,
-      "quick": true
-    }
+      "id": "hourCycle", "type": "select", "name": "时间制式", "default": "24",
+      "options": [
+        { "value": "24", "name": "24 小时" },
+        { "value": "12", "name": "12 小时" }
+      ]
+    },
+    {
+      "id": "dateFormat", "type": "select", "name": "日期格式", "default": "long",
+      "options": [
+        { "value": "long", "name": "2026年8月1日" },
+        { "value": "short", "name": "2026-08-01" },
+        { "value": "slash", "name": "2026/08/01" },
+        { "value": "us", "name": "08/01/2026" },
+        { "value": "eu", "name": "01/08/2026" }
+      ]
+    },
+    {
+      "id": "timeZone", "type": "select", "name": "时区", "default": "local",
+      "options": [
+        { "value": "local", "name": "本地时间" },
+        { "value": "utc", "name": "UTC" },
+        { "value": "beijing", "name": "北京时间" },
+        { "value": "tokyo", "name": "东京时间" },
+        { "value": "london", "name": "伦敦时间" },
+        { "value": "newYork", "name": "纽约时间" },
+        { "value": "losAngeles", "name": "洛杉矶时间" }
+      ]
+    },
+    {
+      "id": "titleMode", "type": "select", "name": "胶囊标题", "default": "time",
+      "options": [
+        { "value": "time", "name": "当前时间" },
+        { "value": "date", "name": "当前日期" },
+        { "value": "zone", "name": "时区和时间" },
+        { "value": "fixed", "name": "固定为“时钟”" },
+        { "value": "custom", "name": "自定义文字" }
+      ]
+    },
+    { "id": "customTitle", "type": "string", "name": "自定义标题", "placeholder": "仅在标题模式为自定义时使用", "maxLength": 40, "default": "" },
+    { "id": "showWeekNumber", "type": "boolean", "name": "显示周数", "default": true },
+    { "id": "clockScale", "type": "number", "name": "时钟字号倍率", "default": 1, "min": 0.75, "max": 1.6, "step": 0.05, "suffix": "×" }
   ]
 }

--- a/plugin-samples/PaperTodo.Plugin.OfficialClockWeb/web/index.html
+++ b/plugin-samples/PaperTodo.Plugin.OfficialClockWeb/web/index.html
@@ -11,39 +11,161 @@
       --text: #222;
       --weak: #777;
       --accent: #b07a31;
+      --border: #807050;
       --font: system-ui, sans-serif;
-      --scale: 1;
+      --host-scale: 1;
+      --clock-scale: 1;
     }
     * { box-sizing: border-box; }
-    html, body { width: 100%; height: 100%; margin: 0; background: var(--paper); }
+    html, body { width: 100%; height: 100%; margin: 0; background: transparent; }
     body {
       display: grid;
       place-items: center;
       color: var(--text);
       font-family: var(--font);
-      font-size: calc(16px * var(--scale));
+      font-size: calc(16px * var(--host-scale));
       user-select: none;
       overflow: hidden;
     }
-    main { text-align: center; padding: 20px; }
-    #time { font-size: clamp(38px, 15vw, 76px); font-weight: 650; letter-spacing: .04em; }
-    #date { margin-top: 10px; color: var(--weak); font-size: .86em; }
+    main {
+      width: min(100%, 620px);
+      padding: clamp(18px, 5vw, 32px);
+      text-align: center;
+    }
+    .zone {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      padding: 4px 10px;
+      border: 1px solid color-mix(in srgb, var(--border) 45%, transparent);
+      border-radius: 999px;
+      color: var(--weak);
+      font-size: .72em;
+      letter-spacing: .04em;
+    }
+    .zone::before {
+      content: "";
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+    }
+    .time-row {
+      display: flex;
+      justify-content: center;
+      align-items: baseline;
+      margin-top: 12px;
+      white-space: nowrap;
+    }
+    #time {
+      font-size: calc(clamp(48px, 16vw, 92px) * var(--clock-scale));
+      font-weight: 650;
+      line-height: 1;
+      letter-spacing: .025em;
+      font-variant-numeric: tabular-nums;
+    }
     #seconds { color: var(--accent); }
+    #meridiem {
+      margin-left: 10px;
+      color: var(--weak);
+      font-size: .78em;
+      font-weight: 600;
+    }
+    #date {
+      min-height: 1.4em;
+      margin-top: 12px;
+      color: var(--weak);
+      font-size: .9em;
+    }
+    .progress {
+      height: 5px;
+      margin: 20px 10px 0;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--text) 13%, transparent);
+      overflow: hidden;
+    }
+    #progress {
+      height: 100%;
+      width: 0;
+      border-radius: inherit;
+      background: var(--accent);
+      transition: width .4s ease;
+    }
+    .meta {
+      display: flex;
+      justify-content: space-between;
+      gap: 14px;
+      margin-top: 9px;
+      color: var(--weak);
+      font-size: .68em;
+    }
+    [hidden] { display: none !important; }
   </style>
 </head>
 <body>
   <main>
-    <div id="time"><span id="hours"></span>:<span id="minutes"></span><span id="seconds"></span></div>
+    <div id="zone" class="zone"></div>
+    <div class="time-row">
+      <div id="time"><span id="hours"></span>:<span id="minutes"></span><span id="seconds"></span></div>
+      <span id="meridiem"></span>
+    </div>
     <div id="date"></div>
+    <div id="progressTrack" class="progress"><div id="progress"></div></div>
+    <div class="meta">
+      <span id="week"></span>
+      <span id="dayPercent"></span>
+    </div>
   </main>
   <script>
+    const defaults = Object.freeze({
+      showSeconds: true,
+      showDate: true,
+      showWeekday: true,
+      showDayProgress: true,
+      showWeekNumber: true,
+      hourCycle: '24',
+      dateFormat: 'long',
+      timeZone: 'local',
+      titleMode: 'time',
+      customTitle: '',
+      clockScale: 1
+    });
+
+    let settings = { ...defaults };
     let visible = true;
-    let showSeconds = true;
     let timer = 0;
-    const hoursElement = document.getElementById('hours');
-    const minutesElement = document.getElementById('minutes');
-    const secondsElement = document.getElementById('seconds');
-    const dateElement = document.getElementById('date');
+
+    const $ = id => document.getElementById(id);
+    const hoursElement = $('hours');
+    const minutesElement = $('minutes');
+    const secondsElement = $('seconds');
+    const meridiemElement = $('meridiem');
+    const dateElement = $('date');
+    const zoneElement = $('zone');
+    const progressTrack = $('progressTrack');
+    const progressElement = $('progress');
+    const weekElement = $('week');
+    const dayPercentElement = $('dayPercent');
+
+    const zoneMap = Object.freeze({
+      local: undefined,
+      utc: 'UTC',
+      beijing: 'Asia/Shanghai',
+      tokyo: 'Asia/Tokyo',
+      london: 'Europe/London',
+      newYork: 'America/New_York',
+      losAngeles: 'America/Los_Angeles'
+    });
+    const zoneLabels = Object.freeze({
+      local: '本地时间',
+      utc: 'UTC',
+      beijing: '北京时间',
+      tokyo: '东京时间',
+      london: '伦敦时间',
+      newYork: '纽约时间',
+      losAngeles: '洛杉矶时间'
+    });
 
     function applyTheme(theme) {
       if (!theme) return;
@@ -52,29 +174,108 @@
       root.setProperty('--text', theme.textColor || '#222');
       root.setProperty('--weak', theme.weakTextColor || '#777');
       root.setProperty('--accent', theme.accentColor || '#b07a31');
+      root.setProperty('--border', theme.borderColor || '#807050');
       root.setProperty('--font', JSON.stringify(theme.fontFamily || 'system-ui'));
-      root.setProperty('--scale', String(theme.fontScale || 1));
+      root.setProperty('--host-scale', String(theme.fontScale || 1));
     }
 
-    function applySettings(settings) {
-      showSeconds = settings?.showSeconds !== false;
+    function applySettings(value) {
+      settings = { ...defaults, ...(value || {}) };
+      settings.clockScale = Math.min(1.6, Math.max(.75, Number(settings.clockScale) || 1));
+      document.documentElement.style.setProperty('--clock-scale', String(settings.clockScale));
+      progressTrack.hidden = !settings.showDayProgress;
+      weekElement.hidden = !settings.showWeekNumber;
+    }
+
+    function zonedParts(date) {
+      const timeZone = zoneMap[settings.timeZone];
+      const parts = new Intl.DateTimeFormat(undefined, {
+        timeZone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        weekday: 'long',
+        hour12: settings.hourCycle === '12'
+      }).formatToParts(date);
+      return Object.fromEntries(parts.map(part => [part.type, part.value]));
+    }
+
+    function formatDate(date, parts) {
+      if (!settings.showDate && !settings.showWeekday) return '';
+      let base = '';
+      if (settings.showDate) {
+        const y = parts.year;
+        const m = parts.month;
+        const d = parts.day;
+        base = settings.dateFormat === 'short' ? `${y}-${m}-${d}`
+          : settings.dateFormat === 'slash' ? `${y}/${m}/${d}`
+          : settings.dateFormat === 'us' ? `${m}/${d}/${y}`
+          : settings.dateFormat === 'eu' ? `${d}/${m}/${y}`
+          : `${y}年${Number(m)}月${Number(d)}日`;
+      }
+      return [base, settings.showWeekday ? parts.weekday : ''].filter(Boolean).join(' · ');
+    }
+
+    function zonedClockParts(date) {
+      const timeZone = zoneMap[settings.timeZone];
+      const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hourCycle: 'h23'
+      }).formatToParts(date);
+      return Object.fromEntries(parts.map(part => [part.type, part.value]));
+    }
+
+    function isoWeek(year, month, dayOfMonth) {
+      const value = new Date(Date.UTC(Number(year), Number(month) - 1, Number(dayOfMonth)));
+      const day = value.getUTCDay() || 7;
+      value.setUTCDate(value.getUTCDate() + 4 - day);
+      const yearStart = new Date(Date.UTC(value.getUTCFullYear(), 0, 1));
+      return Math.ceil((((value - yearStart) / 86400000) + 1) / 7);
+    }
+
+    function titleText(timeText, dateText) {
+      if (settings.titleMode === 'date') return dateText.split(' · ')[0] || timeText;
+      if (settings.titleMode === 'zone') return `${zoneLabels[settings.timeZone] || '本地时间'} · ${timeText}`;
+      if (settings.titleMode === 'fixed') return '时钟';
+      if (settings.titleMode === 'custom' && String(settings.customTitle || '').trim()) {
+        return String(settings.customTitle).trim();
+      }
+      return timeText;
     }
 
     function render() {
       const now = new Date();
-      const two = value => String(value).padStart(2, '0');
-      hoursElement.textContent = two(now.getHours());
-      minutesElement.textContent = two(now.getMinutes());
-      secondsElement.textContent = showSeconds ? ':' + two(now.getSeconds()) : '';
-      dateElement.textContent = new Intl.DateTimeFormat(undefined, {
-        year: 'numeric', month: 'long', day: 'numeric', weekday: 'long'
-      }).format(now);
-      window.papertodo?.setDisplayTitle(`${two(now.getHours())}:${two(now.getMinutes())}`);
+      const parts = zonedParts(now);
+      hoursElement.textContent = parts.hour;
+      minutesElement.textContent = parts.minute;
+      secondsElement.textContent = settings.showSeconds ? `:${parts.second}` : '';
+      meridiemElement.textContent = settings.hourCycle === '12' ? (parts.dayPeriod || '') : '';
+
+      const dateText = formatDate(now, parts);
+      dateElement.textContent = dateText;
+      dateElement.hidden = !dateText;
+      zoneElement.textContent = zoneLabels[settings.timeZone] || '本地时间';
+
+      const clock = zonedClockParts(now);
+      const elapsed = Number(clock.hour) * 3600 + Number(clock.minute) * 60 + Number(clock.second);
+      const percent = Math.min(100, Math.max(0, elapsed / 864));
+      progressElement.style.width = `${percent}%`;
+      dayPercentElement.textContent = `今日 ${percent.toFixed(1)}%`;
+      weekElement.textContent = `第 ${isoWeek(parts.year, parts.month, parts.day)} 周`;
+
+      const timeText = `${parts.hour}:${parts.minute}`;
+      window.papertodo?.setDisplayTitle(titleText(timeText, dateText));
     }
 
     function updateTimer() {
       clearInterval(timer);
-      if (visible) timer = setInterval(render, 1000);
+      if (visible) timer = setInterval(render, settings.showSeconds ? 250 : 1000);
       render();
     }
 
@@ -87,7 +288,7 @@
         updateTimer();
       } else if (message.type === 'settingsChanged') {
         applySettings(message.settings);
-        render();
+        updateTimer();
       } else if (message.type === 'themeChanged' || message.type === 'typographyChanged') {
         applyTheme(message.theme);
       } else if (message.type === 'visibilityChanged') {
@@ -96,6 +297,7 @@
       }
     });
 
+    applySettings(defaults);
     render();
   </script>
 </body>

--- a/plugin-samples/PaperTodo.Plugin.ReviewArchive/GlobalUsings.cs
+++ b/plugin-samples/PaperTodo.Plugin.ReviewArchive/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using System.IO;

--- a/plugin-samples/PaperTodo.Plugin.ReviewArchive/PaperTodo.Plugin.ReviewArchive.csproj
+++ b/plugin-samples/PaperTodo.Plugin.ReviewArchive/PaperTodo.Plugin.ReviewArchive.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <Version>1.0.0</Version>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\PaperTodo.Plugin.Abstractions\PaperTodo.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/plugin-samples/PaperTodo.Plugin.ReviewArchive/README.md
+++ b/plugin-samples/PaperTodo.Plugin.ReviewArchive/README.md
@@ -1,0 +1,36 @@
+# 待办复盘记录池
+
+这是 Issue #37 的插件化实现，也是协议 1.3 事件监听与只读数据能力的完整原生示例。
+
+它会记录：
+
+- 新建待办的创建时刻；
+- 待办完成、取消完成和删除的时刻；
+- 所属纸片、正文变化和来源是否已经删除；
+- 今日、近 7 天和累计完成数量。
+
+记录池保存在插件目录的 `.runtime/review-archive.json`，不属于任何一张纸片的 `StateJson`。因此删除原待办、删除整张待办纸，甚至删除承载记录池界面的笔记纸，都不会顺带删除历史；重新创建一张笔记并切回本插件即可继续读取。安装脚本升级插件时也会保留 `.runtime`。
+
+插件只在至少有一张使用它的笔记仍可见时监听变化。折叠成胶囊仍会继续记录；彻底隐藏、删除最后一张插件纸片或退出 PaperTodo 后，期间发生的变化无法被纯后台补记。再次打开后可用“导入当前”补录现状，但补录时间会标记为“首次观察值”。
+
+## CSV 导出
+
+“导出 CSV”导出当前筛选和搜索结果。默认使用带 BOM 的 UTF-8，Excel 可直接打开中文内容，不额外引入 Office 或 OpenXML 依赖。
+
+## 构建并安装
+
+先完全退出 PaperTodo，再从仓库根目录运行：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File `
+  .\plugin-samples\Build-And-Install-NativePlugin.ps1 `
+  -ProjectPath .\plugin-samples\PaperTodo.Plugin.ReviewArchive\PaperTodo.Plugin.ReviewArchive.csproj
+```
+
+脚本会安装到：
+
+```text
+plugins\sample.review-archive.native\
+```
+
+启动 PaperTodo，新建一张笔记纸，在正文类型菜单中选择“待办复盘记录池”。

--- a/plugin-samples/PaperTodo.Plugin.ReviewArchive/ReviewArchiveModels.cs
+++ b/plugin-samples/PaperTodo.Plugin.ReviewArchive/ReviewArchiveModels.cs
@@ -1,0 +1,47 @@
+namespace PaperTodo.Plugin.ReviewArchive;
+
+internal sealed record ReviewArchiveSettings(
+    bool TrackCreated,
+    bool KeepDeleted,
+    bool ShowOpenItems,
+    string InitialImport,
+    string DefaultFilter,
+    int RetentionDays,
+    int MaxRecords,
+    string ExportEncoding,
+    string ExportDateFormat,
+    bool IncludePaperTitle,
+    bool ShowDeletedBadge,
+    bool ConfirmClear,
+    string TitleMode,
+    string FixedTitle);
+
+internal sealed class ReviewArchiveViewState
+{
+    public string Filter { get; set; } = "completed";
+    public string Search { get; set; } = "";
+}
+
+internal sealed class ReviewArchiveDocument
+{
+    public int StorageVersion { get; set; } = 1;
+    public Dictionary<string, ReviewArchiveRecord> Records { get; set; } =
+        new(StringComparer.Ordinal);
+}
+
+internal sealed class ReviewArchiveRecord
+{
+    public string PaperId { get; set; } = "";
+    public string PaperTitle { get; set; } = "";
+    public string TodoId { get; set; } = "";
+    public string Text { get; set; } = "";
+    public bool Done { get; set; }
+    public bool SourceDeleted { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+    public DateTimeOffset? DeletedAt { get; set; }
+    public DateTimeOffset LastChangedAt { get; set; }
+    public bool CreatedAtEstimated { get; set; }
+    public bool CompletedAtEstimated { get; set; }
+    public string Origin { get; set; } = "user";
+}

--- a/plugin-samples/PaperTodo.Plugin.ReviewArchive/ReviewArchivePlugin.cs
+++ b/plugin-samples/PaperTodo.Plugin.ReviewArchive/ReviewArchivePlugin.cs
@@ -1,0 +1,19 @@
+using PaperTodo.Plugin;
+
+namespace PaperTodo.Plugin.ReviewArchive;
+
+public sealed class ReviewArchivePlugin : IPaperBodyPlugin
+{
+    public string Id => "sample.review-archive.native";
+    public string DisplayName => "待办复盘记录池";
+    public string Description => "监听待办创建、完成和删除，长期保存时间戳并导出 Excel 可直接打开的 CSV。";
+    public Version Version => new(1, 0, 0);
+    public string ApiVersion => "1.3";
+    public int StateVersion => 1;
+    public PaperBodyCapabilities Capabilities => PaperBodyCapabilities.TextZoom;
+    public PaperBodyRuntimeRequirements RuntimeRequirements =>
+        PaperBodyRuntimeRequirements.BackgroundUpdates;
+
+    public IPaperBodySession Create(PaperBodyContext context) =>
+        new ReviewArchiveSession(context);
+}

--- a/plugin-samples/PaperTodo.Plugin.ReviewArchive/ReviewArchiveSession.cs
+++ b/plugin-samples/PaperTodo.Plugin.ReviewArchive/ReviewArchiveSession.cs
@@ -1,0 +1,536 @@
+using System.Text;
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Microsoft.Win32;
+using PaperTodo.Plugin;
+using static PaperTodo.Plugin.ReviewArchive.ReviewArchiveSettingsReader;
+
+namespace PaperTodo.Plugin.ReviewArchive;
+
+internal sealed class ReviewArchiveSession : IPaperBodySession
+{
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web);
+
+    private readonly PaperBodyContext _context;
+    private readonly Grid _root;
+    private readonly TextBlock _summaryText;
+    private readonly TextBlock _hintText;
+    private readonly ComboBox _filterBox;
+    private readonly TextBox _searchBox;
+    private readonly StackPanel _listPanel;
+    private readonly TextBlock _emptyText;
+    private readonly Button _importButton;
+    private readonly Button _exportButton;
+    private readonly Button _clearButton;
+    private readonly List<Button> _buttons;
+    private readonly IDisposable _subscription;
+
+    private ReviewArchiveSettings _settings;
+    private ReviewArchiveViewState _viewState;
+    private PaperBodyTheme _theme;
+    private bool _disposed;
+    private string _lastDisplayTitle = "";
+
+    public ReviewArchiveSession(PaperBodyContext context)
+    {
+        _context = context;
+        _theme = context.Theme;
+        _settings = ReadSettings(context.SettingsJson);
+        _viewState = ReadViewState(context.StateJson, _settings.DefaultFilter);
+        ReviewArchiveStore.EnsureLoaded();
+
+        _summaryText = new TextBlock
+        {
+            FontWeight = FontWeights.SemiBold,
+            FontSize = 18
+        };
+        _hintText = new TextBlock
+        {
+            Margin = new Thickness(0, 3, 0, 0),
+            FontSize = 11,
+            TextWrapping = TextWrapping.Wrap
+        };
+
+        var heading = new StackPanel();
+        heading.Children.Add(_summaryText);
+        heading.Children.Add(_hintText);
+
+        _filterBox = new ComboBox
+        {
+            Width = 112,
+            Margin = new Thickness(0, 0, 8, 0),
+            ItemsSource = new[]
+            {
+                new FilterOption("completed", "已完成"),
+                new FilterOption("today", "今天完成"),
+                new FilterOption("week", "近 7 天"),
+                new FilterOption("month", "近 30 天"),
+                new FilterOption("open", "进行中"),
+                new FilterOption("deleted", "源已删除"),
+                new FilterOption("all", "全部记录")
+            },
+            DisplayMemberPath = nameof(FilterOption.Name),
+            SelectedValuePath = nameof(FilterOption.Id),
+            SelectedValue = _viewState.Filter
+        };
+        _filterBox.SelectionChanged += (_, _) =>
+        {
+            _viewState.Filter = _filterBox.SelectedValue as string ?? "completed";
+            SaveViewState();
+            Refresh();
+        };
+
+        _searchBox = new TextBox
+        {
+            MinWidth = 120,
+            MaxWidth = 240,
+            Height = 30,
+            Padding = new Thickness(8, 4, 8, 4),
+            Text = _viewState.Search,
+            ToolTip = "搜索待办正文或所属纸片"
+        };
+        _searchBox.TextChanged += (_, _) =>
+        {
+            _viewState.Search = _searchBox.Text.Trim();
+            SaveViewState();
+            Refresh();
+        };
+
+        var filters = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Margin = new Thickness(0, 12, 0, 10)
+        };
+        filters.Children.Add(_filterBox);
+        filters.Children.Add(_searchBox);
+
+        _listPanel = new StackPanel();
+        _emptyText = new TextBlock
+        {
+            Text = "当前筛选没有记录",
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(20),
+            TextAlignment = TextAlignment.Center
+        };
+        var scroll = new ScrollViewer
+        {
+            Content = _listPanel,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled
+        };
+
+        _importButton = MakeButton("导入当前");
+        _exportButton = MakeButton("导出 CSV");
+        _clearButton = MakeButton("清空记录");
+        _buttons = [_importButton, _exportButton, _clearButton];
+        _importButton.Click += OnImport;
+        _exportButton.Click += OnExport;
+        _clearButton.Click += OnClear;
+
+        var actions = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Margin = new Thickness(0, 10, 0, 0)
+        };
+        actions.Children.Add(_importButton);
+        actions.Children.Add(_exportButton);
+        actions.Children.Add(_clearButton);
+
+        _root = new Grid
+        {
+            Margin = new Thickness(16, 13, 16, 14),
+            Background = Brushes.Transparent
+        };
+        _root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        _root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        _root.RowDefinitions.Add(new RowDefinition());
+        _root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        Grid.SetRow(heading, 0);
+        Grid.SetRow(filters, 1);
+        Grid.SetRow(scroll, 2);
+        Grid.SetRow(actions, 3);
+        _root.Children.Add(heading);
+        _root.Children.Add(filters);
+        _root.Children.Add(scroll);
+        _root.Children.Add(actions);
+
+        _subscription = context.Host.Subscribe(
+            new PaperTodoEventFilter
+            {
+                Kinds = new HashSet<PaperTodoEventKind>
+                {
+                    PaperTodoEventKind.PaperChanged,
+                    PaperTodoEventKind.PaperDeleted,
+                    PaperTodoEventKind.TodoCreated,
+                    PaperTodoEventKind.TodoChanged,
+                    PaperTodoEventKind.TodoDeleted
+                }
+            },
+            value => ReviewArchiveStore.Apply(value, _settings));
+        ReviewArchiveStore.Changed += OnArchiveChanged;
+
+        _ = ReviewArchiveStore.ImportCurrent(context.Host, _settings, manual: false);
+        ReviewArchiveStore.ApplyRetention(_settings);
+        ApplyTheme(context.Theme);
+        Refresh();
+    }
+
+    public FrameworkElement View => _root;
+
+    private sealed record FilterOption(string Id, string Name);
+
+    private static Button MakeButton(string text) => new()
+    {
+        Content = text,
+        Padding = new Thickness(12, 5, 12, 5),
+        Margin = new Thickness(6, 0, 0, 0),
+        MinHeight = 30,
+        BorderThickness = new Thickness(1),
+        Cursor = System.Windows.Input.Cursors.Hand
+    };
+
+    private void OnArchiveChanged()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var all = ReviewArchiveStore.Snapshot();
+        var today = DateTimeOffset.Now.Date;
+        var completed = all.Where(item => item.Done && item.CompletedAt.HasValue).ToArray();
+        var todayCount = completed.Count(item => item.CompletedAt!.Value.ToLocalTime().Date == today);
+        var weekCount = completed.Count(item => item.CompletedAt >= DateTimeOffset.Now.AddDays(-7));
+        _summaryText.Text = $"已完成 {completed.Length} · 今日 {todayCount} · 近 7 天 {weekCount}";
+        _hintText.Text = string.IsNullOrWhiteSpace(ReviewArchiveStore.LastSaveError)
+            ? "记录池独立保存在插件 .runtime 中；删除原待办纸片后仍可复盘和导出。"
+            : "记录池暂时无法写入：" + ReviewArchiveStore.LastSaveError;
+
+        var filtered = Filter(all)
+            .OrderByDescending(item => item.CompletedAt ?? item.LastChangedAt)
+            .Take(300)
+            .ToArray();
+        _listPanel.Children.Clear();
+        if (filtered.Length == 0)
+        {
+            _listPanel.Children.Add(_emptyText);
+        }
+        else
+        {
+            foreach (var record in filtered)
+            {
+                _listPanel.Children.Add(BuildRow(record));
+            }
+        }
+
+        var title = _settings.TitleMode switch
+        {
+            "today" => $"今日完成 {todayCount}",
+            "fixed" => string.IsNullOrWhiteSpace(_settings.FixedTitle)
+                ? "复盘记录"
+                : _settings.FixedTitle,
+            _ => $"复盘 · {completed.Length} 条"
+        };
+        SetDisplayTitle(title);
+        ApplyTheme(_theme);
+    }
+
+    private IEnumerable<ReviewArchiveRecord> Filter(IEnumerable<ReviewArchiveRecord> records)
+    {
+        var now = DateTimeOffset.Now;
+        var filter = _viewState.Filter;
+        var result = records.Where(item => filter switch
+        {
+            "today" => item.Done && item.CompletedAt?.ToLocalTime().Date == now.Date,
+            "week" => item.Done && item.CompletedAt >= now.AddDays(-7),
+            "month" => item.Done && item.CompletedAt >= now.AddDays(-30),
+            "open" => !item.Done,
+            "deleted" => item.SourceDeleted,
+            "all" => true,
+            _ => item.Done
+        });
+
+        if (!_settings.ShowOpenItems && filter == "all")
+        {
+            result = result.Where(item => item.Done || item.SourceDeleted);
+        }
+
+        var search = _viewState.Search;
+        if (search.Length > 0)
+        {
+            result = result.Where(item =>
+                item.Text.Contains(search, StringComparison.CurrentCultureIgnoreCase) ||
+                item.PaperTitle.Contains(search, StringComparison.CurrentCultureIgnoreCase));
+        }
+        return result;
+    }
+
+    private Border BuildRow(ReviewArchiveRecord record)
+    {
+        var title = new TextBlock
+        {
+            Text = string.IsNullOrWhiteSpace(record.Text) ? "（空待办）" : record.Text,
+            TextWrapping = TextWrapping.Wrap,
+            FontWeight = record.Done ? FontWeights.Normal : FontWeights.SemiBold
+        };
+
+        var metadata = new List<string>();
+        if (_settings.IncludePaperTitle && !string.IsNullOrWhiteSpace(record.PaperTitle))
+        {
+            metadata.Add(record.PaperTitle);
+        }
+        metadata.Add(record.Done
+            ? "完成 " + FormatDate(record.CompletedAt ?? record.LastChangedAt)
+            : "创建 " + FormatDate(record.CreatedAt));
+        if (record.CreatedAtEstimated || record.CompletedAtEstimated)
+        {
+            metadata.Add("时间为首次观察值");
+        }
+        if (_settings.ShowDeletedBadge && record.SourceDeleted)
+        {
+            metadata.Add("源已删除");
+        }
+
+        var detail = new TextBlock
+        {
+            Text = string.Join(" · ", metadata),
+            Margin = new Thickness(0, 4, 0, 0),
+            FontSize = 10.5,
+            TextWrapping = TextWrapping.Wrap
+        };
+
+        var panel = new StackPanel();
+        panel.Children.Add(title);
+        panel.Children.Add(detail);
+        return new Border
+        {
+            Child = panel,
+            Padding = new Thickness(10, 8, 10, 8),
+            Margin = new Thickness(0, 0, 0, 6),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(7)
+        };
+    }
+
+    private string FormatDate(DateTimeOffset value) =>
+        _settings.ExportDateFormat == "iso"
+            ? value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")
+            : value.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
+
+    private void OnImport(object sender, RoutedEventArgs e)
+    {
+        var changed = ReviewArchiveStore.ImportCurrent(_context.Host, _settings, manual: true);
+        if (!changed)
+        {
+            _hintText.Text = "当前待办已经全部存在于记录池中。";
+        }
+    }
+
+    private void OnExport(object sender, RoutedEventArgs e)
+    {
+        var records = Filter(ReviewArchiveStore.Snapshot())
+            .OrderByDescending(item => item.CompletedAt ?? item.LastChangedAt)
+            .ToArray();
+        var dialog = new SaveFileDialog
+        {
+            Title = "导出 PaperTodo 复盘记录",
+            Filter = "CSV 文件 (*.csv)|*.csv",
+            FileName = $"PaperTodo-复盘-{DateTime.Now:yyyyMMdd-HHmm}.csv",
+            AddExtension = true,
+            DefaultExt = ".csv"
+        };
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        try
+        {
+            var csv = BuildCsv(records);
+            var encoding = new UTF8Encoding(
+                encoderShouldEmitUTF8Identifier: _settings.ExportEncoding == "utf8bom");
+            File.WriteAllText(dialog.FileName, csv, encoding);
+            _hintText.Text = $"已导出 {records.Length} 条：{dialog.FileName}";
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(
+                ex.GetBaseException().Message,
+                "导出失败",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+        }
+    }
+
+    private string BuildCsv(IReadOnlyList<ReviewArchiveRecord> records)
+    {
+        var builder = new StringBuilder();
+        var headers = new List<string> { "状态", "待办" };
+        if (_settings.IncludePaperTitle)
+        {
+            headers.Add("所属纸片");
+        }
+        headers.AddRange(["创建时间", "完成时间", "源已删除", "创建时间精度", "完成时间精度", "来源"]);
+        builder.AppendLine(string.Join(',', headers.Select(Csv)));
+
+        foreach (var record in records)
+        {
+            var row = new List<string>
+            {
+                record.Done ? "已完成" : "进行中",
+                record.Text
+            };
+            if (_settings.IncludePaperTitle)
+            {
+                row.Add(record.PaperTitle);
+            }
+            row.Add(FormatDate(record.CreatedAt));
+            row.Add(record.CompletedAt.HasValue ? FormatDate(record.CompletedAt.Value) : "");
+            row.Add(record.SourceDeleted ? "是" : "否");
+            row.Add(record.CreatedAtEstimated ? "首次观察" : "精确");
+            row.Add(record.CompletedAtEstimated ? "首次观察" : record.CompletedAt.HasValue ? "精确" : "");
+            row.Add(record.Origin);
+            builder.AppendLine(string.Join(',', row.Select(Csv)));
+        }
+        return builder.ToString();
+    }
+
+    private static string Csv(string value) =>
+        '"' + (value ?? "").Replace("\"", "\"\"") + '"';
+
+    private void OnClear(object sender, RoutedEventArgs e)
+    {
+        if (_settings.ConfirmClear &&
+            MessageBox.Show(
+                "确定清空全部复盘记录吗？此操作不会删除 PaperTodo 中的待办。",
+                "清空复盘记录",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Warning) != MessageBoxResult.Yes)
+        {
+            return;
+        }
+        ReviewArchiveStore.Clear(_settings);
+    }
+
+    private void ApplyTheme(PaperBodyTheme theme)
+    {
+        _theme = theme;
+        var scale = Math.Clamp(theme.FontScale, 0.7, 2.5);
+        var text = Brush(theme.TextColor, "#202020");
+        var weak = Brush(theme.WeakTextColor, "#707070");
+        var border = Brush(theme.BorderColor, "#807050");
+        var surface = Brush(theme.IsDark ? "#18FFFFFF" : "#0C000000", "#0C000000");
+        var font = new FontFamily(theme.FontFamily);
+
+        _summaryText.Foreground = text;
+        _summaryText.FontFamily = font;
+        _summaryText.FontSize = 18 * scale;
+        _hintText.Foreground = weak;
+        _hintText.FontFamily = font;
+        _hintText.FontSize = 11 * scale;
+        _emptyText.Foreground = weak;
+        _emptyText.FontFamily = font;
+        _searchBox.Foreground = text;
+        _searchBox.Background = surface;
+        _searchBox.BorderBrush = border;
+        _filterBox.Foreground = text;
+        _filterBox.Background = surface;
+        _filterBox.BorderBrush = border;
+        foreach (var button in _buttons)
+        {
+            button.Foreground = text;
+            button.Background = surface;
+            button.BorderBrush = border;
+            button.FontFamily = font;
+            button.FontSize = 11.5 * scale;
+        }
+
+        foreach (var row in _listPanel.Children.OfType<Border>())
+        {
+            row.BorderBrush = border;
+            row.Background = surface;
+            foreach (var block in Descendants<TextBlock>(row))
+            {
+                block.Foreground = block.FontSize <= 10.5 ? weak : text;
+                block.FontFamily = font;
+            }
+        }
+    }
+
+    private static IEnumerable<T> Descendants<T>(DependencyObject root)
+        where T : DependencyObject
+    {
+        for (var i = 0; i < VisualTreeHelper.GetChildrenCount(root); i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            if (child is T match)
+            {
+                yield return match;
+            }
+            foreach (var descendant in Descendants<T>(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    private static SolidColorBrush Brush(string value, string fallback)
+    {
+        try
+        {
+            return new SolidColorBrush((Color)ColorConverter.ConvertFromString(value)!);
+        }
+        catch
+        {
+            return new SolidColorBrush((Color)ColorConverter.ConvertFromString(fallback)!);
+        }
+    }
+
+    private void SetDisplayTitle(string title)
+    {
+        if (string.Equals(_lastDisplayTitle, title, StringComparison.Ordinal))
+        {
+            return;
+        }
+        _lastDisplayTitle = title;
+        _context.SetDisplayTitle(title);
+    }
+
+    private void SaveViewState() =>
+        _context.SaveStateJson(JsonSerializer.Serialize(_viewState, JsonOptions));
+
+    public void OnSettingsChanged(string settingsJson)
+    {
+        _settings = ReadSettings(settingsJson);
+        ReviewArchiveStore.ApplyRetention(_settings);
+        Refresh();
+    }
+
+    public void OnThemeChanged(PaperBodyTheme theme) => ApplyTheme(theme);
+
+    public void OnTypographyChanged(PaperBodyTheme theme) => OnThemeChanged(theme);
+
+    public void OnPresentationChanged(bool visible) => _root.IsHitTestVisible = visible;
+
+    public void Commit() => SaveViewState();
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        ReviewArchiveStore.Changed -= OnArchiveChanged;
+        _subscription.Dispose();
+    }
+}

--- a/plugin-samples/PaperTodo.Plugin.ReviewArchive/ReviewArchiveSettingsReader.cs
+++ b/plugin-samples/PaperTodo.Plugin.ReviewArchive/ReviewArchiveSettingsReader.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+
+namespace PaperTodo.Plugin.ReviewArchive;
+
+internal static class ReviewArchiveSettingsReader
+{
+    internal static ReviewArchiveViewState ReadViewState(string json, string defaultFilter)
+    {
+        try
+        {
+            var state = JsonSerializer.Deserialize<ReviewArchiveViewState>(
+                string.IsNullOrWhiteSpace(json) ? "{}" : json,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web)) ?? new ReviewArchiveViewState();
+            state.Filter = ValidFilter(state.Filter) ? state.Filter : defaultFilter;
+            state.Search = (state.Search ?? "").Trim();
+            return state;
+        }
+        catch
+        {
+            return new ReviewArchiveViewState { Filter = defaultFilter };
+        }
+    }
+
+    private static bool ValidFilter(string value) => value is
+        "completed" or "today" or "week" or "month" or "open" or "deleted" or "all";
+
+    internal static ReviewArchiveSettings ReadSettings(string json)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(string.IsNullOrWhiteSpace(json) ? "{}" : json);
+            var root = document.RootElement;
+            return new ReviewArchiveSettings(
+                Bool(root, "trackCreated", true),
+                Bool(root, "keepDeleted", true),
+                Bool(root, "showOpenItems", false),
+                Choice(root, "initialImport", "completed", "none", "completed", "all"),
+                Choice(root, "defaultFilter", "completed", "completed", "today", "week", "month", "all"),
+                Number(root, "retentionDays", 0, 0, 3650),
+                Number(root, "maxRecords", 10000, 100, 50000),
+                Choice(root, "exportEncoding", "utf8bom", "utf8bom", "utf8"),
+                Choice(root, "exportDateFormat", "local", "local", "iso"),
+                Bool(root, "includePaperTitle", true),
+                Bool(root, "showDeletedBadge", true),
+                Bool(root, "confirmClear", true),
+                Choice(root, "titleMode", "summary", "summary", "today", "fixed"),
+                Text(root, "fixedTitle", "复盘记录", 40));
+        }
+        catch
+        {
+            return new ReviewArchiveSettings(
+                true, true, false, "completed", "completed", 0, 10000,
+                "utf8bom", "local", true, true, true, "summary", "复盘记录");
+        }
+    }
+
+    private static bool Bool(JsonElement root, string name, bool fallback) =>
+        root.TryGetProperty(name, out var value) &&
+        value.ValueKind is JsonValueKind.True or JsonValueKind.False
+            ? value.GetBoolean()
+            : fallback;
+
+    private static int Number(
+        JsonElement root,
+        string name,
+        int fallback,
+        int min,
+        int max) =>
+        root.TryGetProperty(name, out var value) && value.TryGetInt32(out var number)
+            ? Math.Clamp(number, min, max)
+            : fallback;
+
+    private static string Choice(
+        JsonElement root,
+        string name,
+        string fallback,
+        params string[] choices)
+    {
+        if (!root.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.String)
+        {
+            return fallback;
+        }
+        var text = value.GetString() ?? "";
+        return choices.Contains(text, StringComparer.Ordinal) ? text : fallback;
+    }
+
+    private static string Text(
+        JsonElement root,
+        string name,
+        string fallback,
+        int maxLength)
+    {
+        if (!root.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.String)
+        {
+            return fallback;
+        }
+        var text = (value.GetString() ?? "").Trim();
+        return text.Length <= maxLength ? text : text[..maxLength];
+    }
+}

--- a/plugin-samples/PaperTodo.Plugin.ReviewArchive/ReviewArchiveStore.cs
+++ b/plugin-samples/PaperTodo.Plugin.ReviewArchive/ReviewArchiveStore.cs
@@ -1,0 +1,467 @@
+using System.Text;
+using System.Text.Json;
+using PaperTodo.Plugin;
+
+namespace PaperTodo.Plugin.ReviewArchive;
+
+internal static class ReviewArchiveStore
+{
+    private static readonly object Gate = new();
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+    private static readonly HashSet<Guid> SeenEventIds = [];
+    private static readonly Queue<Guid> SeenEventOrder = [];
+    private static ReviewArchiveDocument? _document;
+    private static string? _path;
+
+    public static event Action? Changed;
+    public static string LastSaveError { get; private set; } = "";
+
+    public static void EnsureLoaded()
+    {
+        lock (Gate)
+        {
+            if (_document != null)
+            {
+                return;
+            }
+
+            var pluginDirectory = Path.GetDirectoryName(
+                typeof(ReviewArchivePlugin).Assembly.Location) ?? AppContext.BaseDirectory;
+            var runtimeDirectory = Path.Combine(pluginDirectory, ".runtime");
+            _path = Path.Combine(runtimeDirectory, "review-archive.json");
+            _document = ReadDocument(_path) ??
+                ReadDocument(_path + ".bak") ??
+                new ReviewArchiveDocument();
+        }
+    }
+
+    public static IReadOnlyList<ReviewArchiveRecord> Snapshot()
+    {
+        EnsureLoaded();
+        lock (Gate)
+        {
+            return _document!.Records.Values
+                .Select(Clone)
+                .ToArray();
+        }
+    }
+
+    public static bool ImportCurrent(
+        IPaperTodoHostApi host,
+        ReviewArchiveSettings settings,
+        bool manual)
+    {
+        if (!settings.TrackCreated ||
+            (!manual && string.Equals(settings.InitialImport, "none", StringComparison.Ordinal)))
+        {
+            return false;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var changed = false;
+        foreach (var todo in host.ListTodos(includeBlank: false))
+        {
+            if (!manual &&
+                string.Equals(settings.InitialImport, "completed", StringComparison.Ordinal) &&
+                !todo.Done)
+            {
+                continue;
+            }
+
+            lock (Gate)
+            {
+                var key = Key(todo.PaperId, todo.Id);
+                if (_document!.Records.ContainsKey(key))
+                {
+                    continue;
+                }
+
+                _document.Records[key] = FromSnapshot(
+                    todo,
+                    now,
+                    createdEstimated: true,
+                    completedEstimated: todo.Done,
+                    origin: manual ? "manual-import" : "initial-import");
+                changed = true;
+            }
+        }
+
+        if (changed)
+        {
+            SaveAndNotify(settings);
+        }
+        return changed;
+    }
+
+    public static void Apply(PaperTodoEvent value, ReviewArchiveSettings settings)
+    {
+        EnsureLoaded();
+        lock (Gate)
+        {
+            if (!SeenEventIds.Add(value.Metadata.EventId))
+            {
+                return;
+            }
+            SeenEventOrder.Enqueue(value.Metadata.EventId);
+            while (SeenEventOrder.Count > 2048)
+            {
+                SeenEventIds.Remove(SeenEventOrder.Dequeue());
+            }
+        }
+
+        var changed = value switch
+        {
+            TodoCreatedEvent item => ApplyTodoCreated(item, settings),
+            TodoChangedEvent item => ApplyTodoChanged(item, settings),
+            TodoDeletedEvent item => ApplyTodoDeleted(item, settings),
+            PaperChangedEvent item => ApplyPaperChanged(item),
+            PaperDeletedEvent item => ApplyPaperDeleted(item, settings),
+            _ => false
+        };
+
+        if (changed)
+        {
+            SaveAndNotify(settings);
+        }
+    }
+
+    public static void Clear(ReviewArchiveSettings settings)
+    {
+        EnsureLoaded();
+        lock (Gate)
+        {
+            _document!.Records.Clear();
+        }
+        SaveAndNotify(settings);
+    }
+
+    public static void ApplyRetention(ReviewArchiveSettings settings)
+    {
+        EnsureLoaded();
+        if (Prune(settings))
+        {
+            SaveAndNotify(settings, prune: false);
+        }
+    }
+
+    private static bool ApplyTodoCreated(TodoCreatedEvent item, ReviewArchiveSettings settings)
+    {
+        if (!settings.TrackCreated)
+        {
+            return false;
+        }
+
+        lock (Gate)
+        {
+            var key = Key(item.Todo.PaperId, item.Todo.Id);
+            if (_document!.Records.TryGetValue(key, out var existing))
+            {
+                UpdateFromSnapshot(existing, item.Todo, item.Metadata.OccurredAt);
+                return true;
+            }
+
+            _document.Records[key] = FromSnapshot(
+                item.Todo,
+                item.Metadata.OccurredAt,
+                createdEstimated: false,
+                completedEstimated: false,
+                origin: OriginText(item.Metadata));
+            return true;
+        }
+    }
+
+    private static bool ApplyTodoChanged(TodoChangedEvent item, ReviewArchiveSettings settings)
+    {
+        lock (Gate)
+        {
+            var key = Key(item.After.PaperId, item.After.Id);
+            if (!_document!.Records.TryGetValue(key, out var record))
+            {
+                if (!settings.TrackCreated && !item.After.Done)
+                {
+                    return false;
+                }
+                record = FromSnapshot(
+                    item.Before,
+                    item.Metadata.OccurredAt,
+                    createdEstimated: true,
+                    completedEstimated: item.Before.Done,
+                    origin: OriginText(item.Metadata));
+                _document.Records[key] = record;
+            }
+
+            UpdateFromSnapshot(record, item.After, item.Metadata.OccurredAt);
+            if ((item.ChangedFields & TodoChangedFields.Completion) != 0)
+            {
+                if (item.After.Done)
+                {
+                    record.CompletedAt = item.Metadata.OccurredAt;
+                    record.CompletedAtEstimated = false;
+                }
+                else
+                {
+                    record.CompletedAt = null;
+                    record.CompletedAtEstimated = false;
+                }
+            }
+            return true;
+        }
+    }
+
+    private static bool ApplyTodoDeleted(TodoDeletedEvent item, ReviewArchiveSettings settings)
+    {
+        lock (Gate)
+        {
+            var key = Key(item.Todo.PaperId, item.Todo.Id);
+            if (!_document!.Records.TryGetValue(key, out var record))
+            {
+                if (!settings.KeepDeleted || (!settings.TrackCreated && !item.Todo.Done))
+                {
+                    return false;
+                }
+                record = FromSnapshot(
+                    item.Todo,
+                    item.Metadata.OccurredAt,
+                    createdEstimated: true,
+                    completedEstimated: item.Todo.Done,
+                    origin: OriginText(item.Metadata));
+                _document.Records[key] = record;
+            }
+
+            if (!settings.KeepDeleted)
+            {
+                return _document.Records.Remove(key);
+            }
+
+            UpdateFromSnapshot(record, item.Todo, item.Metadata.OccurredAt);
+            record.SourceDeleted = true;
+            record.DeletedAt = item.Metadata.OccurredAt;
+            return true;
+        }
+    }
+
+    private static bool ApplyPaperChanged(PaperChangedEvent item)
+    {
+        if ((item.ChangedFields & PaperChangedFields.Title) == 0)
+        {
+            return false;
+        }
+
+        var changed = false;
+        lock (Gate)
+        {
+            foreach (var record in _document!.Records.Values.Where(record =>
+                         string.Equals(record.PaperId, item.After.Id, StringComparison.Ordinal)))
+            {
+                if (string.Equals(record.PaperTitle, item.After.Title, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                record.PaperTitle = item.After.Title;
+                record.LastChangedAt = item.Metadata.OccurredAt;
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    private static bool ApplyPaperDeleted(PaperDeletedEvent item, ReviewArchiveSettings settings)
+    {
+        var changed = false;
+        lock (Gate)
+        {
+            foreach (var pair in _document!.Records
+                         .Where(pair => string.Equals(
+                             pair.Value.PaperId,
+                             item.Paper.Id,
+                             StringComparison.Ordinal))
+                         .ToArray())
+            {
+                if (!settings.KeepDeleted)
+                {
+                    _document.Records.Remove(pair.Key);
+                    changed = true;
+                    continue;
+                }
+
+                pair.Value.SourceDeleted = true;
+                pair.Value.DeletedAt ??= item.Metadata.OccurredAt;
+                pair.Value.LastChangedAt = item.Metadata.OccurredAt;
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    private static ReviewArchiveRecord FromSnapshot(
+        TodoSnapshot todo,
+        DateTimeOffset observedAt,
+        bool createdEstimated,
+        bool completedEstimated,
+        string origin) => new()
+    {
+        PaperId = todo.PaperId,
+        PaperTitle = todo.PaperTitle,
+        TodoId = todo.Id,
+        Text = todo.Text,
+        Done = todo.Done,
+        CreatedAt = observedAt,
+        CompletedAt = todo.Done ? observedAt : null,
+        LastChangedAt = observedAt,
+        CreatedAtEstimated = createdEstimated,
+        CompletedAtEstimated = completedEstimated,
+        Origin = origin
+    };
+
+    private static void UpdateFromSnapshot(
+        ReviewArchiveRecord record,
+        TodoSnapshot todo,
+        DateTimeOffset changedAt)
+    {
+        record.PaperId = todo.PaperId;
+        record.PaperTitle = todo.PaperTitle;
+        record.TodoId = todo.Id;
+        record.Text = todo.Text;
+        record.Done = todo.Done;
+        record.LastChangedAt = changedAt;
+    }
+
+    private static string OriginText(PaperTodoEventMetadata metadata) =>
+        metadata.Origin switch
+        {
+            PaperTodoEventOrigin.Mcp => "mcp",
+            PaperTodoEventOrigin.Plugin => "plugin",
+            PaperTodoEventOrigin.System => "system",
+            PaperTodoEventOrigin.Import => "import",
+            _ => "user"
+        };
+
+    private static string Key(string paperId, string todoId) => paperId + "/" + todoId;
+
+    private static ReviewArchiveRecord Clone(ReviewArchiveRecord value) => new()
+    {
+        PaperId = value.PaperId,
+        PaperTitle = value.PaperTitle,
+        TodoId = value.TodoId,
+        Text = value.Text,
+        Done = value.Done,
+        SourceDeleted = value.SourceDeleted,
+        CreatedAt = value.CreatedAt,
+        CompletedAt = value.CompletedAt,
+        DeletedAt = value.DeletedAt,
+        LastChangedAt = value.LastChangedAt,
+        CreatedAtEstimated = value.CreatedAtEstimated,
+        CompletedAtEstimated = value.CompletedAtEstimated,
+        Origin = value.Origin
+    };
+
+    private static ReviewArchiveDocument? ReadDocument(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+            var document = JsonSerializer.Deserialize<ReviewArchiveDocument>(
+                File.ReadAllText(path),
+                JsonOptions);
+            if (document == null)
+            {
+                return null;
+            }
+            NormalizeDocument(document);
+            return document;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void NormalizeDocument(ReviewArchiveDocument document)
+    {
+        document.Records ??= new Dictionary<string, ReviewArchiveRecord>(StringComparer.Ordinal);
+        if (document.StorageVersion != 1)
+        {
+            throw new InvalidDataException(
+                $"Unsupported review archive version {document.StorageVersion}.");
+        }
+    }
+
+    private static bool Prune(ReviewArchiveSettings settings)
+    {
+        var changed = false;
+        lock (Gate)
+        {
+            if (settings.RetentionDays > 0)
+            {
+                var cutoff = DateTimeOffset.UtcNow.AddDays(-settings.RetentionDays);
+                foreach (var key in _document!.Records
+                             .Where(pair => EffectiveTime(pair.Value) < cutoff)
+                             .Select(pair => pair.Key)
+                             .ToArray())
+                {
+                    _document.Records.Remove(key);
+                    changed = true;
+                }
+            }
+
+            var overflow = _document!.Records.Count - settings.MaxRecords;
+            if (overflow > 0)
+            {
+                foreach (var key in _document.Records
+                             .OrderBy(pair => EffectiveTime(pair.Value))
+                             .Take(overflow)
+                             .Select(pair => pair.Key)
+                             .ToArray())
+                {
+                    _document.Records.Remove(key);
+                    changed = true;
+                }
+            }
+        }
+        return changed;
+    }
+
+    private static DateTimeOffset EffectiveTime(ReviewArchiveRecord value) =>
+        value.CompletedAt ?? value.DeletedAt ?? value.LastChangedAt;
+
+    private static void SaveAndNotify(ReviewArchiveSettings settings, bool prune = true)
+    {
+        EnsureLoaded();
+        if (prune)
+        {
+            _ = Prune(settings);
+        }
+
+        string json;
+        string path;
+        lock (Gate)
+        {
+            json = JsonSerializer.Serialize(_document, JsonOptions);
+            path = _path!;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var temp = path + ".tmp";
+            File.WriteAllText(temp, json, new UTF8Encoding(false));
+            if (File.Exists(path))
+            {
+                File.Copy(path, path + ".bak", overwrite: true);
+            }
+            File.Move(temp, path, overwrite: true);
+            LastSaveError = "";
+        }
+        catch (Exception ex)
+        {
+            LastSaveError = ex.GetBaseException().Message;
+        }
+        Changed?.Invoke();
+    }
+}

--- a/plugin-samples/PaperTodo.Plugin.ReviewArchive/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.ReviewArchive/plugin.json
@@ -1,0 +1,146 @@
+{
+  "kind": "native",
+  "id": "sample.review-archive.native",
+  "name": "待办复盘记录池",
+  "description": "记录待办创建、完成和删除时间，保留历史并导出 Excel 可直接打开的 CSV。",
+  "version": "1.0.0",
+  "apiVersion": "1.3",
+  "stateVersion": 1,
+  "entry": "PaperTodo.Plugin.ReviewArchive.dll",
+  "capabilities": ["textZoom"],
+  "requires": ["backgroundUpdates"],
+  "permissions": [
+    "papers.read",
+    "papers.observe",
+    "todos.read",
+    "todos.observe"
+  ],
+  "settings": [
+    {
+      "id": "trackCreated",
+      "type": "boolean",
+      "name": "记录创建时间",
+      "description": "为新建待办保存精确创建时刻。",
+      "default": true,
+      "quick": true
+    },
+    {
+      "id": "keepDeleted",
+      "type": "boolean",
+      "name": "保留已删除来源",
+      "description": "删除原待办或整张待办纸后仍保留复盘记录。",
+      "default": true,
+      "quick": true
+    },
+    {
+      "id": "showOpenItems",
+      "type": "boolean",
+      "name": "显示进行中待办",
+      "description": "在“全部记录”和“进行中”筛选中显示尚未完成的项目。",
+      "default": false,
+      "quick": true
+    },
+    {
+      "id": "initialImport",
+      "type": "select",
+      "name": "首次导入现有待办",
+      "default": "completed",
+      "options": [
+        { "value": "none", "name": "不自动导入" },
+        { "value": "completed", "name": "仅已完成" },
+        { "value": "all", "name": "全部待办" }
+      ]
+    },
+    {
+      "id": "defaultFilter",
+      "type": "select",
+      "name": "默认筛选",
+      "default": "completed",
+      "options": [
+        { "value": "completed", "name": "已完成" },
+        { "value": "today", "name": "今天完成" },
+        { "value": "week", "name": "近 7 天" },
+        { "value": "month", "name": "近 30 天" },
+        { "value": "all", "name": "全部记录" }
+      ]
+    },
+    {
+      "id": "retentionDays",
+      "type": "number",
+      "name": "保留天数",
+      "description": "0 表示永久保留。",
+      "default": 0,
+      "min": 0,
+      "max": 3650,
+      "step": 30,
+      "suffix": "天"
+    },
+    {
+      "id": "maxRecords",
+      "type": "number",
+      "name": "最大记录数",
+      "default": 10000,
+      "min": 100,
+      "max": 50000,
+      "step": 100,
+      "suffix": "条"
+    },
+    {
+      "id": "exportEncoding",
+      "type": "select",
+      "name": "CSV 编码",
+      "default": "utf8bom",
+      "options": [
+        { "value": "utf8bom", "name": "UTF-8 BOM（推荐 Excel）" },
+        { "value": "utf8", "name": "UTF-8" }
+      ]
+    },
+    {
+      "id": "exportDateFormat",
+      "type": "select",
+      "name": "时间格式",
+      "default": "local",
+      "options": [
+        { "value": "local", "name": "本地时间（到分钟）" },
+        { "value": "iso", "name": "ISO 风格（到秒）" }
+      ]
+    },
+    {
+      "id": "includePaperTitle",
+      "type": "boolean",
+      "name": "包含所属纸片",
+      "default": true
+    },
+    {
+      "id": "showDeletedBadge",
+      "type": "boolean",
+      "name": "标记来源已删除",
+      "default": true
+    },
+    {
+      "id": "confirmClear",
+      "type": "boolean",
+      "name": "清空前确认",
+      "default": true
+    },
+    {
+      "id": "titleMode",
+      "type": "select",
+      "name": "胶囊标题",
+      "default": "summary",
+      "options": [
+        { "value": "summary", "name": "累计完成数" },
+        { "value": "today", "name": "今日完成数" },
+        { "value": "fixed", "name": "固定文字" }
+      ]
+    },
+    {
+      "id": "fixedTitle",
+      "type": "string",
+      "name": "固定标题",
+      "default": "复盘记录",
+      "maxLength": 40,
+      "placeholder": "复盘记录"
+    }
+  ]
+}

--- a/plugin-samples/PaperTodo.Plugin.SampleClock/PaperTodo.Plugin.SampleClock.csproj
+++ b/plugin-samples/PaperTodo.Plugin.SampleClock/PaperTodo.Plugin.SampleClock.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/plugin-samples/PaperTodo.Plugin.SampleClock/README.md
+++ b/plugin-samples/PaperTodo.Plugin.SampleClock/README.md
@@ -1,6 +1,17 @@
-# 原生 DLL 插件示例
+# WPF 原生时钟
 
-所有原生 DLL 示例共用仓库根目录下的构建安装脚本。先完全退出 PaperTodo，然后运行：
+这是一个完全由 WPF 控件构成的 PaperTodo 正文插件示例。它不再只是显示当前时间，还展示了宿主设置、主题和后台生命周期如何组合成一个完整插件：
+
+- 12 / 24 小时制和秒数显示；
+- 多种日期格式、星期和日进度；
+- 本地、UTC、北京、东京、伦敦、纽约和洛杉矶时区；
+- 时间、日期、时区或自定义胶囊标题；
+- 正文缩放、主题和字体适配；
+- 折叠为胶囊后继续更新，隐藏后停止计时器。
+
+## 构建并安装
+
+先完全退出 PaperTodo，再从仓库根目录运行：
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File `
@@ -8,11 +19,10 @@ powershell -ExecutionPolicy Bypass -File `
   -ProjectPath .\plugin-samples\PaperTodo.Plugin.SampleClock\PaperTodo.Plugin.SampleClock.csproj
 ```
 
-脚本会读取本目录的 `plugin.json`，构建 Release DLL，清理宿主已提供的共享程序集，并安装到：
+脚本会安装到：
 
 ```text
 plugins\sample.clock.native\
 ```
 
-新插件可立即识别；本次运行已经加载过的原生插件发生修改后，会明确提示重启 PaperTodo，不伪装成热更新。
-`PaperTodo.Plugin.Abstractions.dll` 由主程序提供，不会被复制进最终插件目录。
+新插件可立即识别；本次运行已经加载过的原生插件发生修改后，需要重启 PaperTodo。`PaperTodo.Plugin.Abstractions.dll` 由主程序提供，不会被复制进插件目录。

--- a/plugin-samples/PaperTodo.Plugin.SampleClock/SampleClockPlugin.cs
+++ b/plugin-samples/PaperTodo.Plugin.SampleClock/SampleClockPlugin.cs
@@ -10,116 +10,383 @@ namespace PaperTodo.Plugin.SampleClock;
 public sealed class SampleClockPlugin : IPaperBodyPlugin
 {
     public string Id => "sample.clock.native";
-    public string DisplayName => "原生时钟示例";
-    public string Description => "用于验证 PaperTodo 原生 DLL 正文插件加载。";
-    public Version Version => new(1, 2, 0);
+    public string DisplayName => "原生时钟";
+    public string Description => "完整的 WPF 时钟示例：时区、日期格式、标题和日进度均可配置。";
+    public Version Version => new(1, 3, 0);
     public string ApiVersion => "1.2";
     public int StateVersion => 1;
-    public PaperBodyCapabilities Capabilities => PaperBodyCapabilities.None;
+    public PaperBodyCapabilities Capabilities => PaperBodyCapabilities.TextZoom;
     public PaperBodyRuntimeRequirements RuntimeRequirements =>
         PaperBodyRuntimeRequirements.BackgroundUpdates;
 
-    public IPaperBodySession Create(PaperBodyContext context)
-        => new ClockSession(context);
+    public IPaperBodySession Create(PaperBodyContext context) =>
+        new ClockSession(context);
+
+    private sealed record ClockSettings(
+        bool ShowSeconds,
+        bool ShowDate,
+        bool ShowWeekday,
+        bool ShowDayProgress,
+        string HourCycle,
+        string DateFormat,
+        string TimeZone,
+        string TitleMode,
+        string CustomTitle,
+        double ClockScale);
 
     private sealed class ClockSession : IPaperBodySession
     {
+        private static readonly IReadOnlyDictionary<string, string> TimeZoneIds =
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["local"] = "",
+                ["utc"] = "UTC",
+                ["beijing"] = "China Standard Time",
+                ["tokyo"] = "Tokyo Standard Time",
+                ["london"] = "GMT Standard Time",
+                ["newYork"] = "Eastern Standard Time",
+                ["losAngeles"] = "Pacific Standard Time"
+            };
+
         private readonly PaperBodyContext _context;
+        private readonly Grid _root;
         private readonly TextBlock _time;
+        private readonly TextBlock _meridiem;
         private readonly TextBlock _date;
+        private readonly TextBlock _zone;
+        private readonly ProgressBar _dayProgress;
         private readonly DispatcherTimer _timer;
-        private bool _showSeconds;
+        private ClockSettings _settings;
+        private PaperBodyTheme _theme;
+        private bool _runtimeVisible;
+        private string _lastDisplayTitle = "";
 
         public ClockSession(PaperBodyContext context)
         {
             _context = context;
-            _showSeconds = ReadShowSeconds(context.SettingsJson);
+            _theme = context.Theme;
+            _settings = ReadSettings(context.SettingsJson);
+
             _time = new TextBlock
             {
-                FontSize = 42,
                 FontWeight = FontWeights.SemiBold,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                TextAlignment = TextAlignment.Center
+            };
+            _meridiem = new TextBlock
+            {
+                Margin = new Thickness(8, 0, 0, 6),
+                VerticalAlignment = VerticalAlignment.Bottom
+            };
+
+            var timeRow = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Center
             };
+            timeRow.Children.Add(_time);
+            timeRow.Children.Add(_meridiem);
+
             _date = new TextBlock
             {
-                FontSize = 13,
-                Opacity = 0.7,
-                Margin = new Thickness(0, 8, 0, 0),
-                HorizontalAlignment = HorizontalAlignment.Center
-            };
-            var panel = new StackPanel
-            {
+                Margin = new Thickness(0, 7, 0, 0),
                 HorizontalAlignment = HorizontalAlignment.Center,
+                TextAlignment = TextAlignment.Center
+            };
+            _zone = new TextBlock
+            {
+                Margin = new Thickness(0, 4, 0, 0),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                TextAlignment = TextAlignment.Center
+            };
+            _dayProgress = new ProgressBar
+            {
+                Minimum = 0,
+                Maximum = 1,
+                Height = 4,
+                Margin = new Thickness(18, 16, 18, 0),
+                BorderThickness = new Thickness(0)
+            };
+
+            var content = new StackPanel
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Center
             };
-            panel.Children.Add(_time);
-            panel.Children.Add(_date);
-            View = new Grid
+            content.Children.Add(timeRow);
+            content.Children.Add(_date);
+            content.Children.Add(_zone);
+            content.Children.Add(_dayProgress);
+
+            _root = new Grid
             {
                 Background = Brushes.Transparent,
-                Children = { panel }
+                Margin = new Thickness(16, 14, 16, 16),
+                Children = { content }
             };
-            _timer = new DispatcherTimer
-            {
-                Interval = TimeSpan.FromSeconds(1)
-            };
-            _timer.Tick += (_, _) => Refresh();
+
+            _timer = new DispatcherTimer(DispatcherPriority.Background);
+            _timer.Tick += OnTick;
+
             ApplyTheme(context.Theme);
+            ApplySettings(_settings);
             Refresh();
-            _timer.Start();
         }
 
-        public FrameworkElement View { get; }
+        public FrameworkElement View => _root;
+
+        private void OnTick(object? sender, EventArgs e) => Refresh();
+
+        private void ApplySettings(ClockSettings settings)
+        {
+            _settings = settings;
+            _date.Visibility = settings.ShowDate || settings.ShowWeekday
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+            _dayProgress.Visibility = settings.ShowDayProgress
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+            _timer.Interval = settings.ShowSeconds
+                ? TimeSpan.FromMilliseconds(250)
+                : TimeSpan.FromSeconds(1);
+            ApplyTheme(_theme);
+            if (_runtimeVisible && !_timer.IsEnabled)
+            {
+                _timer.Start();
+            }
+        }
 
         private void Refresh()
         {
-            var now = DateTime.Now;
-            _time.Text = now.ToString(_showSeconds ? "HH:mm:ss" : "HH:mm");
-            _date.Text = now.ToString("yyyy-MM-dd dddd");
-            _context.SetDisplayTitle(now.ToString("HH:mm"));
+            var now = CurrentTime();
+            var twelveHour = string.Equals(
+                _settings.HourCycle,
+                "12",
+                StringComparison.Ordinal);
+            var timeFormat = twelveHour
+                ? (_settings.ShowSeconds ? "hh:mm:ss" : "hh:mm")
+                : (_settings.ShowSeconds ? "HH:mm:ss" : "HH:mm");
+
+            _time.Text = now.ToString(timeFormat);
+            _meridiem.Text = twelveHour ? now.ToString("tt") : "";
+            _meridiem.Visibility = twelveHour
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+
+            var dateParts = new List<string>();
+            if (_settings.ShowDate)
+            {
+                dateParts.Add(FormatDate(now));
+            }
+            if (_settings.ShowWeekday)
+            {
+                dateParts.Add(now.ToString("dddd"));
+            }
+            _date.Text = string.Join(" · ", dateParts);
+            _zone.Text = TimeZoneLabel();
+
+            var seconds = now.TimeOfDay.TotalSeconds;
+            _dayProgress.Value = Math.Clamp(
+                seconds / TimeSpan.FromDays(1).TotalSeconds,
+                0,
+                1);
+
+            SetDisplayTitle(DisplayTitle(now));
+        }
+
+        private DateTimeOffset CurrentTime()
+        {
+            if (string.Equals(_settings.TimeZone, "local", StringComparison.Ordinal))
+            {
+                return DateTimeOffset.Now;
+            }
+
+            try
+            {
+                var id = TimeZoneIds.TryGetValue(_settings.TimeZone, out var value)
+                    ? value
+                    : "";
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    return DateTimeOffset.Now;
+                }
+                var zone = TimeZoneInfo.FindSystemTimeZoneById(id);
+                return TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, zone);
+            }
+            catch
+            {
+                return DateTimeOffset.Now;
+            }
+        }
+
+        private string TimeZoneLabel()
+        {
+            return _settings.TimeZone switch
+            {
+                "utc" => "UTC",
+                "beijing" => "北京时间",
+                "tokyo" => "东京时间",
+                "london" => "伦敦时间",
+                "newYork" => "纽约时间",
+                "losAngeles" => "洛杉矶时间",
+                _ => "本地时间"
+            };
+        }
+
+        private string FormatDate(DateTimeOffset now) =>
+            _settings.DateFormat switch
+            {
+                "short" => now.ToString("yyyy-MM-dd"),
+                "slash" => now.ToString("yyyy/MM/dd"),
+                "us" => now.ToString("MM/dd/yyyy"),
+                "eu" => now.ToString("dd/MM/yyyy"),
+                _ => now.ToString("yyyy年M月d日")
+            };
+
+        private string DisplayTitle(DateTimeOffset now)
+        {
+            var time = now.ToString(
+                string.Equals(_settings.HourCycle, "12", StringComparison.Ordinal)
+                    ? "hh:mm tt"
+                    : "HH:mm");
+            return _settings.TitleMode switch
+            {
+                "date" => FormatDate(now),
+                "zone" => $"{TimeZoneLabel()} · {time}",
+                "custom" when !string.IsNullOrWhiteSpace(_settings.CustomTitle) =>
+                    _settings.CustomTitle.Trim(),
+                "fixed" => "时钟",
+                _ => time
+            };
         }
 
         private void ApplyTheme(PaperBodyTheme theme)
         {
-            _time.Foreground = Brush(theme.TextColor);
-            _date.Foreground = Brush(theme.WeakTextColor);
-            _time.FontFamily = new FontFamily(theme.FontFamily);
-            _date.FontFamily = new FontFamily(theme.FontFamily);
+            _theme = theme;
+            var scale = Math.Clamp(theme.FontScale * _settings.ClockScale, 0.7, 3);
+            var font = new FontFamily(theme.FontFamily);
+            var text = ToBrush(theme.TextColor, "#202020");
+            var weak = ToBrush(theme.WeakTextColor, "#707070");
+
+            _time.FontFamily = font;
+            _meridiem.FontFamily = font;
+            _date.FontFamily = font;
+            _zone.FontFamily = font;
+
+            _time.FontSize = 44 * scale;
+            _meridiem.FontSize = 11 * scale;
+            _date.FontSize = 12 * scale;
+            _zone.FontSize = 10 * scale;
+
+            _time.Foreground = text;
+            _meridiem.Foreground = weak;
+            _date.Foreground = text;
+            _zone.Foreground = weak;
+            _dayProgress.Foreground = ToBrush(theme.AccentColor, "#B07A31");
+            _dayProgress.Background = ToBrush(
+                theme.IsDark ? "#28FFFFFF" : "#22000000",
+                "#22000000");
         }
 
-        private static SolidColorBrush Brush(string color)
-        {
-            return new SolidColorBrush((Color)ColorConverter.ConvertFromString(color));
-        }
-
-        private static bool ReadShowSeconds(string json)
+        private static ClockSettings ReadSettings(string json)
         {
             try
             {
                 using var document = JsonDocument.Parse(
                     string.IsNullOrWhiteSpace(json) ? "{}" : json);
-                return document.RootElement.TryGetProperty("showSeconds", out var value) &&
-                    value.ValueKind is JsonValueKind.True or JsonValueKind.False
-                        ? value.GetBoolean()
-                        : true;
+                var root = document.RootElement;
+                return new ClockSettings(
+                    Boolean(root, "showSeconds", true),
+                    Boolean(root, "showDate", true),
+                    Boolean(root, "showWeekday", true),
+                    Boolean(root, "showDayProgress", true),
+                    String(root, "hourCycle", "24"),
+                    String(root, "dateFormat", "long"),
+                    String(root, "timeZone", "local"),
+                    String(root, "titleMode", "time"),
+                    String(root, "customTitle", ""),
+                    Number(root, "clockScale", 1));
             }
             catch
             {
-                return true;
+                return new ClockSettings(
+                    true, true, true, true, "24", "long", "local", "time", "", 1);
             }
+        }
+
+        private static bool Boolean(JsonElement root, string name, bool fallback) =>
+            root.TryGetProperty(name, out var value) &&
+            value.ValueKind is JsonValueKind.True or JsonValueKind.False
+                ? value.GetBoolean()
+                : fallback;
+
+        private static string String(JsonElement root, string name, string fallback) =>
+            root.TryGetProperty(name, out var value) &&
+            value.ValueKind == JsonValueKind.String
+                ? value.GetString() ?? fallback
+                : fallback;
+
+        private static double Number(JsonElement root, string name, double fallback) =>
+            root.TryGetProperty(name, out var value) &&
+            value.ValueKind == JsonValueKind.Number &&
+            value.TryGetDouble(out var number)
+                ? number
+                : fallback;
+
+        private static SolidColorBrush ToBrush(string value, string fallback)
+        {
+            try
+            {
+                return new SolidColorBrush(
+                    (Color)ColorConverter.ConvertFromString(value)!);
+            }
+            catch
+            {
+                return new SolidColorBrush(
+                    (Color)ColorConverter.ConvertFromString(fallback)!);
+            }
+        }
+
+        private void SetDisplayTitle(string title)
+        {
+            if (string.Equals(_lastDisplayTitle, title, StringComparison.Ordinal))
+            {
+                return;
+            }
+            _lastDisplayTitle = title;
+            _context.SetDisplayTitle(title);
+        }
+
+        public void OnSettingsChanged(string settingsJson)
+        {
+            ApplySettings(ReadSettings(settingsJson));
+            Refresh();
         }
 
         public void OnThemeChanged(PaperBodyTheme theme) => ApplyTheme(theme);
         public void OnTypographyChanged(PaperBodyTheme theme) => ApplyTheme(theme);
-        public void OnSettingsChanged(string settingsJson)
-        {
-            _showSeconds = ReadShowSeconds(settingsJson);
-            Refresh();
-        }
+
         public void OnVisibilityChanged(bool visible)
         {
-            if (visible) _timer.Start(); else _timer.Stop();
+            _runtimeVisible = visible;
+            if (visible)
+            {
+                if (!_timer.IsEnabled) _timer.Start();
+                Refresh();
+            }
+            else
+            {
+                _timer.Stop();
+            }
         }
-        public void Dispose() => _timer.Stop();
+
+        public void OnPresentationChanged(bool visible) =>
+            _root.IsHitTestVisible = visible;
+
+        public void Dispose()
+        {
+            _timer.Stop();
+            _timer.Tick -= OnTick;
+        }
     }
 }

--- a/plugin-samples/PaperTodo.Plugin.SampleClock/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.SampleClock/plugin.json
@@ -1,14 +1,18 @@
 {
   "kind": "native",
   "id": "sample.clock.native",
-  "name": "原生时钟示例",
-  "description": "用于验证 PaperTodo 原生 DLL 正文插件加载。",
-  "version": "1.2.0",
+  "name": "原生时钟",
+  "description": "完整的 WPF 时钟示例：时区、日期格式、标题和日进度均可配置。",
+  "version": "1.3.0",
   "apiVersion": "1.2",
   "stateVersion": 1,
   "entry": "PaperTodo.Plugin.SampleClock.dll",
-  "capabilities": [],
-  "requires": ["backgroundUpdates"],
+  "capabilities": [
+    "textZoom"
+  ],
+  "requires": [
+    "backgroundUpdates"
+  ],
   "settings": [
     {
       "id": "showSeconds",
@@ -16,6 +20,96 @@
       "name": "显示秒数",
       "default": true,
       "quick": true
+    },
+    {
+      "id": "showDate",
+      "type": "boolean",
+      "name": "显示日期",
+      "default": true,
+      "quick": true
+    },
+    {
+      "id": "showDayProgress",
+      "type": "boolean",
+      "name": "显示日进度",
+      "description": "在底部显示今天已经过去的比例。",
+      "default": true,
+      "quick": true
+    },
+    {
+      "id": "showWeekday",
+      "type": "boolean",
+      "name": "显示星期",
+      "default": true
+    },
+    {
+      "id": "hourCycle",
+      "type": "select",
+      "name": "时间制式",
+      "default": "24",
+      "options": [
+        { "value": "24", "name": "24 小时" },
+        { "value": "12", "name": "12 小时" }
+      ]
+    },
+    {
+      "id": "dateFormat",
+      "type": "select",
+      "name": "日期格式",
+      "default": "long",
+      "options": [
+        { "value": "long", "name": "2026年8月1日" },
+        { "value": "short", "name": "2026-08-01" },
+        { "value": "slash", "name": "2026/08/01" },
+        { "value": "us", "name": "08/01/2026" },
+        { "value": "eu", "name": "01/08/2026" }
+      ]
+    },
+    {
+      "id": "timeZone",
+      "type": "select",
+      "name": "时区",
+      "default": "local",
+      "options": [
+        { "value": "local", "name": "本地时间" },
+        { "value": "utc", "name": "UTC" },
+        { "value": "beijing", "name": "北京时间" },
+        { "value": "tokyo", "name": "东京时间" },
+        { "value": "london", "name": "伦敦时间" },
+        { "value": "newYork", "name": "纽约时间" },
+        { "value": "losAngeles", "name": "洛杉矶时间" }
+      ]
+    },
+    {
+      "id": "titleMode",
+      "type": "select",
+      "name": "胶囊标题",
+      "default": "time",
+      "options": [
+        { "value": "time", "name": "当前时间" },
+        { "value": "date", "name": "当前日期" },
+        { "value": "zone", "name": "时区和时间" },
+        { "value": "fixed", "name": "固定为“时钟”" },
+        { "value": "custom", "name": "自定义文字" }
+      ]
+    },
+    {
+      "id": "customTitle",
+      "type": "string",
+      "name": "自定义标题",
+      "placeholder": "仅在标题模式为自定义时使用",
+      "maxLength": 40,
+      "default": ""
+    },
+    {
+      "id": "clockScale",
+      "type": "number",
+      "name": "时钟字号倍率",
+      "default": 1,
+      "min": 0.75,
+      "max": 1.6,
+      "step": 0.05,
+      "suffix": "×"
     }
   ]
 }

--- a/plugin-samples/README.md
+++ b/plugin-samples/README.md
@@ -5,9 +5,18 @@
 - `plugin-samples/` 保存插件源码、清单源文件和构建说明；
 - `plugins/` 只保存已经构建、可由 PaperTodo 直接加载的最终产物；
 - `plugins/data/` 保存 PaperTodo 代管的插件全局设置和纸片状态；
+- 插件自己的 `.runtime/` 可保存运行缓存或独立于纸片的长期数据，构建安装脚本会保留它；
 - PaperTodo 的本地发布和 GitHub Release 都不携带插件，插件需要单独分发。
 
 最终原生插件目录只保留 `plugin.json`、入口 DLL、必要的 `.deps.json`、插件私有依赖和原生库。不要放入 PDB、XML 文档、重复 DLL 或 PaperTodo 宿主已经提供的共享程序集。
+
+## 示例定位
+
+- `PaperTodo.Plugin.SampleClock`：完整 WPF 时钟，演示多种宿主设置、主题、缩放、后台更新和运行时标题；
+- `PaperTodo.Plugin.OfficialClockWeb`：与原生时钟功能接近的 Web 对照实现；
+- `PaperTodo.Plugin.FocusTimer`：完整 WPF 番茄钟，演示状态恢复、自动轮转、声音和每日统计；
+- `PaperTodo.Plugin.ReviewArchive`：Issue #37 的实现，演示协议 1.3 数据读取、事件监听、插件私有长期存储和 CSV 导出；
+- `PaperTodo.Plugin.CloudGenshin`：WebView2 远程应用嵌入、导航、输入占用和进程恢复示例。
 
 ## 原生插件构建与安装
 
@@ -21,10 +30,13 @@
   -ProjectPath .\plugin-samples\PaperTodo.Plugin.FocusTimer\PaperTodo.Plugin.FocusTimer.csproj
 
 .\plugin-samples\Build-And-Install-NativePlugin.ps1 `
+  -ProjectPath .\plugin-samples\PaperTodo.Plugin.ReviewArchive\PaperTodo.Plugin.ReviewArchive.csproj
+
+.\plugin-samples\Build-And-Install-NativePlugin.ps1 `
   -ProjectPath .\plugin-samples\PaperTodo.Plugin.CloudGenshin\PaperTodo.Plugin.CloudGenshin.csproj
 ```
 
-`PaperTodo.Plugin.FocusTimer` 是不依赖 WebView2 的完整 WPF 示例，包含原生交互、状态保存、后台运行、运行时标题和主题适配。纯 Web 插件不需要编译，直接将清单和 `web/` 静态文件复制到对应的 `plugins/<插件 ID>/` 目录。
+纯 Web 插件不需要编译，直接将清单和 `web/` 静态文件复制到对应的 `plugins/<插件 ID>/` 目录。
 
 ## 部署目录
 
@@ -42,7 +54,7 @@ plugins\
    │  ├─ index.html
    │  └─ CSS、脚本与图片
    ├─ WeatherPlugin.dll / 依赖 DLL / 原生库
-   └─ .runtime\                     # WebView2 Profile、缓存和临时运行数据
+   └─ .runtime\                     # 插件私有缓存或长期数据
 ```
 
 当前 PaperTodo 插件协议为 **1.3**。同一主版本内向后兼容：插件声明的小版本不高于宿主即可加载；使用 `permissions` 必须声明 1.3。目录名必须与 `id` 一致，`data` 是宿主保留 ID。
@@ -97,7 +109,9 @@ plugins\
 }
 ```
 
-每个插件的数据保存在 `plugins/data/<插件 ID>.json`：`settings` 是插件所有纸片共享的设置，`papers` 以纸片 ID 保存独立状态。单张纸片状态上限为 1 MiB（只在保存时按 UTF-8 JSON 字节数检查）。这些数据不写入 `data.json`，旧版 `BodyStates` 不迁移；删除纸片时会同步删除各插件中的对应状态。正常数据文件无法读取时，原文件保持不变，插件从空状态运行，之后只写入唯一的 `<插件 ID>.json.recovered`，该文件存在时会优先使用。
+每个插件的宿主管理数据保存在 `plugins/data/<插件 ID>.json`：`settings` 是插件所有纸片共享的设置，`papers` 以纸片 ID 保存独立状态。单张纸片状态上限为 1 MiB（只在保存时按 UTF-8 JSON 字节数检查）。这些数据不写入 `data.json`，旧版 `BodyStates` 不迁移；删除纸片时会同步删除各插件中的对应状态。正常数据文件无法读取时，原文件保持不变，插件从空状态运行，之后只写入唯一的 `<插件 ID>.json.recovered`，该文件存在时会优先使用。
+
+`.runtime/` 不受宿主状态协议管理，适合 WebView2 Profile、可重建缓存或必须独立于纸片生命周期的插件私有数据。原生插件应自行负责格式版本、原子写入、损坏恢复和容量控制，不应把普通单纸片界面状态重复放入 `.runtime`。
 
 原生插件通过 `PaperBodyContext.SettingsJson` 获取初始设置，并通过 `IPaperBodySession.OnSettingsChanged` 接收更新。
 
@@ -108,6 +122,7 @@ plugins\
 支持：`papers.read/observe/create/delete`、`todos.read/observe/append/update/delete`、`notes.read/observe/append/replace`。写入结果只返回 ID 或内容长度，不会绕过独立的读取权限。
 
 原生插件使用 `PaperBodyContext.Host`；Web 插件使用 `papertodo.request()` 与 `papertodo.onHostEvent()`。
+
 ## Web 插件
 
 Web 插件的 `entry` 所在目录会成为本地静态根；建议固定使用 `web/`，使同一插件目录下的 `.runtime/` 不会被网页映射。插件自己的本地顶层页面运行在 `https://<id>.papertodo.local/`，只有该本地顶层页面会获得 `window.papertodo` 桥接。外部顶层导航、远程 iframe、弹窗和浏览器权限请求使用 WebView2 默认行为。
@@ -117,12 +132,12 @@ Web 插件的 `entry` 所在目录会成为本地静态根；建议固定使用 
 可通过 `window.papertodo` 调用：
 
 ```js
-papertodo.saveState({ city: "Shanghai" }); // 每次状态变化后立即调用
-papertodo.registerStateProvider(() => currentState); // 关闭前的辅助快照，不能替代即时保存
-papertodo.setTitle("上海天气"); // 持久化、可由用户编辑的正式标题
-papertodo.setDisplayTitle("26°C 晴"); // 运行时标题，同时显示在顶栏和胶囊
-papertodo.setInputClaims(["escapeKey", "contextMenu"]); // 进入交互模式前声明
-papertodo.setInputClaims([]); // 离开交互模式后释放
+papertodo.saveState({ city: "Shanghai" });
+papertodo.registerStateProvider(() => currentState);
+papertodo.setTitle("上海天气");
+papertodo.setDisplayTitle("26°C 晴");
+papertodo.setInputClaims(["escapeKey", "contextMenu"]);
+papertodo.setInputClaims([]);
 papertodo.markDirty();
 papertodo.openExternal("https://example.com");
 papertodo.onEvent(message => console.log(message));

--- a/plugins/official.clock.web/plugin.json
+++ b/plugins/official.clock.web/plugin.json
@@ -2,20 +2,59 @@
   "kind": "web",
   "id": "official.clock.web",
   "name": "Web 时钟",
-  "description": "PaperTodo 官方 Web 正文插件示例。",
-  "version": "1.2.0",
+  "description": "完整的 Web 插件示例：主题、时区、日期格式、标题和日进度均可配置。",
+  "version": "1.3.0",
   "apiVersion": "1.2",
   "stateVersion": 1,
   "entry": "web/index.html",
-  "capabilities": [],
+  "capabilities": ["textZoom"],
   "requires": ["backgroundUpdates"],
   "settings": [
+    { "id": "showSeconds", "type": "boolean", "name": "显示秒数", "default": true, "quick": true },
+    { "id": "showDate", "type": "boolean", "name": "显示日期", "default": true, "quick": true },
+    { "id": "showDayProgress", "type": "boolean", "name": "显示日进度", "description": "在底部显示今天已经过去的比例。", "default": true, "quick": true },
+    { "id": "showWeekday", "type": "boolean", "name": "显示星期", "default": true },
     {
-      "id": "showSeconds",
-      "type": "boolean",
-      "name": "显示秒数",
-      "default": true,
-      "quick": true
-    }
+      "id": "hourCycle", "type": "select", "name": "时间制式", "default": "24",
+      "options": [
+        { "value": "24", "name": "24 小时" },
+        { "value": "12", "name": "12 小时" }
+      ]
+    },
+    {
+      "id": "dateFormat", "type": "select", "name": "日期格式", "default": "long",
+      "options": [
+        { "value": "long", "name": "2026年8月1日" },
+        { "value": "short", "name": "2026-08-01" },
+        { "value": "slash", "name": "2026/08/01" },
+        { "value": "us", "name": "08/01/2026" },
+        { "value": "eu", "name": "01/08/2026" }
+      ]
+    },
+    {
+      "id": "timeZone", "type": "select", "name": "时区", "default": "local",
+      "options": [
+        { "value": "local", "name": "本地时间" },
+        { "value": "utc", "name": "UTC" },
+        { "value": "beijing", "name": "北京时间" },
+        { "value": "tokyo", "name": "东京时间" },
+        { "value": "london", "name": "伦敦时间" },
+        { "value": "newYork", "name": "纽约时间" },
+        { "value": "losAngeles", "name": "洛杉矶时间" }
+      ]
+    },
+    {
+      "id": "titleMode", "type": "select", "name": "胶囊标题", "default": "time",
+      "options": [
+        { "value": "time", "name": "当前时间" },
+        { "value": "date", "name": "当前日期" },
+        { "value": "zone", "name": "时区和时间" },
+        { "value": "fixed", "name": "固定为“时钟”" },
+        { "value": "custom", "name": "自定义文字" }
+      ]
+    },
+    { "id": "customTitle", "type": "string", "name": "自定义标题", "placeholder": "仅在标题模式为自定义时使用", "maxLength": 40, "default": "" },
+    { "id": "showWeekNumber", "type": "boolean", "name": "显示周数", "default": true },
+    { "id": "clockScale", "type": "number", "name": "时钟字号倍率", "default": 1, "min": 0.75, "max": 1.6, "step": 0.05, "suffix": "×" }
   ]
 }

--- a/plugins/official.clock.web/web/index.html
+++ b/plugins/official.clock.web/web/index.html
@@ -11,39 +11,161 @@
       --text: #222;
       --weak: #777;
       --accent: #b07a31;
+      --border: #807050;
       --font: system-ui, sans-serif;
-      --scale: 1;
+      --host-scale: 1;
+      --clock-scale: 1;
     }
     * { box-sizing: border-box; }
-    html, body { width: 100%; height: 100%; margin: 0; background: var(--paper); }
+    html, body { width: 100%; height: 100%; margin: 0; background: transparent; }
     body {
       display: grid;
       place-items: center;
       color: var(--text);
       font-family: var(--font);
-      font-size: calc(16px * var(--scale));
+      font-size: calc(16px * var(--host-scale));
       user-select: none;
       overflow: hidden;
     }
-    main { text-align: center; padding: 20px; }
-    #time { font-size: clamp(38px, 15vw, 76px); font-weight: 650; letter-spacing: .04em; }
-    #date { margin-top: 10px; color: var(--weak); font-size: .86em; }
+    main {
+      width: min(100%, 620px);
+      padding: clamp(18px, 5vw, 32px);
+      text-align: center;
+    }
+    .zone {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      padding: 4px 10px;
+      border: 1px solid color-mix(in srgb, var(--border) 45%, transparent);
+      border-radius: 999px;
+      color: var(--weak);
+      font-size: .72em;
+      letter-spacing: .04em;
+    }
+    .zone::before {
+      content: "";
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+    }
+    .time-row {
+      display: flex;
+      justify-content: center;
+      align-items: baseline;
+      margin-top: 12px;
+      white-space: nowrap;
+    }
+    #time {
+      font-size: calc(clamp(48px, 16vw, 92px) * var(--clock-scale));
+      font-weight: 650;
+      line-height: 1;
+      letter-spacing: .025em;
+      font-variant-numeric: tabular-nums;
+    }
     #seconds { color: var(--accent); }
+    #meridiem {
+      margin-left: 10px;
+      color: var(--weak);
+      font-size: .78em;
+      font-weight: 600;
+    }
+    #date {
+      min-height: 1.4em;
+      margin-top: 12px;
+      color: var(--weak);
+      font-size: .9em;
+    }
+    .progress {
+      height: 5px;
+      margin: 20px 10px 0;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--text) 13%, transparent);
+      overflow: hidden;
+    }
+    #progress {
+      height: 100%;
+      width: 0;
+      border-radius: inherit;
+      background: var(--accent);
+      transition: width .4s ease;
+    }
+    .meta {
+      display: flex;
+      justify-content: space-between;
+      gap: 14px;
+      margin-top: 9px;
+      color: var(--weak);
+      font-size: .68em;
+    }
+    [hidden] { display: none !important; }
   </style>
 </head>
 <body>
   <main>
-    <div id="time"><span id="hours"></span>:<span id="minutes"></span><span id="seconds"></span></div>
+    <div id="zone" class="zone"></div>
+    <div class="time-row">
+      <div id="time"><span id="hours"></span>:<span id="minutes"></span><span id="seconds"></span></div>
+      <span id="meridiem"></span>
+    </div>
     <div id="date"></div>
+    <div id="progressTrack" class="progress"><div id="progress"></div></div>
+    <div class="meta">
+      <span id="week"></span>
+      <span id="dayPercent"></span>
+    </div>
   </main>
   <script>
+    const defaults = Object.freeze({
+      showSeconds: true,
+      showDate: true,
+      showWeekday: true,
+      showDayProgress: true,
+      showWeekNumber: true,
+      hourCycle: '24',
+      dateFormat: 'long',
+      timeZone: 'local',
+      titleMode: 'time',
+      customTitle: '',
+      clockScale: 1
+    });
+
+    let settings = { ...defaults };
     let visible = true;
-    let showSeconds = true;
     let timer = 0;
-    const hoursElement = document.getElementById('hours');
-    const minutesElement = document.getElementById('minutes');
-    const secondsElement = document.getElementById('seconds');
-    const dateElement = document.getElementById('date');
+
+    const $ = id => document.getElementById(id);
+    const hoursElement = $('hours');
+    const minutesElement = $('minutes');
+    const secondsElement = $('seconds');
+    const meridiemElement = $('meridiem');
+    const dateElement = $('date');
+    const zoneElement = $('zone');
+    const progressTrack = $('progressTrack');
+    const progressElement = $('progress');
+    const weekElement = $('week');
+    const dayPercentElement = $('dayPercent');
+
+    const zoneMap = Object.freeze({
+      local: undefined,
+      utc: 'UTC',
+      beijing: 'Asia/Shanghai',
+      tokyo: 'Asia/Tokyo',
+      london: 'Europe/London',
+      newYork: 'America/New_York',
+      losAngeles: 'America/Los_Angeles'
+    });
+    const zoneLabels = Object.freeze({
+      local: '本地时间',
+      utc: 'UTC',
+      beijing: '北京时间',
+      tokyo: '东京时间',
+      london: '伦敦时间',
+      newYork: '纽约时间',
+      losAngeles: '洛杉矶时间'
+    });
 
     function applyTheme(theme) {
       if (!theme) return;
@@ -52,29 +174,108 @@
       root.setProperty('--text', theme.textColor || '#222');
       root.setProperty('--weak', theme.weakTextColor || '#777');
       root.setProperty('--accent', theme.accentColor || '#b07a31');
+      root.setProperty('--border', theme.borderColor || '#807050');
       root.setProperty('--font', JSON.stringify(theme.fontFamily || 'system-ui'));
-      root.setProperty('--scale', String(theme.fontScale || 1));
+      root.setProperty('--host-scale', String(theme.fontScale || 1));
     }
 
-    function applySettings(settings) {
-      showSeconds = settings?.showSeconds !== false;
+    function applySettings(value) {
+      settings = { ...defaults, ...(value || {}) };
+      settings.clockScale = Math.min(1.6, Math.max(.75, Number(settings.clockScale) || 1));
+      document.documentElement.style.setProperty('--clock-scale', String(settings.clockScale));
+      progressTrack.hidden = !settings.showDayProgress;
+      weekElement.hidden = !settings.showWeekNumber;
+    }
+
+    function zonedParts(date) {
+      const timeZone = zoneMap[settings.timeZone];
+      const parts = new Intl.DateTimeFormat(undefined, {
+        timeZone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        weekday: 'long',
+        hour12: settings.hourCycle === '12'
+      }).formatToParts(date);
+      return Object.fromEntries(parts.map(part => [part.type, part.value]));
+    }
+
+    function formatDate(date, parts) {
+      if (!settings.showDate && !settings.showWeekday) return '';
+      let base = '';
+      if (settings.showDate) {
+        const y = parts.year;
+        const m = parts.month;
+        const d = parts.day;
+        base = settings.dateFormat === 'short' ? `${y}-${m}-${d}`
+          : settings.dateFormat === 'slash' ? `${y}/${m}/${d}`
+          : settings.dateFormat === 'us' ? `${m}/${d}/${y}`
+          : settings.dateFormat === 'eu' ? `${d}/${m}/${y}`
+          : `${y}年${Number(m)}月${Number(d)}日`;
+      }
+      return [base, settings.showWeekday ? parts.weekday : ''].filter(Boolean).join(' · ');
+    }
+
+    function zonedClockParts(date) {
+      const timeZone = zoneMap[settings.timeZone];
+      const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hourCycle: 'h23'
+      }).formatToParts(date);
+      return Object.fromEntries(parts.map(part => [part.type, part.value]));
+    }
+
+    function isoWeek(year, month, dayOfMonth) {
+      const value = new Date(Date.UTC(Number(year), Number(month) - 1, Number(dayOfMonth)));
+      const day = value.getUTCDay() || 7;
+      value.setUTCDate(value.getUTCDate() + 4 - day);
+      const yearStart = new Date(Date.UTC(value.getUTCFullYear(), 0, 1));
+      return Math.ceil((((value - yearStart) / 86400000) + 1) / 7);
+    }
+
+    function titleText(timeText, dateText) {
+      if (settings.titleMode === 'date') return dateText.split(' · ')[0] || timeText;
+      if (settings.titleMode === 'zone') return `${zoneLabels[settings.timeZone] || '本地时间'} · ${timeText}`;
+      if (settings.titleMode === 'fixed') return '时钟';
+      if (settings.titleMode === 'custom' && String(settings.customTitle || '').trim()) {
+        return String(settings.customTitle).trim();
+      }
+      return timeText;
     }
 
     function render() {
       const now = new Date();
-      const two = value => String(value).padStart(2, '0');
-      hoursElement.textContent = two(now.getHours());
-      minutesElement.textContent = two(now.getMinutes());
-      secondsElement.textContent = showSeconds ? ':' + two(now.getSeconds()) : '';
-      dateElement.textContent = new Intl.DateTimeFormat(undefined, {
-        year: 'numeric', month: 'long', day: 'numeric', weekday: 'long'
-      }).format(now);
-      window.papertodo?.setDisplayTitle(`${two(now.getHours())}:${two(now.getMinutes())}`);
+      const parts = zonedParts(now);
+      hoursElement.textContent = parts.hour;
+      minutesElement.textContent = parts.minute;
+      secondsElement.textContent = settings.showSeconds ? `:${parts.second}` : '';
+      meridiemElement.textContent = settings.hourCycle === '12' ? (parts.dayPeriod || '') : '';
+
+      const dateText = formatDate(now, parts);
+      dateElement.textContent = dateText;
+      dateElement.hidden = !dateText;
+      zoneElement.textContent = zoneLabels[settings.timeZone] || '本地时间';
+
+      const clock = zonedClockParts(now);
+      const elapsed = Number(clock.hour) * 3600 + Number(clock.minute) * 60 + Number(clock.second);
+      const percent = Math.min(100, Math.max(0, elapsed / 864));
+      progressElement.style.width = `${percent}%`;
+      dayPercentElement.textContent = `今日 ${percent.toFixed(1)}%`;
+      weekElement.textContent = `第 ${isoWeek(parts.year, parts.month, parts.day)} 周`;
+
+      const timeText = `${parts.hour}:${parts.minute}`;
+      window.papertodo?.setDisplayTitle(titleText(timeText, dateText));
     }
 
     function updateTimer() {
       clearInterval(timer);
-      if (visible) timer = setInterval(render, 1000);
+      if (visible) timer = setInterval(render, settings.showSeconds ? 250 : 1000);
       render();
     }
 
@@ -87,7 +288,7 @@
         updateTimer();
       } else if (message.type === 'settingsChanged') {
         applySettings(message.settings);
-        render();
+        updateTimer();
       } else if (message.type === 'themeChanged' || message.type === 'typographyChanged') {
         applyTheme(message.theme);
       } else if (message.type === 'visibilityChanged') {
@@ -96,6 +297,7 @@
       }
     });
 
+    applySettings(defaults);
     render();
   </script>
 </body>


### PR DESCRIPTION
## 改动内容

- 将原生时钟从最小加载示例完善为可实际使用的 WPF 时钟：支持秒数、日期、星期、日进度、12/24 小时制、多时区、日期格式、标题模式和字号倍率。
- 将 Web 时钟同步完善为功能接近的 Web 对照实现，并更新仓库中的可加载副本。
- 将专注计时器完善为完整番茄钟：支持自动阶段轮转、提示音、每日目标、完成统计、加减步长、跳过、重置确认和多种胶囊标题。
- 新增 `PaperTodo.Plugin.ReviewArchive`，实现 Issue #37：
  - 监听待办创建、完成、取消完成、删除和纸片删除；
  - 保存创建/完成/删除时间、正文和所属纸片；
  - 原来源删除后仍保留历史；
  - 支持今日、近 7 天、近 30 天、进行中、已删除和全部筛选；
  - 支持搜索、补录当前待办、保留策略、容量上限和 CSV 导出；
  - 默认导出 UTF-8 BOM CSV，Excel 可直接打开中文内容。
- 新增 Windows CI，逐个编译所有原生示例插件。
- 扩展插件示例文档，说明 `.runtime` 的适用边界和各示例定位。

## 设计说明

复盘记录池不写入任何单张纸片的 `StateJson`，而是保存在插件目录的 `.runtime/review-archive.json`。安装脚本升级插件时会保留 `.runtime`，因此删除原待办、整张待办纸或承载插件界面的笔记纸，不会顺带删除历史。存储使用临时文件替换和 `.bak` 回退，并受保留天数与最大记录数双重限制。

没有为该需求修改宿主协议或主业务代码。插件使用现有 1.3 读取/监听权限即可完成。

## 已知边界

当前插件模型是纸片会话型：至少需要保留一张使用该插件的可见纸片；折叠成胶囊后可继续监听。完全隐藏、删除最后一张插件纸片或 PaperTodo 未运行期间，无法获得当时的精确事件时间。再次打开后可“导入当前”补录现状，并明确标记为“首次观察值”。

## 验证

- 已静态检查全部插件清单，快速设置不超过 3 项，API、权限、版本和入口保持一致。
- Web 时钟脚本已通过 JavaScript 语法检查。
- PR 新增 `Plugin samples` Windows 工作流，以 .NET 10 Release 模式编译全部原生插件示例。

Closes #37
