### PR TITLE
fix(capsule): 消除边缘浏览空帧与队列错位

### DIFF
--- a/AppController.EdgeCapsulePreview.cs
+++ b/AppController.EdgeCapsulePreview.cs
@@ -12,7 +12,6 @@ public sealed partial class AppController
     private readonly EdgeCapsuleHoverIntentPredictor
         _edgeCapsulePreviewIntentPredictor = new();
     private EdgeCapsulePreviewLayoutSession? _edgeCapsulePreviewSession;
-    private string? _edgeCapsulePreviewOutgoingPaperId;
     private string? _edgeCapsulePreviewQueuedTransferPaperId;
     private string? _edgeCapsulePreviewQueuedCloseOwnerPaperId;
     private EdgeCapsulePreviewActivationIntent?
@@ -124,12 +123,10 @@ public sealed partial class AppController
                 $"queue={session.QueueKey}->{currentQueueKey}");
             session = EdgeCapsulePreviewLayoutCoordinator.OpenOrTransfer(
                 basePlan,
-                null,
                 currentQueueKey,
                 session.OwnerPaperId,
                 session.Size,
-                PaperLayoutDefaults.CapsuleHeight,
-                DeepCapsuleGap);
+                PaperLayoutDefaults.CapsuleHeight);
             if (session == null)
             {
                 TraceEdgeCapsulePreview(
@@ -146,7 +143,6 @@ public sealed partial class AppController
 
     private void ResetEdgeCapsulePreviewWithoutArrange()
     {
-        ReleaseOutgoingEdgeCapsulePreviewContent();
         var session = _edgeCapsulePreviewSession;
         TraceEdgeCapsulePreview(
             $"reset without arrange owner={EdgeCapsulePreviewTraceId(session?.OwnerPaperId)}");
@@ -162,7 +158,6 @@ public sealed partial class AppController
             _windows.TryGetValue(session.OwnerPaperId, out var owner))
         {
             owner.SetEdgeCapsulePreviewClosed(animate: false);
-            _edgeCapsulePreviewOutgoingPaperId = session.OwnerPaperId;
         }
     }
 
@@ -581,9 +576,6 @@ public sealed partial class AppController
         _edgeCapsulePreviewQueuedTransferPaperId = null;
         _edgeCapsulePreviewQueuedCloseOwnerPaperId = null;
         _edgeCapsulePreviewActivationIntent = null;
-        // A newly prepared view is already a WPF tree even before it is parented. Retire the
-        // oldest shrinking card first so rapid A -> B -> C browsing never retains three trees.
-        ReleaseOutgoingEdgeCapsulePreviewContent();
         var request = window.PrepareEdgeCapsulePreview();
         if (request == null)
         {
@@ -597,12 +589,10 @@ public sealed partial class AppController
         var queueKey = QueueKey(window.EdgeCapsulePreviewPaper);
         var next = EdgeCapsulePreviewLayoutCoordinator.OpenOrTransfer(
             basePlan,
-            _edgeCapsulePreviewSession,
             queueKey,
             window.EdgeCapsulePreviewPaperId,
             request.Size,
-            PaperLayoutDefaults.CapsuleHeight,
-            DeepCapsuleGap);
+            PaperLayoutDefaults.CapsuleHeight);
         if (next == null)
         {
             TraceEdgeCapsulePreview(
@@ -637,7 +627,6 @@ public sealed partial class AppController
                 next.OwnerPaperId,
                 StringComparison.Ordinal))
         {
-            _edgeCapsulePreviewOutgoingPaperId = previous.OwnerPaperId;
             if (_windows.TryGetValue(previous.OwnerPaperId, out var oldOwner))
             {
                 oldOwner.SetEdgeCapsulePreviewClosed(animate: true);
@@ -658,7 +647,6 @@ public sealed partial class AppController
 
     private void CloseEdgeCapsulePreview(bool animate, bool arrange)
     {
-        ReleaseOutgoingEdgeCapsulePreviewContent();
         _edgeCapsulePreviewTransferGeneration++;
         _edgeCapsulePreviewCloseGeneration++;
         var session = _edgeCapsulePreviewSession;
@@ -675,7 +663,6 @@ public sealed partial class AppController
         {
             owner = currentOwner;
             currentOwner.SetEdgeCapsulePreviewClosed(animate);
-            _edgeCapsulePreviewOutgoingPaperId = session.OwnerPaperId;
         }
 
         if (arrange && session != null && owner != null)
@@ -694,21 +681,6 @@ public sealed partial class AppController
         if (arrange)
         {
             ArrangeDeepCapsules(animate);
-        }
-    }
-
-    private void ReleaseOutgoingEdgeCapsulePreviewContent()
-    {
-        var outgoingPaperId = _edgeCapsulePreviewOutgoingPaperId;
-        _edgeCapsulePreviewOutgoingPaperId = null;
-        if (outgoingPaperId == null)
-        {
-            return;
-        }
-
-        if (_windows.TryGetValue(outgoingPaperId, out var outgoing))
-        {
-            outgoing.ClearEdgeCapsulePreviewContent();
         }
     }
 

--- a/AppController.EdgeCapsuleVisualTransaction.cs
+++ b/AppController.EdgeCapsuleVisualTransaction.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Windows.Threading;
 
 namespace PaperTodo;
@@ -96,20 +97,44 @@ public sealed partial class AppController
             TraceEdgeCapsulePreview(
                 $"visual transaction commit count={entries.Length}");
 
+            var transactionTimestamp = Stopwatch.GetTimestamp();
+            var snapBatch = entries.Any(entry =>
+                !entry.Window.IsClosed &&
+                entry.Motion.Kind == EdgeCapsuleMotionKind.Snap);
+
             // Desired preview state and every affected queue placement are already staged. Prevent
             // nested Dispatcher processing while each Presenter creates its transition from the
-            // current applied frame. WPF cannot render between these Flush calls, so the existing
-            // shared frame scheduler receives the complete transition set on its next composition
-            // tick instead of discovering one sibling per dispatcher/render turn.
+            // current applied frame. One timestamp gives every queue member identical progress;
+            // if any staged correction must snap, snap the whole batch so one card cannot jump to
+            // the endpoint while its neighbours are still interpolating toward it.
+            var nativeBatchCommitted = true;
             using (entries[0].Window.Dispatcher.DisableProcessing())
             {
+                using var nativeBoundsBatch =
+                    WindowNative.BeginWindowDeviceBoundsBatch(entries.Length);
                 foreach (var entry in entries)
                 {
                     if (!entry.Window.IsClosed)
                     {
                         entry.Window.CommitEdgeCapsuleVisualTransaction(
-                            entry.Motion,
-                            entry.RefreshLayout);
+                            snapBatch &&
+                                entry.Motion.Kind != EdgeCapsuleMotionKind.Snap
+                                ? EdgeCapsuleMotion.Snap(entry.Motion.Reason)
+                                : entry.Motion,
+                            entry.RefreshLayout,
+                            transactionTimestamp);
+                    }
+                }
+                nativeBatchCommitted = nativeBoundsBatch.Commit();
+            }
+
+            if (!nativeBatchCommitted)
+            {
+                foreach (var entry in entries)
+                {
+                    if (!entry.Window.IsClosed)
+                    {
+                        entry.Window.RetryEdgeCapsuleVisualTransaction();
                     }
                 }
             }

--- a/EdgeCapsuleFrameScheduler.cs
+++ b/EdgeCapsuleFrameScheduler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -6,7 +7,7 @@ namespace PaperTodo;
 
 /// <summary>
 /// One animation-frame scheduler per UI dispatcher. Presenters still own their transitions and
-/// reconcile pipelines; the shared scheduler only batches frame advances and cursor sampling
+/// reconcile pipelines; the shared scheduler only batches frame advances plus cursor/time sampling
 /// on WPF's actual composition frames.
 /// </summary>
 internal sealed class EdgeCapsuleFrameScheduler
@@ -95,18 +96,29 @@ internal sealed class EdgeCapsuleFrameScheduler
         try
         {
             var initialCount = _presenters.Count;
+            var frameTimestamp = Stopwatch.GetTimestamp();
             var pointer = WindowNative.TryGetCursorScreenPosition(out var currentPointer)
                 ? currentPointer
                 : (DeviceScreenPoint?)null;
+            using var nativeBoundsBatch =
+                WindowNative.BeginWindowDeviceBoundsBatch(initialCount);
 
-            // Iterate backwards so a completing presenter can be removed without a per-frame
-            // snapshot allocation. Presenters activated during this tick start on the next one.
+            // Iterate backwards without a per-frame snapshot allocation. Deactivation is deferred
+            // until the native batch commits; presenters activated during this tick start next time.
             for (var index = initialCount - 1; index >= 0; index--)
             {
                 var presenter = _presenters[index];
-                if (!presenter.AdvanceSharedFrame(this, pointer))
+                _ = presenter.AdvanceSharedFrame(
+                    this,
+                    pointer,
+                    frameTimestamp);
+            }
+
+            if (!nativeBoundsBatch.Commit())
+            {
+                for (var index = initialCount - 1; index >= 0; index--)
                 {
-                    _presenters.RemoveAt(index);
+                    _presenters[index].RetrySharedFrameAfterNativeBatchFailure(this);
                 }
             }
 

--- a/EdgeCapsuleHost.PluginContent.cs
+++ b/EdgeCapsuleHost.PluginContent.cs
@@ -41,9 +41,10 @@ internal sealed partial class EdgeCapsuleHost
         {
             _pluginContentLayer.Child = content;
         }
-        _pluginContentLayer.Visibility = _previewVisible
-            ? Visibility.Collapsed
-            : Visibility.Visible;
+        // Keep the compact plugin tree layout-resident for the same reason as ContentGrid: a
+        // closing preview can restore it by opacity without exposing a one-frame empty shell.
+        _pluginContentLayer.Visibility = Visibility.Visible;
+        _pluginContentLayer.Opacity = _previewVisible ? 0 : 1;
         ContentArea.ToolTip = toolTip;
     }
 

--- a/EdgeCapsuleHost.Preview.cs
+++ b/EdgeCapsuleHost.Preview.cs
@@ -28,9 +28,9 @@ internal sealed partial class EdgeCapsuleHost
         }
     }
 
-    // Stage and pre-render the final-size preview tree while it is still detached. The viewport
-    // changes size during the shell animation, but the content tree itself keeps its final layout
-    // size so shrinking never causes a ScrollViewer or wrapped text to re-layout frame-by-frame.
+    // Stage and prepare the final-size preview tree before the visual transaction begins. The
+    // viewport changes size during the shell animation, but the content tree itself keeps its final
+    // layout size so shrinking never makes a ScrollViewer or wrapped text reflow frame-by-frame.
     public void StagePreviewContent(
         FrameworkElement content,
         double contentWidthDip,
@@ -74,6 +74,15 @@ internal sealed partial class EdgeCapsuleHost
 
         _previewContent = content;
         _previewContentLayer.Child = content;
+        if (_previewViewportLayer != null)
+        {
+            // Join layout before the transaction can make the layer opaque. The compact tree stays
+            // painted at progress zero, so the first compositor frame still has valid content even
+            // if this newly mounted tree needs one layout pass.
+            _previewViewportLayer.Visibility = Visibility.Visible;
+            _previewViewportLayer.Opacity = 0;
+            _previewViewportLayer.IsHitTestVisible = false;
+        }
     }
 
     public void ClearPreviewContent()
@@ -151,6 +160,10 @@ internal sealed partial class EdgeCapsuleHost
         // DockedPreview until the width/height transition reaches its common final frame. Surface,
         // not the intermediate height threshold, therefore owns the preview tree's lifetime.
         var retainPreview = previewSurface || heightExpanded;
+        var previewProgress = Math.Clamp(
+            (bodyHeight - _options.BodyHeight) / 48.0,
+            0,
+            1);
 
         var hasContent =
             _previewViewportLayer != null &&
@@ -166,27 +179,30 @@ internal sealed partial class EdgeCapsuleHost
         }
         ApplyPreviewLayerState(
             _previewVisible,
-            _previewVisible && frame.IsHitTestVisible);
+            _previewVisible ? previewProgress : 0,
+            _previewVisible &&
+                previewProgress > 0.001 &&
+                frame.IsHitTestVisible);
 
-        // Compact and preview text are mutually exclusive. During a rapid third-card transfer the
-        // controller may deliberately release the oldest tree before its non-interactive shell has
-        // finished shrinking; keep that shell blank, but retain the compact title if an interactive
-        // preview ever reaches Apply without staged content.
-        ApplyCompactContentVisibility(
-            suppressed: _previewVisible ||
-                (retainPreview && !frame.IsHitTestVisible));
+        // Keep one painted tree on both ends of the transition. At the opening compact frame the
+        // staged preview has not necessarily completed its first WPF layout/render pass yet; while
+        // closing, the compact tree must already be ready to replace it. Mirroring this short
+        // cross-fade prevents either visibility hand-off from becoming a blank frame.
+        ApplyCompactContentProgress(
+            _previewVisible ? previewProgress : 0);
 
         if (!retainPreview && hasContent)
         {
             // Keep the outgoing final-size tree while the viewport shrinks, then release it on the
-            // common final compact frame. The controller may clear an older outgoing tree earlier
-            // during a rapid third-card transfer.
+            // common final compact frame. Each host owns this lifetime independently, so a rapid
+            // third-card transfer cannot expose an older still-shrinking shell without content.
             DetachPreviewContent();
         }
     }
 
     private void ApplyPreviewLayerState(
         bool visible,
+        double progress,
         bool hitTestVisible)
     {
         if (_previewViewportLayer == null)
@@ -196,26 +212,30 @@ internal sealed partial class EdgeCapsuleHost
 
         _previewViewportLayer.Visibility =
             visible ? Visibility.Visible : Visibility.Collapsed;
-        _previewViewportLayer.Opacity = visible ? 1 : 0;
+        _previewViewportLayer.Opacity = visible ? progress : 0;
         _previewViewportLayer.IsHitTestVisible = visible && hitTestVisible;
     }
 
-    private void ApplyCompactContentVisibility(bool suppressed)
+    private void ApplyCompactContentProgress(double previewProgress)
     {
-        ContentGrid.Visibility =
-            suppressed ? Visibility.Collapsed : Visibility.Visible;
-        ContentGrid.Opacity = 1;
+        var progress = Math.Clamp(previewProgress, 0, 1);
+        var compactOpacity = 1 - progress;
+
+        // Keep compact content in layout at opacity zero. It can then return on a closing or Snap
+        // frame without paying a Collapsed -> Visible layout gap; the preview layer remains above
+        // it and owns input as soon as the cross-fade starts.
+        ContentGrid.Visibility = Visibility.Visible;
+        ContentGrid.Opacity = compactOpacity;
+        ContentGrid.IsHitTestVisible = progress <= 0.001;
         if (_pluginContentLayer != null)
         {
-            _pluginContentLayer.Visibility = suppressed
-                ? Visibility.Collapsed
-                : _pluginContentLayer.Child != null
-                    ? Visibility.Visible
-                    : Visibility.Collapsed;
-            _pluginContentLayer.Opacity = 1;
+            _pluginContentLayer.Visibility = _pluginContentLayer.Child != null
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+            _pluginContentLayer.Opacity = compactOpacity;
         }
 
-        ContentArea.Background = suppressed
+        ContentArea.Background = progress > 0.001
             ? Brushes.Transparent
             : ContentArea.IsMouseOver
                 ? _hoverBrush

--- a/EdgeCapsulePresenter.cs
+++ b/EdgeCapsulePresenter.cs
@@ -40,6 +40,7 @@ internal sealed class EdgeCapsulePresenter
     private bool _frameSchedulerActive;
     private Dispatcher? _dispatcher;
     private Func<EdgeCapsuleDirty, EdgeCapsuleDirty>? _reconcile;
+    private long? _reconcileTimestampOverride;
     private EdgeCapsuleLayoutSnapshot? _layoutSnapshot;
     private bool _hasFramePointerOverride;
     private DeviceScreenPoint? _framePointerOverride;
@@ -127,7 +128,9 @@ internal sealed class EdgeCapsulePresenter
         long? nowTimestamp = null)
     {
         var remaining = EdgeCapsuleDirty.None;
-        var now = nowTimestamp ?? Stopwatch.GetTimestamp();
+        var now = nowTimestamp ??
+            _reconcileTimestampOverride ??
+            Stopwatch.GetTimestamp();
         var pointer = _hasFramePointerOverride
             ? _framePointerOverride
             : capturePointer();
@@ -301,13 +304,14 @@ internal sealed class EdgeCapsulePresenter
     public void Flush(
         EdgeCapsuleDirty dirty,
         Dispatcher dispatcher,
-        Func<EdgeCapsuleDirty, EdgeCapsuleDirty> reconcile)
+        Func<EdgeCapsuleDirty, EdgeCapsuleDirty> reconcile,
+        long? nowTimestamp = null)
     {
         _dirty |= dirty;
         Configure(dispatcher, reconcile);
         _reconcileGeneration++;
         _reconcileScheduled = false;
-        RunReconcile();
+        RunReconcile(nowTimestamp);
     }
 
     public void ClearDeferredWork()
@@ -468,20 +472,31 @@ internal sealed class EdgeCapsulePresenter
         _frameScheduler.DeferRenderingUntilLoadedBatchDrains();
     }
 
-    private void RunReconcile()
+    private void RunReconcile(long? nowTimestamp = null)
     {
         if (_reconcile == null)
         {
             return;
         }
+        var reconcileTimestamp = nowTimestamp ?? Stopwatch.GetTimestamp();
         var dirty = _dirty;
         _dirty = EdgeCapsuleDirty.None;
-        var remaining = _reconcile(dirty);
+        EdgeCapsuleDirty remaining;
+        var previousTimestampOverride = _reconcileTimestampOverride;
+        _reconcileTimestampOverride = reconcileTimestamp;
+        try
+        {
+            remaining = _reconcile(dirty);
+        }
+        finally
+        {
+            _reconcileTimestampOverride = previousTimestampOverride;
+        }
         var needsFrame = (remaining & EdgeCapsuleDirty.Frame) != 0;
         var needsApplyRetry = (remaining & EdgeCapsuleDirty.ApplyRetry) != 0;
         _dirty |= remaining & ~EdgeCapsuleDirty.Frame;
         var applyRetryExpired = needsApplyRetry &&
-            ApplyRetryExpired(Stopwatch.GetTimestamp());
+            ApplyRetryExpired(reconcileTimestamp);
         if (applyRetryExpired)
         {
             // Keep Presentation dirty for a later explicit/display invalidation, but stop the
@@ -582,9 +597,25 @@ internal sealed class EdgeCapsulePresenter
     internal bool UsesSharedFrameScheduler(EdgeCapsuleFrameScheduler scheduler) =>
         _frameSchedulerActive && ReferenceEquals(_frameScheduler, scheduler);
 
+    internal void RetrySharedFrameAfterNativeBatchFailure(
+        EdgeCapsuleFrameScheduler scheduler)
+    {
+        if (_dispatcher == null ||
+            _reconcile == null ||
+            !ReferenceEquals(_frameScheduler, scheduler))
+        {
+            return;
+        }
+
+        ForceApplyCurrentPresentation();
+        _dirty |= EdgeCapsuleDirty.Presentation;
+        StartFrameScheduler();
+    }
+
     internal bool AdvanceSharedFrame(
         EdgeCapsuleFrameScheduler scheduler,
-        DeviceScreenPoint? pointer)
+        DeviceScreenPoint? pointer,
+        long frameTimestamp)
     {
         var pointerTracking = NeedsPointerTracking;
         var applyRetryPending = (_dirty & EdgeCapsuleDirty.ApplyRetry) != 0;
@@ -613,7 +644,7 @@ internal sealed class EdgeCapsulePresenter
         _framePointerOverride = pointer;
         try
         {
-            RunReconcile();
+            RunReconcile(frameTimestamp);
         }
         finally
         {

--- a/EdgeCapsulePreview.cs
+++ b/EdgeCapsulePreview.cs
@@ -137,19 +137,17 @@ internal sealed record EdgeCapsulePreviewLayoutSession(
 
 /// <summary>
 /// Pure preview placement policy. The compact queue remains the base plan. During one browsing
-/// session only the owner has a non-standard height. Downward transfers preserve the target's lower
-/// anchor to avoid visual reordering; upward transfers may compact space released by the old owner.
+/// session only the owner has a non-standard height. Every endpoint is a tightly packed queue;
+/// shared transition progress then preserves the same gap between every adjacent pair in flight.
 /// </summary>
 internal static class EdgeCapsulePreviewLayoutCoordinator
 {
     public static EdgeCapsulePreviewLayoutSession? OpenOrTransfer(
         EdgeCapsuleQueuePlan basePlan,
-        EdgeCapsulePreviewLayoutSession? previous,
         string queueKey,
         string ownerPaperId,
         EdgeCapsulePreviewSize size,
-        double compactHeightDip,
-        double gapDip)
+        double compactHeightDip)
     {
         var queue = basePlan.Queues.FirstOrDefault(item =>
             string.Equals(item.Key, queueKey, StringComparison.Ordinal));
@@ -166,105 +164,18 @@ internal static class EdgeCapsulePreviewLayoutCoordinator
         }
 
         var compactHeight = Math.Max(1, compactHeightDip);
-        var gap = Math.Max(0, gapDip);
-        var slotHeight = compactHeight + gap;
-        var baseTops = papers
-            .Select(paper =>
-                basePlan.Placements[paper.Id].VisualIndex * slotHeight)
-            .ToArray();
-        var currentTops = baseTops.ToArray();
-
         var paperIds = papers.Select(paper => paper.Id).ToArray();
-        var sameQueue = previous != null &&
-            string.Equals(previous.QueueKey, queueKey, StringComparison.Ordinal) &&
-            previous.QueuePaperIds.SequenceEqual(
-                paperIds,
-                StringComparer.Ordinal);
-        var oldIndex = -1;
-        if (sameQueue)
-        {
-            for (var index = 0; index < papers.Count; index++)
-            {
-                currentTops[index] += previous!.TopOffsetsDip
-                    .GetValueOrDefault(papers[index].Id);
-            }
-            oldIndex = IndexOf(papers, previous!.OwnerPaperId);
-        }
-
         var newHeight = Math.Max(compactHeight, size.HeightDip);
-        var tops = currentTops.ToArray();
+        var expansion = newHeight - compactHeight;
 
         // Accepted temporary 1.8 behavior: preview browsing preserves the queue-relative motion
         // even when a tall card or its followers extend beyond the monitor work area. Do not clamp
         // the card height or shrink the whole corridor here; that policy needs a separate design.
 
-        if (oldIndex < 0)
-        {
-            tops[newIndex] = baseTops[newIndex];
-            PushFollowingMembers(
-                tops,
-                currentTops,
-                newIndex,
-                newHeight,
-                compactHeight,
-                gap);
-        }
-        else if (newIndex > oldIndex)
-        {
-            // Moving downward: compact the released side, keep the first member below the target
-            // where it currently is, and let the new card grow upward into the released space.
-            for (var index = 0; index < newIndex; index++)
-            {
-                tops[index] = baseTops[index];
-            }
-
-            var nextTop = newIndex + 1 < papers.Count
-                ? currentTops[newIndex + 1]
-                : currentTops[newIndex] + compactHeight + gap;
-            var proposedTop = nextTop - gap - newHeight;
-            var anchoredTop = Math.Min(
-                proposedTop,
-                currentTops[newIndex]);
-            var minimumTop = newIndex > 0
-                ? tops[newIndex - 1] + compactHeight + gap
-                : baseTops[newIndex];
-            tops[newIndex] = Math.Max(anchoredTop, minimumTop);
-            PushFollowingMembers(
-                tops,
-                currentTops,
-                newIndex,
-                newHeight,
-                compactHeight,
-                gap);
-        }
-        else if (newIndex < oldIndex)
-        {
-            // Moving upward cannot invert any crossed member. Compact from the new owner downward
-            // so followers fill space released by a taller old card. The downward branch above
-            // intentionally remains anchored because compacting below a skipped target can make a
-            // follower appear to pass that target during the shared transition.
-            for (var index = 0; index <= newIndex; index++)
-            {
-                tops[index] = baseTops[index];
-            }
-            PlaceFollowingMembers(
-                tops,
-                currentTops,
-                newIndex,
-                newHeight,
-                compactHeight,
-                gap,
-                retainExistingGaps: false);
-        }
-        else
-        {
-            return previous! with { Size = size };
-        }
-
         var offsets = new Dictionary<string, double>(StringComparer.Ordinal);
         for (var index = 0; index < papers.Count; index++)
         {
-            offsets[papers[index].Id] = tops[index] - baseTops[index];
+            offsets[papers[index].Id] = index > newIndex ? expansion : 0;
         }
 
         return new EdgeCapsulePreviewLayoutSession(
@@ -297,43 +208,6 @@ internal static class EdgeCapsulePreviewLayoutCoordinator
         }
 
         return new EdgeCapsuleQueuePlan(basePlan.Queues, placements);
-    }
-
-    private static void PushFollowingMembers(
-        double[] tops,
-        double[] currentTops,
-        int ownerIndex,
-        double ownerHeight,
-        double compactHeight,
-        double gap) =>
-        PlaceFollowingMembers(
-            tops,
-            currentTops,
-            ownerIndex,
-            ownerHeight,
-            compactHeight,
-            gap,
-            retainExistingGaps: true);
-
-    private static void PlaceFollowingMembers(
-        double[] tops,
-        double[] currentTops,
-        int ownerIndex,
-        double ownerHeight,
-        double compactHeight,
-        double gap,
-        bool retainExistingGaps)
-    {
-        for (var index = ownerIndex + 1; index < tops.Length; index++)
-        {
-            var previousHeight = index - 1 == ownerIndex
-                ? ownerHeight
-                : compactHeight;
-            var minimumTop = tops[index - 1] + previousHeight + gap;
-            tops[index] = retainExistingGaps
-                ? Math.Max(currentTops[index], minimumTop)
-                : minimumTop;
-        }
     }
 
     private static int IndexOf(IReadOnlyList<PaperData> papers, string paperId)

--- a/PaperWindow.EdgeCapsuleVisualTransaction.cs
+++ b/PaperWindow.EdgeCapsuleVisualTransaction.cs
@@ -20,7 +20,8 @@ public sealed partial class PaperWindow
 
     internal void CommitEdgeCapsuleVisualTransaction(
         EdgeCapsuleMotion motion,
-        bool refreshLayout)
+        bool refreshLayout,
+        long transactionTimestamp)
     {
         if (_windowLifecycle != PaperWindowLifecycleState.Alive ||
             IsClosed ||
@@ -37,6 +38,21 @@ public sealed partial class PaperWindow
         }
 
         var dispatcher = _edgeCapsuleHost?.Dispatcher ?? Dispatcher;
-        _edgeCapsule.Flush(dirty, dispatcher, ReconcileEdgeCapsule);
+        _edgeCapsule.Flush(
+            dirty,
+            dispatcher,
+            ReconcileEdgeCapsule,
+            transactionTimestamp);
+    }
+
+    internal void RetryEdgeCapsuleVisualTransaction()
+    {
+        if (_windowLifecycle != PaperWindowLifecycleState.Alive || IsClosed)
+        {
+            return;
+        }
+
+        _edgeCapsule.ForceApplyCurrentPresentation();
+        InvalidateEdgeCapsule(EdgeCapsuleDirty.Presentation);
     }
 }

--- a/WindowNative.cs
+++ b/WindowNative.cs
@@ -9,6 +9,9 @@ namespace PaperTodo;
 // verbatim across PaperWindow.Native and MasterCapsuleWindow.
 internal static class WindowNative
 {
+    [ThreadStatic]
+    private static WindowDeviceBoundsBatch? _currentDeviceBoundsBatch;
+
     private const int GwlExStyle = -20;
     private const int GwlpHwndParent = -8;
     private const uint GwOwner = 4;
@@ -429,6 +432,19 @@ internal static class WindowNative
 
         var helper = new WindowInteropHelper(window);
         var handle = helper.Handle != IntPtr.Zero ? helper.Handle : helper.EnsureHandle();
+        if (handle != IntPtr.Zero &&
+            window.IsVisible &&
+            _currentDeviceBoundsBatch is { } batch)
+        {
+            if (batch.HasFailed)
+            {
+                return false;
+            }
+            if (batch.IsAvailable)
+            {
+                return batch.TryDefer(handle, bounds);
+            }
+        }
         return handle != IntPtr.Zero && SetWindowPos(
             handle,
             IntPtr.Zero,
@@ -539,6 +555,11 @@ internal static class WindowNative
     public static bool TryGetWindowDeviceBounds(Window window, out DeviceScreenRect bounds)
     {
         var handle = new WindowInteropHelper(window).Handle;
+        if (handle != IntPtr.Zero &&
+            _currentDeviceBoundsBatch?.TryGetPending(handle, out bounds) == true)
+        {
+            return true;
+        }
         if (handle != IntPtr.Zero && GetWindowRect(handle, out var nativeRect))
         {
             bounds = new DeviceScreenRect(nativeRect.Left, nativeRect.Top, nativeRect.Right, nativeRect.Bottom);
@@ -547,6 +568,134 @@ internal static class WindowNative
 
         bounds = default;
         return false;
+    }
+
+    /// <summary>
+    /// Defers all visible HWND bounds submitted on the current UI thread and commits them through
+    /// one HDWP. This is the native half of a cross-capsule visual transaction: DWM can no longer
+    /// sample one queue member at the new animation frame while a sibling is still on the old one.
+    /// </summary>
+    public static WindowDeviceBoundsBatch BeginWindowDeviceBoundsBatch(int capacity) =>
+        new(Math.Max(1, capacity));
+
+    internal sealed class WindowDeviceBoundsBatch : IDisposable
+    {
+        private readonly bool _ownsCurrentBatch;
+        private readonly Dictionary<IntPtr, DeviceScreenRect> _pendingBounds = new();
+        private IntPtr _deferredWindowPosition;
+        private bool _completed;
+
+        internal WindowDeviceBoundsBatch(int capacity)
+        {
+            if (_currentDeviceBoundsBatch != null)
+            {
+                // A nested visual callback already participates in the outer native transaction.
+                return;
+            }
+
+            _ownsCurrentBatch = true;
+            _deferredWindowPosition = BeginDeferWindowPos(capacity);
+            _currentDeviceBoundsBatch = this;
+        }
+
+        internal bool IsAvailable =>
+            _ownsCurrentBatch &&
+            !_completed &&
+            !HasFailed &&
+            _deferredWindowPosition != IntPtr.Zero;
+
+        internal bool HasFailed { get; private set; }
+
+        internal bool TryDefer(IntPtr handle, DeviceScreenRect bounds)
+        {
+            if (!IsAvailable || handle == IntPtr.Zero || bounds.IsEmpty)
+            {
+                return false;
+            }
+
+            var updated = DeferWindowPos(
+                _deferredWindowPosition,
+                handle,
+                IntPtr.Zero,
+                bounds.Left,
+                bounds.Top,
+                bounds.Width,
+                bounds.Height,
+                SwpNoZOrder | SwpNoActivate | SwpNoOwnerZOrder);
+            if (updated == IntPtr.Zero)
+            {
+                HasFailed = true;
+                _deferredWindowPosition = IntPtr.Zero;
+                _pendingBounds.Clear();
+                return false;
+            }
+
+            _deferredWindowPosition = updated;
+            _pendingBounds[handle] = bounds;
+            return true;
+        }
+
+        internal bool TryGetPending(IntPtr handle, out DeviceScreenRect bounds)
+        {
+            if (_ownsCurrentBatch &&
+                _pendingBounds.TryGetValue(handle, out bounds))
+            {
+                return true;
+            }
+
+            bounds = default;
+            return false;
+        }
+
+        public bool Commit()
+        {
+            if (_completed)
+            {
+                return !HasFailed;
+            }
+            _completed = true;
+
+            if (!_ownsCurrentBatch)
+            {
+                return true;
+            }
+            if (ReferenceEquals(_currentDeviceBoundsBatch, this))
+            {
+                _currentDeviceBoundsBatch = null;
+            }
+
+            // If BeginDeferWindowPos was unavailable, callers already used the ordinary immediate
+            // SetWindowPos fallback. A failed DeferWindowPos, however, invalidates the entire HDWP.
+            if (_deferredWindowPosition == IntPtr.Zero)
+            {
+                return !HasFailed;
+            }
+
+            var committed = EndDeferWindowPos(_deferredWindowPosition);
+            _deferredWindowPosition = IntPtr.Zero;
+            if (!committed)
+            {
+                HasFailed = true;
+                return false;
+            }
+
+            foreach (var (handle, expected) in _pendingBounds)
+            {
+                if (!GetWindowRect(handle, out var actual) ||
+                    new DeviceScreenRect(
+                        actual.Left,
+                        actual.Top,
+                        actual.Right,
+                        actual.Bottom) != expected)
+                {
+                    HasFailed = true;
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public void Dispose() => Commit();
     }
 
     public static bool TryGetWindowScreenBounds(Window window, out Rect bounds)
@@ -683,6 +832,23 @@ internal static class WindowNative
         int cx,
         int cy,
         uint uFlags);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr BeginDeferWindowPos(int nNumWindows);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr DeferWindowPos(
+        IntPtr hWinPosInfo,
+        IntPtr hWnd,
+        IntPtr hWndInsertAfter,
+        int x,
+        int y,
+        int cx,
+        int cy,
+        uint uFlags);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool EndDeferWindowPos(IntPtr hWinPosInfo);
 
     [DllImport("user32.dll")]
     private static extern IntPtr GetWindow(IntPtr hWnd, uint uCmd);


### PR DESCRIPTION
## 问题

边缘浏览在高刷新率下仍有两类瞬时回归：

- 快速 A → B → C 浏览会提前拆掉最旧的退出内容树，而它的壳仍在收起，录屏可以捕捉到空胶囊；紧凑树和预览树直接在 `Collapsed` / `Visible` 间切换也把首个布局帧暴露出来。
- 所谓共享帧只共享了鼠标位置，各 Presenter 仍分别读取时间并逐个调用 `SetWindowPos`。在 240Hz 的 4.17ms 帧窗口内，DWM 可能采到一部分胶囊已进入新帧、另一部分仍停在旧帧。
- 旧的向下转移布局会保留下方锚点；当前后预览高度不同时，它会主动留下额外间距，因此端点本身也不保证紧凑排列。

## 修改

- 退出预览由各自 Host 在共同的紧凑终帧释放，不再为限制临时内容树数量提前制造空壳。
- 恢复紧凑内容与预览内容的短交叉淡化；预览在事务前进入布局，紧凑内容在透明时仍保持布局驻留，Snap/关闭也不需要等待一次 `Collapsed -> Visible` 布局。
- 视觉事务开始和每次共享渲染帧各只采样一次 `Stopwatch` 时间戳，所有胶囊使用完全相同的动画进度。
- 用 `BeginDeferWindowPos / DeferWindowPos / EndDeferWindowPos` 一次提交同帧的多个 HWND 位置；批量失败时整批强制重放。只要一项需要 Snap，整个事务一起 Snap，避免混合相位。
- 预览布局统一为“当前卡原位展开，所有后续成员让出同一高度差”，端点始终紧凑；在共享进度插值下，中间每帧也保持相邻间距。

## 验证

- `git diff --check` 通过。
- 9 个修改后的 C# 文件通过 Tree-sitter 语法解析。
- 对 2–12 个胶囊、不同前后 owner、38–420 DIP 不同卡高和 101 个动画采样点做组合验证，相邻间距始终保持 12 DIP。
- 远端提交树与本地提交树 SHA 完全一致：`2961a9685f1866e7c873387be3103b2859f814b5`。

当前容器没有 .NET/Windows WPF 工具链，因此这里无法执行 Windows 构建和 240Hz 实机录制；合并前需要用原复现路径手测。