### PR TITLE
test(fullscreen): add detailed diagnostic logging

### DIFF
--- a/FullscreenDiagnosticLogger.cs
+++ b/FullscreenDiagnosticLogger.cs
@@ -1,0 +1,704 @@
+using System.Collections;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows.Threading;
+
+namespace PaperTodo;
+
+/// <summary>
+/// Temporary diagnostics for fullscreen-avoidance investigation. This observer never calls
+/// TryGetFullscreenWindow and never changes z-order or detector state. Remove after testing.
+/// </summary>
+internal static class FullscreenDiagnosticLogger
+{
+    private const int GwlStyle = -16;
+    private const int GwlExStyle = -20;
+    private const int WsExTopmost = 0x00000008;
+    private const int WsExToolWindow = 0x00000080;
+    private const int DwmwaExtendedFrameBounds = 9;
+    private const int DwmwaCloaked = 14;
+    private const uint MonitorDefaultToNearest = 2;
+    private const uint GaRoot = 2;
+    private const uint GaRootOwner = 3;
+    private const uint GwOwner = 4;
+    private const int FullscreenTolerance = 2;
+    private const int ZOrderLimit = 100;
+    private const long MaxLogBytes = 32L * 1024 * 1024;
+
+    private static readonly object FileGate = new();
+    private static readonly Type DetectorType = typeof(FullscreenForegroundWindowDetector);
+    private static readonly FieldInfo? LastExternalField = DetectorField("_lastExternalForegroundWindow");
+    private static readonly FieldInfo? SessionWindowField = DetectorField("_foregroundSessionWindow");
+    private static readonly FieldInfo? SessionPidField = DetectorField("_foregroundSessionProcessId");
+    private static readonly FieldInfo? TrackedField = DetectorField("_trackedFullscreenWindow");
+    private static readonly FieldInfo? IgnoredField = DetectorField("_ignoredSessionFullscreenWindows");
+    private static readonly FieldInfo? ContinuationField = DetectorField("_temporaryContinuationWindow");
+    private static readonly FieldInfo? AvoidanceField = ControllerField("_fullscreenAvoidanceWindow");
+    private static readonly FieldInfo? AvoidanceMonitorField = ControllerField("_fullscreenAvoidanceMonitorDeviceName");
+    private static readonly FieldInfo? LastGlobalScanField = ControllerField("_lastFullscreenGlobalScanAt");
+    private static readonly FieldInfo? ForceGlobalScanField = ControllerField("_fullscreenEventForceGlobalScan");
+
+    private static System.Threading.Timer? _timer;
+    private static int _queued;
+    private static long _sequence;
+    private static string _lastFingerprint = "";
+    private static DateTimeOffset _lastPeriodicAt = DateTimeOffset.MinValue;
+
+    private static string LogPath => Path.Combine(AppContext.BaseDirectory, "fullscreen-diagnostic.log");
+    private static string PreviousLogPath => Path.Combine(AppContext.BaseDirectory, "fullscreen-diagnostic.previous.log");
+
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        try
+        {
+            if (!OperatingSystem.IsWindows() || !IsPaperTodoProcess())
+            {
+                return;
+            }
+
+            WriteSessionHeader();
+            _timer = new System.Threading.Timer(
+                static _ => QueueSample(),
+                null,
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromMilliseconds(250));
+        }
+        catch
+        {
+            // Diagnostics must never affect startup.
+        }
+    }
+
+    private static void QueueSample()
+    {
+        if (Interlocked.Exchange(ref _queued, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher == null || dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
+            {
+                Interlocked.Exchange(ref _queued, 0);
+                return;
+            }
+
+            _ = dispatcher.BeginInvoke((Action)SampleOnUiThread, DispatcherPriority.Background);
+        }
+        catch
+        {
+            Interlocked.Exchange(ref _queued, 0);
+        }
+    }
+
+    private static void SampleOnUiThread()
+    {
+        try
+        {
+            var state = CaptureState();
+            var fingerprint = Fingerprint(state);
+            var now = DateTimeOffset.UtcNow;
+            var changed = !string.Equals(fingerprint, _lastFingerprint, StringComparison.Ordinal);
+            var periodic = now - _lastPeriodicAt >= TimeSpan.FromSeconds(2);
+            if (!changed && !periodic)
+            {
+                return;
+            }
+
+            _lastFingerprint = fingerprint;
+            _lastPeriodicAt = now;
+            var text = BuildSnapshot(
+                Interlocked.Increment(ref _sequence),
+                changed ? "state-change" : "periodic",
+                state);
+            ThreadPool.QueueUserWorkItem(static value => Append((string)value!), text);
+        }
+        catch
+        {
+            // Windows can disappear between any two diagnostic calls.
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _queued, 0);
+        }
+    }
+
+    private static State CaptureState()
+    {
+        var controller = TryGetController();
+        return new State(
+            GetForegroundWindow(),
+            ReadStaticIntPtr(LastExternalField),
+            ReadStaticIntPtr(SessionWindowField),
+            ReadStaticUInt32(SessionPidField),
+            ReadStaticIntPtr(TrackedField),
+            ReadIgnored(),
+            ReadStaticIntPtr(ContinuationField),
+            ReadInstanceIntPtr(controller, AvoidanceField),
+            ReadInstanceString(controller, AvoidanceMonitorField),
+            ReadInstanceDateTimeOffset(controller, LastGlobalScanField),
+            ReadInstanceInt32(controller, ForceGlobalScanField));
+    }
+
+    private static string Fingerprint(State state) => string.Join('|',
+        Hex(state.Foreground),
+        Hex(state.LastExternal),
+        Hex(state.SessionWindow),
+        state.SessionPid,
+        Hex(state.Tracked),
+        string.Join(',', state.Ignored.Select(Hex)),
+        Hex(state.Continuation),
+        Hex(state.Avoidance),
+        state.AvoidanceMonitor,
+        state.ForceGlobalScan);
+
+    private static string BuildSnapshot(long sequence, string reason, State state)
+    {
+        var builder = new StringBuilder(48 * 1024);
+        builder.AppendLine();
+        builder.Append("================ FULLSCREEN DIAGNOSTIC #")
+            .Append(sequence)
+            .Append(" reason=").Append(reason)
+            .Append(" local=").Append(DateTimeOffset.Now.ToString("O"))
+            .AppendLine(" ================");
+        builder.Append("controller shouldSuppress=").Append(state.Avoidance != IntPtr.Zero ? '1' : '0')
+            .Append(" avoidance=0x").Append(Hex(state.Avoidance))
+            .Append(" monitor=").Append(Quote(state.AvoidanceMonitor))
+            .Append(" lastGlobalScanUtc=").Append(state.LastGlobalScan.ToString("O"))
+            .Append(" forceGlobalScan=").Append(state.ForceGlobalScan)
+            .AppendLine();
+        builder.Append("detector foreground=0x").Append(Hex(state.Foreground))
+            .Append(" lastExternal=0x").Append(Hex(state.LastExternal))
+            .Append(" session=0x").Append(Hex(state.SessionWindow))
+            .Append(" sessionPid=").Append(state.SessionPid)
+            .Append(" tracked=0x").Append(Hex(state.Tracked))
+            .Append(" continuation=0x").Append(Hex(state.Continuation))
+            .Append(" ignored=").Append(FormatHandles(state.Ignored))
+            .AppendLine();
+
+        builder.AppendLine("keyWindows:");
+        AppendWindow(builder, "foreground", state.Foreground, state);
+        AppendWindow(builder, "lastExternal", state.LastExternal, state);
+        AppendWindow(builder, "session", state.SessionWindow, state);
+        AppendWindow(builder, "tracked", state.Tracked, state);
+        AppendWindow(builder, "avoidance", state.Avoidance, state);
+        foreach (var ignored in state.Ignored)
+        {
+            AppendWindow(builder, "ignored", ignored, state);
+        }
+
+        AppendSamePidWindows(builder, state);
+        AppendFullscreenLikeWindows(builder, state);
+        AppendZOrder(builder, state);
+
+        builder.AppendLine("existingDetectorSnapshot:");
+        try
+        {
+            builder.Append(FullscreenForegroundWindowDetector.BuildDebugSnapshot());
+        }
+        catch (Exception ex)
+        {
+            builder.Append("snapshotError=").Append(Quote(ex.GetBaseException().Message)).AppendLine();
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendSamePidWindows(StringBuilder builder, State state)
+    {
+        var pid = state.SessionPid != 0 ? state.SessionPid : ProcessIdFor(state.Foreground);
+        builder.Append("samePidTopWindows pid=").Append(pid)
+            .Append(" process=").Append(Quote(ProcessName(pid))).AppendLine(":");
+        var count = 0;
+        if (pid != 0)
+        {
+            EnumWindows((hwnd, _) =>
+            {
+                if (ProcessIdFor(hwnd) == pid)
+                {
+                    AppendWindow(builder, "samePid" + count.ToString("D2"), hwnd, state);
+                    count++;
+                }
+                return true;
+            }, IntPtr.Zero);
+        }
+        if (count == 0) builder.AppendLine("samePid=<none>");
+    }
+
+    private static void AppendFullscreenLikeWindows(StringBuilder builder, State state)
+    {
+        builder.AppendLine("fullscreenLikeTopWindows:");
+        var count = 0;
+        EnumWindows((hwnd, _) =>
+        {
+            var detail = ReadDetail(hwnd);
+            if (detail.DwmCovers || detail.RawCovers)
+            {
+                AppendWindow(builder, "fullLike" + count.ToString("D2"), hwnd, state, detail);
+                count++;
+            }
+            return true;
+        }, IntPtr.Zero);
+        if (count == 0) builder.AppendLine("fullscreenLike=<none>");
+    }
+
+    private static void AppendZOrder(StringBuilder builder, State state)
+    {
+        builder.AppendLine("zOrder top-to-bottom:");
+        var index = 0;
+        EnumWindows((hwnd, _) =>
+        {
+            if (index >= ZOrderLimit) return false;
+            var d = ReadDetail(hwnd);
+            builder.Append("z=").Append(index.ToString("D3"))
+                .Append(" markers=").Append(Markers(hwnd, state))
+                .Append(" hwnd=0x").Append(Hex(hwnd))
+                .Append(" pid=").Append(d.ProcessId)
+                .Append(" tid=").Append(d.ThreadId)
+                .Append(" process=").Append(Quote(d.ProcessName))
+                .Append(" class=").Append(Quote(d.ClassName))
+                .Append(" title=").Append(Quote(d.Title))
+                .Append(" visible=").Append(d.Visible ? '1' : '0')
+                .Append(" iconic=").Append(d.Iconic ? '1' : '0')
+                .Append(" topmost=").Append(d.Topmost ? '1' : '0')
+                .Append(" tool=").Append(d.Tool ? '1' : '0')
+                .Append(" cloaked=").Append(d.Cloaked)
+                .Append(" candidateReason=").Append(d.CandidateReason)
+                .Append(" root=0x").Append(Hex(d.Root))
+                .Append(" rootOwner=0x").Append(Hex(d.RootOwner))
+                .Append(" owner=0x").Append(Hex(d.Owner))
+                .Append(" dwmRect=").Append(d.HasDwm ? FormatRect(d.DwmRect) : "<none>")
+                .Append(" rawRect=").Append(d.HasRaw ? FormatRect(d.RawRect) : "<none>")
+                .Append(" monitor=").Append(d.HasMonitor ? FormatRect(d.Monitor) : "<none>")
+                .Append(" dwmCovers=").Append(d.DwmCovers ? '1' : '0')
+                .Append(" rawCovers=").Append(d.RawCovers ? '1' : '0')
+                .Append(" dwmDelta=").Append(d.HasDwm && d.HasMonitor ? Delta(d.DwmRect, d.Monitor) : "<none>")
+                .Append(" rawDelta=").Append(d.HasRaw && d.HasMonitor ? Delta(d.RawRect, d.Monitor) : "<none>")
+                .AppendLine();
+            index++;
+            return true;
+        }, IntPtr.Zero);
+    }
+
+    private static void AppendWindow(StringBuilder builder, string label, IntPtr hwnd, State state, Detail? existing = null)
+    {
+        var d = existing ?? ReadDetail(hwnd);
+        builder.Append(label)
+            .Append(" markers=").Append(Markers(hwnd, state))
+            .Append(" z=").Append(ZIndex(hwnd))
+            .Append(" hwnd=0x").Append(Hex(hwnd))
+            .Append(" pid=").Append(d.ProcessId)
+            .Append(" tid=").Append(d.ThreadId)
+            .Append(" process=").Append(Quote(d.ProcessName))
+            .Append(" class=").Append(Quote(d.ClassName))
+            .Append(" title=").Append(Quote(d.Title))
+            .Append(" valid=").Append(d.Valid ? '1' : '0')
+            .Append(" visible=").Append(d.Visible ? '1' : '0')
+            .Append(" iconic=").Append(d.Iconic ? '1' : '0')
+            .Append(" topmost=").Append(d.Topmost ? '1' : '0')
+            .Append(" tool=").Append(d.Tool ? '1' : '0')
+            .Append(" cloaked=").Append(d.Cloaked)
+            .Append(" candidateReason=").Append(d.CandidateReason)
+            .Append(" root=0x").Append(Hex(d.Root))
+            .Append(" rootOwner=0x").Append(Hex(d.RootOwner))
+            .Append(" owner=0x").Append(Hex(d.Owner))
+            .Append(" style=0x").Append(d.Style.ToString("X8"))
+            .Append(" exStyle=0x").Append(d.ExStyle.ToString("X8"))
+            .Append(" dwmRect=").Append(d.HasDwm ? FormatRect(d.DwmRect) : "<none>")
+            .Append(" rawRect=").Append(d.HasRaw ? FormatRect(d.RawRect) : "<none>")
+            .Append(" monitor=").Append(d.HasMonitor ? FormatRect(d.Monitor) : "<none>")
+            .Append(" workArea=").Append(d.HasMonitor ? FormatRect(d.WorkArea) : "<none>")
+            .Append(" dwmCovers=").Append(d.DwmCovers ? '1' : '0')
+            .Append(" rawCovers=").Append(d.RawCovers ? '1' : '0')
+            .Append(" dwmDelta=").Append(d.HasDwm && d.HasMonitor ? Delta(d.DwmRect, d.Monitor) : "<none>")
+            .Append(" rawDelta=").Append(d.HasRaw && d.HasMonitor ? Delta(d.RawRect, d.Monitor) : "<none>")
+            .AppendLine();
+    }
+
+    private static Detail ReadDetail(IntPtr hwnd)
+    {
+        var valid = hwnd != IntPtr.Zero && IsWindow(hwnd);
+        uint pid = 0;
+        var tid = valid ? GetWindowThreadProcessId(hwnd, out pid) : 0;
+        var style = valid ? GetWindowLong(hwnd, GwlStyle) : 0;
+        var exStyle = valid ? GetWindowLong(hwnd, GwlExStyle) : 0;
+        var visible = valid && IsWindowVisible(hwnd);
+        var iconic = valid && IsIconic(hwnd);
+        var cloaked = TryGetCloaked(hwnd, out var cloakValue) ? cloakValue : -1;
+        var hasDwm = TryGetDwmRect(hwnd, out var dwmRect);
+        var hasRaw = TryGetRawRect(hwnd, out var rawRect);
+        var sourceRect = hasDwm ? dwmRect : rawRect;
+        var hasMonitor = TryGetMonitor(sourceRect, out var monitor, out var workArea);
+        var className = WindowClass(hwnd);
+        return new Detail(
+            valid, tid, pid, ProcessName(pid), className, WindowTitle(hwnd), style, exStyle,
+            visible, iconic, (exStyle & WsExTopmost) != 0, (exStyle & WsExToolWindow) != 0,
+            cloaked, CandidateReason(hwnd, valid, pid, visible, iconic, exStyle, cloaked, className),
+            valid ? GetAncestor(hwnd, GaRoot) : IntPtr.Zero,
+            valid ? GetAncestor(hwnd, GaRootOwner) : IntPtr.Zero,
+            valid ? GetWindow(hwnd, GwOwner) : IntPtr.Zero,
+            hasDwm, dwmRect, hasRaw, rawRect, hasMonitor, monitor, workArea,
+            hasDwm && hasMonitor && Covers(dwmRect, monitor),
+            hasRaw && hasMonitor && Covers(rawRect, monitor));
+    }
+
+    private static string CandidateReason(IntPtr hwnd, bool valid, uint pid, bool visible, bool iconic, int exStyle, int cloaked, string className)
+    {
+        if (hwnd == IntPtr.Zero) return "zero";
+        if (hwnd == GetShellWindow()) return "shell-window";
+        if (!valid) return "invalid";
+        if (pid == Environment.ProcessId) return "current-process";
+        if (!visible) return "hidden";
+        if (iconic) return "iconic";
+        if ((exStyle & WsExToolWindow) != 0) return "tool-window";
+        if (cloaked > 0) return "cloaked";
+        if (className is "Progman" or "WorkerW" or "Shell_TrayWnd" or "Shell_SecondaryTrayWnd") return "shell-class";
+        return "candidate";
+    }
+
+    private static string Markers(IntPtr hwnd, State state)
+    {
+        if (hwnd == IntPtr.Zero) return "-";
+        var value = new StringBuilder();
+        if (hwnd == state.Foreground) value.Append('F');
+        if (hwnd == state.LastExternal) value.Append('L');
+        if (hwnd == state.SessionWindow) value.Append('S');
+        if (hwnd == state.Tracked) value.Append('T');
+        if (hwnd == state.Avoidance) value.Append('A');
+        if (hwnd == state.Continuation) value.Append('C');
+        if (state.Ignored.Contains(hwnd)) value.Append('I');
+        if (ProcessIdFor(hwnd) == Environment.ProcessId) value.Append('P');
+        return value.Length == 0 ? "-" : value.ToString();
+    }
+
+    private static int ZIndex(IntPtr target)
+    {
+        if (target == IntPtr.Zero) return -1;
+        var index = 0;
+        var result = -1;
+        EnumWindows((hwnd, _) =>
+        {
+            if (hwnd == target)
+            {
+                result = index;
+                return false;
+            }
+            index++;
+            return true;
+        }, IntPtr.Zero);
+        return result;
+    }
+
+    private static bool Covers(NativeRect window, NativeRect monitor) =>
+        window.Left <= monitor.Left + FullscreenTolerance &&
+        window.Top <= monitor.Top + FullscreenTolerance &&
+        window.Right >= monitor.Right - FullscreenTolerance &&
+        window.Bottom >= monitor.Bottom - FullscreenTolerance;
+
+    private static string Delta(NativeRect window, NativeRect monitor) =>
+        $"[L={window.Left - monitor.Left},T={window.Top - monitor.Top},R={monitor.Right - window.Right},B={monitor.Bottom - window.Bottom}]";
+
+    private static bool TryGetDwmRect(IntPtr hwnd, out NativeRect rect)
+    {
+        rect = default;
+        return hwnd != IntPtr.Zero &&
+               DwmGetWindowAttribute(hwnd, DwmwaExtendedFrameBounds, out rect, Marshal.SizeOf<NativeRect>()) == 0 &&
+               !rect.IsEmpty;
+    }
+
+    private static bool TryGetRawRect(IntPtr hwnd, out NativeRect rect)
+    {
+        rect = default;
+        return hwnd != IntPtr.Zero && GetWindowRect(hwnd, out rect) && !rect.IsEmpty;
+    }
+
+    private static bool TryGetMonitor(NativeRect rect, out NativeRect monitor, out NativeRect workArea)
+    {
+        monitor = default;
+        workArea = default;
+        if (rect.IsEmpty) return false;
+        var source = rect;
+        var handle = MonitorFromRect(ref source, MonitorDefaultToNearest);
+        if (handle == IntPtr.Zero) return false;
+        var info = new MonitorInfo { Size = Marshal.SizeOf<MonitorInfo>() };
+        if (!GetMonitorInfo(handle, ref info)) return false;
+        monitor = info.Monitor;
+        workArea = info.WorkArea;
+        return true;
+    }
+
+    private static bool TryGetCloaked(IntPtr hwnd, out int cloaked)
+    {
+        cloaked = 0;
+        return hwnd != IntPtr.Zero && DwmGetWindowAttribute(hwnd, DwmwaCloaked, out cloaked, sizeof(int)) == 0;
+    }
+
+    private static uint ProcessIdFor(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero) return 0;
+        _ = GetWindowThreadProcessId(hwnd, out var pid);
+        return pid;
+    }
+
+    private static string ProcessName(uint pid)
+    {
+        if (pid == 0) return "";
+        try
+        {
+            using var process = Process.GetProcessById(checked((int)pid));
+            return process.ProcessName;
+        }
+        catch { return "<unavailable>"; }
+    }
+
+    private static string WindowClass(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero) return "";
+        var builder = new StringBuilder(256);
+        var length = GetClassName(hwnd, builder, builder.Capacity);
+        return length > 0 ? builder.ToString(0, length) : "";
+    }
+
+    private static string WindowTitle(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero) return "";
+        var length = Math.Min(GetWindowTextLength(hwnd), 512);
+        if (length <= 0) return "";
+        var builder = new StringBuilder(length + 1);
+        _ = GetWindowText(hwnd, builder, builder.Capacity);
+        return builder.ToString();
+    }
+
+    private static bool IsPaperTodoProcess()
+    {
+        var path = Environment.ProcessPath;
+        return string.Equals(
+            string.IsNullOrWhiteSpace(path) ? "" : Path.GetFileNameWithoutExtension(path),
+            "PaperTodo",
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void WriteSessionHeader()
+    {
+        lock (FileGate)
+        {
+            var text = new StringBuilder()
+                .AppendLine("PaperTodo fullscreen diagnostic test build")
+                .Append("startedLocal=").Append(DateTimeOffset.Now.ToString("O")).AppendLine()
+                .Append("processId=").Append(Environment.ProcessId).AppendLine()
+                .Append("processPath=").Append(Quote(Environment.ProcessPath)).AppendLine()
+                .Append("appVersion=").Append(Quote(typeof(AppController).Assembly.GetName().Version?.ToString())).AppendLine()
+                .Append("framework=").Append(Quote(RuntimeInformation.FrameworkDescription)).AppendLine()
+                .Append("os=").Append(Quote(RuntimeInformation.OSDescription)).AppendLine()
+                .AppendLine("markers: F=foreground L=lastExternal S=session T=tracked A=avoidance C=continuation I=ignored P=PaperTodo")
+                .AppendLine("Positive right/bottom deltas mean the window falls short of that monitor edge.")
+                .ToString();
+            File.WriteAllText(LogPath, text, new UTF8Encoding(false));
+        }
+    }
+
+    private static void Append(string text)
+    {
+        try
+        {
+            lock (FileGate)
+            {
+                var file = new FileInfo(LogPath);
+                if (file.Exists && file.Length >= MaxLogBytes)
+                {
+                    try { File.Move(LogPath, PreviousLogPath, overwrite: true); }
+                    catch { File.WriteAllText(LogPath, string.Empty, new UTF8Encoding(false)); }
+                }
+                File.AppendAllText(LogPath, text, new UTF8Encoding(false));
+            }
+        }
+        catch
+        {
+            // Diagnostic I/O must never affect normal behavior.
+        }
+    }
+
+    private static AppController? TryGetController()
+    {
+        try { return AppController.Current; }
+        catch { return null; }
+    }
+
+    private static FieldInfo? DetectorField(string name) =>
+        DetectorType.GetField(name, BindingFlags.Static | BindingFlags.NonPublic);
+
+    private static FieldInfo? ControllerField(string name) =>
+        typeof(AppController).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+
+    private static IntPtr ReadStaticIntPtr(FieldInfo? field)
+    {
+        try { return field?.GetValue(null) is IntPtr value ? value : IntPtr.Zero; }
+        catch { return IntPtr.Zero; }
+    }
+
+    private static uint ReadStaticUInt32(FieldInfo? field)
+    {
+        try { return field?.GetValue(null) is uint value ? value : 0; }
+        catch { return 0; }
+    }
+
+    private static IntPtr[] ReadIgnored()
+    {
+        try
+        {
+            if (IgnoredField?.GetValue(null) is IEnumerable values)
+            {
+                return values.Cast<object>().OfType<IntPtr>().OrderBy(value => value.ToInt64()).ToArray();
+            }
+        }
+        catch { }
+        return [];
+    }
+
+    private static IntPtr ReadInstanceIntPtr(AppController? target, FieldInfo? field)
+    {
+        try { return target != null && field?.GetValue(target) is IntPtr value ? value : IntPtr.Zero; }
+        catch { return IntPtr.Zero; }
+    }
+
+    private static string ReadInstanceString(AppController? target, FieldInfo? field)
+    {
+        try { return target != null && field?.GetValue(target) is string value ? value : ""; }
+        catch { return ""; }
+    }
+
+    private static int ReadInstanceInt32(AppController? target, FieldInfo? field)
+    {
+        try { return target != null && field?.GetValue(target) is int value ? value : 0; }
+        catch { return 0; }
+    }
+
+    private static DateTimeOffset ReadInstanceDateTimeOffset(AppController? target, FieldInfo? field)
+    {
+        try { return target != null && field?.GetValue(target) is DateTimeOffset value ? value : DateTimeOffset.MinValue; }
+        catch { return DateTimeOffset.MinValue; }
+    }
+
+    private static string Hex(IntPtr value) => value.ToInt64().ToString("X");
+    private static string FormatRect(NativeRect rect) => $"[{rect.Left},{rect.Top},{rect.Right},{rect.Bottom} {rect.Width}x{rect.Height}]";
+    private static string FormatHandles(IEnumerable<IntPtr> values)
+    {
+        var items = values.Select(value => "0x" + Hex(value)).ToArray();
+        return items.Length == 0 ? "<none>" : string.Join(',', items);
+    }
+
+    private static string Quote(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return "\"\"";
+        value = value.Replace("\r", " ", StringComparison.Ordinal).Replace("\n", " ", StringComparison.Ordinal);
+        if (value.Length > 180) value = value[..180] + "...";
+        return "\"" + value.Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
+    }
+
+    private sealed record State(
+        IntPtr Foreground,
+        IntPtr LastExternal,
+        IntPtr SessionWindow,
+        uint SessionPid,
+        IntPtr Tracked,
+        IntPtr[] Ignored,
+        IntPtr Continuation,
+        IntPtr Avoidance,
+        string AvoidanceMonitor,
+        DateTimeOffset LastGlobalScan,
+        int ForceGlobalScan);
+
+    private sealed record Detail(
+        bool Valid,
+        uint ThreadId,
+        uint ProcessId,
+        string ProcessName,
+        string ClassName,
+        string Title,
+        int Style,
+        int ExStyle,
+        bool Visible,
+        bool Iconic,
+        bool Topmost,
+        bool Tool,
+        int Cloaked,
+        string CandidateReason,
+        IntPtr Root,
+        IntPtr RootOwner,
+        IntPtr Owner,
+        bool HasDwm,
+        NativeRect DwmRect,
+        bool HasRaw,
+        NativeRect RawRect,
+        bool HasMonitor,
+        NativeRect Monitor,
+        NativeRect WorkArea,
+        bool DwmCovers,
+        bool RawCovers);
+
+    private delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetShellWindow();
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetWindow(IntPtr hwnd, uint command);
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetAncestor(IntPtr hwnd, uint flags);
+    [DllImport("user32.dll")]
+    private static extern bool IsWindow(IntPtr hwnd);
+    [DllImport("user32.dll")]
+    private static extern bool IsWindowVisible(IntPtr hwnd);
+    [DllImport("user32.dll")]
+    private static extern bool IsIconic(IntPtr hwnd);
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongW")]
+    private static extern int GetWindowLong(IntPtr hwnd, int index);
+    [DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr hwnd, out NativeRect rect);
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassName(IntPtr hwnd, StringBuilder className, int maxCount);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowText(IntPtr hwnd, StringBuilder text, int maxCount);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowTextLength(IntPtr hwnd);
+    [DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromRect(ref NativeRect rect, uint flags);
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    private static extern bool GetMonitorInfo(IntPtr monitor, ref MonitorInfo info);
+    [DllImport("dwmapi.dll", PreserveSig = true)]
+    private static extern int DwmGetWindowAttribute(IntPtr hwnd, int attribute, out int value, int size);
+    [DllImport("dwmapi.dll", EntryPoint = "DwmGetWindowAttribute", PreserveSig = true)]
+    private static extern int DwmGetWindowAttribute(IntPtr hwnd, int attribute, out NativeRect value, int size);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+        public int Width => Right - Left;
+        public int Height => Bottom - Top;
+        public bool IsEmpty => Right <= Left || Bottom <= Top;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MonitorInfo
+    {
+        public int Size;
+        public NativeRect Monitor;
+        public NativeRect WorkArea;
+        public uint Flags;
+    }
+}

--- a/FullscreenZOrderTraceLogger.cs
+++ b/FullscreenZOrderTraceLogger.cs
@@ -1,0 +1,600 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace PaperTodo;
+
+/// <summary>
+/// Temporary call-adjacent z-order diagnostics for fullscreen avoidance. WinEvent reorder events
+/// and short high-frequency bursts reveal whether PaperTodo is never placed behind the avoidance
+/// HWND, or is placed correctly and then raised again. This observer never changes window state.
+/// </summary>
+internal static class FullscreenZOrderTraceLogger
+{
+    private const uint EventSystemForeground = 0x0003;
+    private const uint EventObjectReorder = 0x8004;
+    private const uint WineventOutOfContext = 0x0000;
+    private const int ObjidWindow = 0;
+    private const int ChildidSelf = 0;
+    private const int GwlExStyle = -20;
+    private const int WsExTopmost = 0x00000008;
+    private const uint GwOwner = 4;
+    private const uint GaRoot = 2;
+    private const int MaxPaperTodoWindows = 32;
+    private const long BurstDurationMilliseconds = 1500;
+    private const long BurstSampleIntervalMilliseconds = 10;
+    private const long MaxLogBytes = 16L * 1024 * 1024;
+
+    private static readonly Type DetectorType = typeof(FullscreenForegroundWindowDetector);
+    private static readonly FieldInfo? TrackedField = DetectorField("_trackedFullscreenWindow");
+    private static readonly FieldInfo? SessionField = DetectorField("_foregroundSessionWindow");
+    private static readonly FieldInfo? AvoidanceField = ControllerField("_fullscreenAvoidanceWindow");
+    private static readonly ConcurrentQueue<string> PendingLines = new();
+    private static readonly object FileGate = new();
+    private static readonly WinEventDelegate WinEventCallback = OnWinEvent;
+
+    private static IntPtr _foregroundHook;
+    private static IntPtr _reorderHook;
+    private static System.Threading.Timer? _timer;
+    private static int _timerRunning;
+    private static int _pendingEventSnapshots;
+    private static long _sequence;
+    private static long _traceUntilTick;
+    private static long _lastBurstSampleTick;
+    private static string _lastStateFingerprint = "";
+
+    private static string LogPath => Path.Combine(AppContext.BaseDirectory, "fullscreen-zorder-trace.log");
+    private static string PreviousLogPath => Path.Combine(AppContext.BaseDirectory, "fullscreen-zorder-trace.previous.log");
+
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        try
+        {
+            if (!OperatingSystem.IsWindows() ||
+                !string.Equals(
+                    Environment.ProcessPath is { } path ? Path.GetFileNameWithoutExtension(path) : "",
+                    "PaperTodo",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            RotateLogAtStartup();
+            EnqueueLine(
+                "PaperTodo fullscreen z-order transition trace" + Environment.NewLine +
+                $"startedLocal={DateTimeOffset.Now:O}" + Environment.NewLine +
+                $"processId={Environment.ProcessId}" + Environment.NewLine +
+                "notes: lower z means nearer the front; relation=front means PaperTodo is incorrectly above avoidance." + Environment.NewLine);
+
+            _foregroundHook = SetWinEventHook(
+                EventSystemForeground,
+                EventSystemForeground,
+                IntPtr.Zero,
+                WinEventCallback,
+                0,
+                0,
+                WineventOutOfContext);
+            _reorderHook = SetWinEventHook(
+                EventObjectReorder,
+                EventObjectReorder,
+                IntPtr.Zero,
+                WinEventCallback,
+                0,
+                0,
+                WineventOutOfContext);
+
+            _timer = new System.Threading.Timer(
+                static _ => OnTimer(),
+                null,
+                TimeSpan.FromMilliseconds(250),
+                TimeSpan.FromMilliseconds(BurstSampleIntervalMilliseconds));
+            AppDomain.CurrentDomain.ProcessExit += static (_, _) => Shutdown();
+        }
+        catch
+        {
+            // Diagnostics must never affect startup.
+        }
+    }
+
+    private static void OnWinEvent(
+        IntPtr hook,
+        uint eventType,
+        IntPtr hwnd,
+        int objectId,
+        int childId,
+        uint eventThread,
+        uint eventTime)
+    {
+        try
+        {
+            if (eventType == EventObjectReorder &&
+                objectId != ObjidWindow &&
+                objectId != 0)
+            {
+                return;
+            }
+            if (eventType == EventObjectReorder &&
+                childId != ChildidSelf &&
+                childId != 0)
+            {
+                return;
+            }
+
+            var state = ReadState();
+            var root = hwnd == IntPtr.Zero ? IntPtr.Zero : GetAncestor(hwnd, GaRoot);
+            var eventProcessId = ProcessIdFor(root != IntPtr.Zero ? root : hwnd);
+            var relevant = eventType == EventSystemForeground ||
+                state.Avoidance != IntPtr.Zero ||
+                eventProcessId == Environment.ProcessId ||
+                hwnd == state.Foreground ||
+                hwnd == state.Avoidance ||
+                hwnd == state.Tracked;
+            if (!relevant)
+            {
+                return;
+            }
+
+            ExtendBurst();
+            if (Interlocked.Increment(ref _pendingEventSnapshots) > 12)
+            {
+                Interlocked.Decrement(ref _pendingEventSnapshots);
+                return;
+            }
+
+            ThreadPool.QueueUserWorkItem(static payload =>
+            {
+                var data = (EventPayload)payload!;
+                try
+                {
+                    EnqueueLine(CaptureSnapshot(
+                        data.EventType == EventSystemForeground ? "foreground-event" : "reorder-event",
+                        data.EventType,
+                        data.Hwnd,
+                        data.ObjectId,
+                        data.ChildId,
+                        data.EventThread,
+                        data.EventTime));
+                }
+                catch
+                {
+                    // A destroyed HWND between the event and snapshot is expected.
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref _pendingEventSnapshots);
+                }
+            }, new EventPayload(eventType, hwnd, objectId, childId, eventThread, eventTime));
+        }
+        catch
+        {
+            // WinEvent callbacks must never escape into user32.
+        }
+    }
+
+    private static void OnTimer()
+    {
+        if (Interlocked.Exchange(ref _timerRunning, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var state = ReadState();
+            var fingerprint = StateFingerprint(state);
+            if (!string.Equals(fingerprint, _lastStateFingerprint, StringComparison.Ordinal))
+            {
+                _lastStateFingerprint = fingerprint;
+                ExtendBurst();
+                EnqueueLine(CaptureSnapshot("controller-state-change", 0, IntPtr.Zero, 0, 0, 0, 0));
+            }
+
+            var now = Environment.TickCount64;
+            if (now <= Interlocked.Read(ref _traceUntilTick) &&
+                now - Interlocked.Read(ref _lastBurstSampleTick) >= BurstSampleIntervalMilliseconds)
+            {
+                Interlocked.Exchange(ref _lastBurstSampleTick, now);
+                EnqueueLine(CaptureSnapshot("burst-sample", 0, IntPtr.Zero, 0, 0, 0, 0));
+            }
+
+            FlushPendingLines();
+        }
+        catch
+        {
+            // Diagnostics are best effort only.
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _timerRunning, 0);
+        }
+    }
+
+    private static void ExtendBurst()
+    {
+        var until = Environment.TickCount64 + BurstDurationMilliseconds;
+        while (true)
+        {
+            var current = Interlocked.Read(ref _traceUntilTick);
+            if (current >= until ||
+                Interlocked.CompareExchange(ref _traceUntilTick, until, current) == current)
+            {
+                return;
+            }
+        }
+    }
+
+    private static TraceState ReadState()
+    {
+        var controller = AppController.Current;
+        return new TraceState(
+            GetForegroundWindow(),
+            ReadHandle(TrackedField, null),
+            ReadHandle(SessionField, null),
+            controller == null ? IntPtr.Zero : ReadHandle(AvoidanceField, controller));
+    }
+
+    private static string CaptureSnapshot(
+        string kind,
+        uint eventType,
+        IntPtr eventHwnd,
+        int objectId,
+        int childId,
+        uint eventThread,
+        uint eventTime)
+    {
+        var state = ReadState();
+        var zOrder = CaptureZOrder();
+        var builder = new StringBuilder(2048);
+        var sequence = Interlocked.Increment(ref _sequence);
+
+        builder.Append("trace seq=").Append(sequence)
+            .Append(" local=").Append(DateTimeOffset.Now.ToString("O"))
+            .Append(" tick=").Append(Environment.TickCount64)
+            .Append(" kind=").Append(kind);
+        if (eventType != 0)
+        {
+            builder.Append(" event=0x").Append(eventType.ToString("X4"))
+                .Append(" eventHwnd=").Append(FormatHandle(eventHwnd))
+                .Append(" objectId=").Append(objectId)
+                .Append(" childId=").Append(childId)
+                .Append(" eventThread=").Append(eventThread)
+                .Append(" eventTime=").Append(eventTime);
+        }
+        builder.AppendLine();
+
+        AppendTarget(builder, "foreground", state.Foreground, zOrder);
+        AppendTarget(builder, "avoidance", state.Avoidance, zOrder);
+        AppendTarget(builder, "tracked", state.Tracked, zOrder);
+        AppendTarget(builder, "session", state.Session, zOrder);
+
+        builder.AppendLine("paperTodoWindows:");
+        var paperWindows = zOrder.Windows
+            .Where(hwnd => ProcessIdFor(hwnd) == Environment.ProcessId)
+            .Select(hwnd => new
+            {
+                Hwnd = hwnd,
+                Z = zOrder.Index.TryGetValue(hwnd, out var z) ? z : -1
+            })
+            .OrderBy(item => item.Z)
+            .Take(MaxPaperTodoWindows)
+            .ToList();
+        if (paperWindows.Count == 0)
+        {
+            builder.AppendLine("  <none>");
+        }
+        else
+        {
+            foreach (var item in paperWindows)
+            {
+                var owner = GetWindow(item.Hwnd, GwOwner);
+                var ownerZ = owner != IntPtr.Zero && zOrder.Index.TryGetValue(owner, out var oz) ? oz : -1;
+                var avoidanceZ = state.Avoidance != IntPtr.Zero &&
+                    zOrder.Index.TryGetValue(state.Avoidance, out var az)
+                    ? az
+                    : -1;
+                var relation = item.Z < 0 || avoidanceZ < 0
+                    ? "unknown"
+                    : item.Z < avoidanceZ
+                        ? "front"
+                        : item.Z > avoidanceZ
+                            ? "behind"
+                            : "same";
+                var exStyle = GetWindowLong(item.Hwnd, GwlExStyle);
+                builder.Append("  hwnd=").Append(FormatHandle(item.Hwnd))
+                    .Append(" z=").Append(item.Z)
+                    .Append(" topmost=").Append((exStyle & WsExTopmost) != 0 ? '1' : '0')
+                    .Append(" visible=").Append(IsWindowVisible(item.Hwnd) ? '1' : '0')
+                    .Append(" owner=").Append(FormatHandle(owner))
+                    .Append(" ownerZ=").Append(ownerZ)
+                    .Append(" relation=").Append(relation)
+                    .Append(" class=").Append(Quote(GetClass(item.Hwnd)))
+                    .Append(" title=").Append(Quote(GetTitle(item.Hwnd)))
+                    .AppendLine();
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendTarget(
+        StringBuilder builder,
+        string label,
+        IntPtr hwnd,
+        ZOrderSnapshot zOrder)
+    {
+        var z = hwnd != IntPtr.Zero && zOrder.Index.TryGetValue(hwnd, out var index) ? index : -1;
+        var owner = hwnd == IntPtr.Zero ? IntPtr.Zero : GetWindow(hwnd, GwOwner);
+        var ownerZ = owner != IntPtr.Zero && zOrder.Index.TryGetValue(owner, out var ownerIndex)
+            ? ownerIndex
+            : -1;
+        var exStyle = hwnd == IntPtr.Zero ? 0 : GetWindowLong(hwnd, GwlExStyle);
+        builder.Append(label)
+            .Append(" hwnd=").Append(FormatHandle(hwnd))
+            .Append(" z=").Append(z)
+            .Append(" pid=").Append(ProcessIdFor(hwnd))
+            .Append(" topmost=").Append((exStyle & WsExTopmost) != 0 ? '1' : '0')
+            .Append(" visible=").Append(hwnd != IntPtr.Zero && IsWindowVisible(hwnd) ? '1' : '0')
+            .Append(" owner=").Append(FormatHandle(owner))
+            .Append(" ownerZ=").Append(ownerZ)
+            .Append(" class=").Append(Quote(GetClass(hwnd)))
+            .Append(" title=").Append(Quote(GetTitle(hwnd)))
+            .AppendLine();
+    }
+
+    private static ZOrderSnapshot CaptureZOrder()
+    {
+        var windows = new List<IntPtr>(256);
+        EnumWindows((hwnd, _) =>
+        {
+            windows.Add(hwnd);
+            return true;
+        }, IntPtr.Zero);
+
+        var index = new Dictionary<IntPtr, int>();
+        for (var i = 0; i < windows.Count; i++)
+        {
+            index[windows[i]] = i;
+        }
+        return new ZOrderSnapshot(windows, index);
+    }
+
+    private static string StateFingerprint(TraceState state) =>
+        $"{state.Foreground.ToInt64():X}:{state.Avoidance.ToInt64():X}:" +
+        $"{state.Tracked.ToInt64():X}:{state.Session.ToInt64():X}";
+
+    private static FieldInfo? DetectorField(string name) =>
+        DetectorType.GetField(name, BindingFlags.NonPublic | BindingFlags.Static);
+
+    private static FieldInfo? ControllerField(string name) =>
+        typeof(AppController).GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+
+    private static IntPtr ReadHandle(FieldInfo? field, object? owner)
+    {
+        try
+        {
+            return field?.GetValue(owner) is IntPtr handle ? handle : IntPtr.Zero;
+        }
+        catch
+        {
+            return IntPtr.Zero;
+        }
+    }
+
+    private static uint ProcessIdFor(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero)
+        {
+            return 0;
+        }
+        _ = GetWindowThreadProcessId(hwnd, out var processId);
+        return processId;
+    }
+
+    private static string GetClass(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero)
+        {
+            return "";
+        }
+        var builder = new StringBuilder(256);
+        var length = GetClassName(hwnd, builder, builder.Capacity);
+        return length > 0 ? builder.ToString(0, length) : "";
+    }
+
+    private static string GetTitle(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero)
+        {
+            return "";
+        }
+        var length = Math.Min(GetWindowTextLength(hwnd), 256);
+        if (length <= 0)
+        {
+            return "";
+        }
+        var builder = new StringBuilder(length + 1);
+        _ = GetWindowText(hwnd, builder, builder.Capacity);
+        return builder.ToString();
+    }
+
+    private static string Quote(string value)
+    {
+        value = value.Replace("\r", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal);
+        if (value.Length > 100)
+        {
+            value = value[..100] + "...";
+        }
+        return "\"" + value.Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
+    }
+
+    private static string FormatHandle(IntPtr hwnd) => $"0x{hwnd.ToInt64():X}";
+
+    private static void EnqueueLine(string text)
+    {
+        PendingLines.Enqueue(text.EndsWith(Environment.NewLine, StringComparison.Ordinal)
+            ? text
+            : text + Environment.NewLine);
+    }
+
+    private static void FlushPendingLines()
+    {
+        if (PendingLines.IsEmpty)
+        {
+            return;
+        }
+
+        var builder = new StringBuilder();
+        while (PendingLines.TryDequeue(out var line))
+        {
+            builder.Append(line);
+            if (builder.Length >= 256 * 1024)
+            {
+                break;
+            }
+        }
+        if (builder.Length == 0)
+        {
+            return;
+        }
+
+        lock (FileGate)
+        {
+            try
+            {
+                RotateLogIfNeeded();
+                File.AppendAllText(LogPath, builder.ToString(), Encoding.UTF8);
+            }
+            catch
+            {
+                // Logging failure must not affect PaperTodo.
+            }
+        }
+    }
+
+    private static void RotateLogAtStartup()
+    {
+        lock (FileGate)
+        {
+            try
+            {
+                if (File.Exists(LogPath))
+                {
+                    File.Move(LogPath, PreviousLogPath, overwrite: true);
+                }
+            }
+            catch
+            {
+                // A locked previous log is not fatal.
+            }
+        }
+    }
+
+    private static void RotateLogIfNeeded()
+    {
+        var file = new FileInfo(LogPath);
+        if (!file.Exists || file.Length < MaxLogBytes)
+        {
+            return;
+        }
+        File.Move(LogPath, PreviousLogPath, overwrite: true);
+    }
+
+    private static void Shutdown()
+    {
+        try
+        {
+            _timer?.Dispose();
+            _timer = null;
+            if (_foregroundHook != IntPtr.Zero)
+            {
+                _ = UnhookWinEvent(_foregroundHook);
+                _foregroundHook = IntPtr.Zero;
+            }
+            if (_reorderHook != IntPtr.Zero)
+            {
+                _ = UnhookWinEvent(_reorderHook);
+                _reorderHook = IntPtr.Zero;
+            }
+            FlushPendingLines();
+        }
+        catch
+        {
+            // Process exit continues regardless of diagnostic cleanup.
+        }
+    }
+
+    private sealed record TraceState(
+        IntPtr Foreground,
+        IntPtr Tracked,
+        IntPtr Session,
+        IntPtr Avoidance);
+
+    private sealed record ZOrderSnapshot(
+        IReadOnlyList<IntPtr> Windows,
+        IReadOnlyDictionary<IntPtr, int> Index);
+
+    private sealed record EventPayload(
+        uint EventType,
+        IntPtr Hwnd,
+        int ObjectId,
+        int ChildId,
+        uint EventThread,
+        uint EventTime);
+
+    private delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
+    private delegate void WinEventDelegate(
+        IntPtr hook,
+        uint eventType,
+        IntPtr hwnd,
+        int objectId,
+        int childId,
+        uint eventThread,
+        uint eventTime);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr SetWinEventHook(
+        uint eventMin,
+        uint eventMax,
+        IntPtr eventHook,
+        WinEventDelegate callback,
+        uint processId,
+        uint threadId,
+        uint flags);
+
+    [DllImport("user32.dll")]
+    private static extern bool UnhookWinEvent(IntPtr hook);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetWindow(IntPtr hwnd, uint command);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetAncestor(IntPtr hwnd, uint flags);
+
+    [DllImport("user32.dll")]
+    private static extern bool IsWindowVisible(IntPtr hwnd);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongW")]
+    private static extern int GetWindowLong(IntPtr hwnd, int index);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassName(IntPtr hwnd, StringBuilder className, int maxCount);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowText(IntPtr hwnd, StringBuilder text, int maxCount);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowTextLength(IntPtr hwnd);
+}


### PR DESCRIPTION
## Purpose

Add temporary, read-only fullscreen diagnostics for comparing working and failing borderless-game window modes and determining whether PaperTodo never moves behind the detected fullscreen HWND or is raised again afterward.

## Scope

- Adds `FullscreenDiagnosticLogger.cs` for broad state/window snapshots.
- Adds `FullscreenZOrderTraceLogger.cs` for short high-frequency Z-order transition tracing.
- Does not change fullscreen detection rules.
- Does not call `TryGetFullscreenWindow` from either observer.
- Does not change Topmost, ownership, native Z-order, or normal window behavior.
- Starts only inside the Windows `PaperTodo.exe` process.

## Output

### `fullscreen-diagnostic.log`

Broad snapshots beside `PaperTodo.exe`, rolled at 32 MiB to `fullscreen-diagnostic.previous.log`.

Captures foreground/session/tracked/ignored/avoidance HWNDs, PID and process information, DWM/raw rectangles and monitor-edge deltas, candidate rejection reasons, root/owner relationships, full-screen-like top-level windows, screen probes, and top-to-bottom Z-order.

### `fullscreen-zorder-trace.log`

Transition trace beside `PaperTodo.exe`, rolled at 16 MiB to `fullscreen-zorder-trace.previous.log`.

Uses `EVENT_SYSTEM_FOREGROUND` and `EVENT_OBJECT_REORDER` plus a 10 ms sampling burst for 1.5 seconds after relevant state changes. Each trace records foreground/avoidance/tracked/session Z positions and every PaperTodo HWND with Topmost, owner/owner Z, and whether it is in front of or behind the avoidance HWND.

This distinguishes:

1. PaperTodo never being inserted behind the detected fullscreen window.
2. PaperTodo briefly moving behind it and then being raised again by a later WPF/owner/window operation.

## Suggested test matrix

1. Desktop idle.
2. A normal maximized window with the taskbar hidden.
3. Dota 2 or CS in borderless mode where avoidance works.
4. Return to desktop.
5. Genshin Impact / Honkai: Star Rail / Zenless Zone Zero in borderless mode where avoidance fails.
6. Switch the same game to exclusive fullscreen if available.
7. Alt-Tab or Win+D out and back once in each mode.

Close PaperTodo after the test and collect both log files.

## Validation

The branch is diagnostic-only and adds source files without changing existing production methods. The repository has no ordinary branch/PR workflow that builds the main WPF executable, so the commits have not received an Actions build result.