### PR TITLE
fix(capsule): 修复边缘预览空白与分段收起

### DIFF
--- a/EdgeCapsuleHost.Preview.cs
+++ b/EdgeCapsuleHost.Preview.cs
@@ -131,38 +131,32 @@ internal sealed partial class EdgeCapsuleHost
             1,
             frame.Bounds.Height - chromeMarginDevice * 2);
         var bodyHeight = bodyHeightDevice / dpiScaleY;
-        var outlineMarginDip =
-            _options.WindowChromeMargin -
-            _options.OutlineThickness +
-            _options.OutlineOverlap;
-        var outlineMarginDevice = Math.Max(
-            0,
-            (int)Math.Round(
-                outlineMarginDip * dpiScaleY,
-                MidpointRounding.AwayFromZero));
-        var outlineHeightDevice = Math.Max(
-            0,
-            frame.Bounds.Height - outlineMarginDevice * 2);
 
-        // Keep the rounded shell inside the exact physical-pixel budget owned by frame.Bounds.
-        // This avoids the lower inner corner being cut by one device pixel while a preview shrinks
-        // on fractional DPI: margins and body height now consume one shared device-pixel budget.
-        Chrome.VerticalAlignment = VerticalAlignment.Top;
-        Chrome.Height = bodyHeight;
-        Shell.VerticalAlignment = VerticalAlignment.Top;
-        Shell.Height = bodyHeight;
-        Outline.VerticalAlignment = VerticalAlignment.Top;
-        Outline.Height = outlineHeightDevice / dpiScaleY;
+        // VisualSurface owns the exact device-pixel frame in both axes. Keep all three shells
+        // stretched inside that one surface so width and height are committed by the same WPF
+        // layout pass; assigning three independent heights here makes the native height resize
+        // visibly lead the surface-width update while a preview is shrinking.
+        Chrome.VerticalAlignment = VerticalAlignment.Stretch;
+        Chrome.Height = double.NaN;
+        Shell.VerticalAlignment = VerticalAlignment.Stretch;
+        Shell.Height = double.NaN;
+        Outline.VerticalAlignment = VerticalAlignment.Stretch;
+        Outline.Height = double.NaN;
 
         var heightExpanded =
             bodyHeight > _options.BodyHeight + 0.5;
-        var visible = heightExpanded;
+        var previewSurface =
+            frame.Surface == EdgeCapsuleSurfaceKind.DockedPreview;
+        // Opening starts with the old compact bounds, while an outgoing preview deliberately keeps
+        // DockedPreview until the width/height transition reaches its common final frame. Surface,
+        // not the intermediate height threshold, therefore owns the preview tree's lifetime.
+        var retainPreview = previewSurface || heightExpanded;
 
         var hasContent =
             _previewViewportLayer != null &&
             _previewContentLayer != null &&
             _previewContent != null;
-        _previewVisible = visible && hasContent;
+        _previewVisible = retainPreview && hasContent;
 
         if (_previewContentLayer != null)
         {
@@ -174,15 +168,18 @@ internal sealed partial class EdgeCapsuleHost
             _previewVisible,
             _previewVisible && frame.IsHitTestVisible);
 
-        // Compact and preview text are mutually exclusive. The preview tree is prepared before the
-        // transaction starts and remains fully rendered while its viewport reveals/shrinks it; the
-        // compact title returns only after the preview has reached the fully compact frame.
-        ApplyCompactContentVisibility(suppressed: visible);
+        // Compact and preview text are mutually exclusive. During a rapid third-card transfer the
+        // controller may deliberately release the oldest tree before its non-interactive shell has
+        // finished shrinking; keep that shell blank, but retain the compact title if an interactive
+        // preview ever reaches Apply without staged content.
+        ApplyCompactContentVisibility(
+            suppressed: _previewVisible ||
+                (retainPreview && !frame.IsHitTestVisible));
 
-        if (!visible && hasContent)
+        if (!retainPreview && hasContent)
         {
             // Keep the outgoing final-size tree while the viewport shrinks, then release it on the
-            // first fully compact frame. The controller may clear an older outgoing tree earlier
+            // common final compact frame. The controller may clear an older outgoing tree earlier
             // during a rapid third-card transfer.
             DetachPreviewContent();
         }


### PR DESCRIPTION
## 修改内容

- 修复边缘预览展开动画首帧误卸载正文，导致卡片只剩空壳的问题。
- 让预览正文树持续到宽高收起动画共同完成后再释放，避免先变矮、再变窄。
- 恢复外壳、正文壳和描边在同一可见面内统一拉伸，避免纵向布局独立抢先更新。
- 保留最新提交引入的跨窗口统一视觉事务和预渲染正文机制。

## 根因

打开动画的起跑帧已经进入预览形态，但仍沿用紧凑高度。最新实现只用中间高度判断正文生命周期，因此在第 0 帧立即拆掉了刚挂载的正文；收回时也会在高度先跨过阈值后提前切换视觉树，而宽度动画尚未完成。

## 验证

- `git diff --check` 通过。
- 分支相对 `main` 仅包含 1 个提交、1 个文件。
- 当前执行环境未安装 .NET，未执行 Windows/WPF 构建和真实动画手测。