### PR TITLE
fix(plugin): harden protocol 1.8 mini previews

### DIFF
--- a/AppController.EdgeCapsulePreview.cs
+++ b/AppController.EdgeCapsulePreview.cs
@@ -408,6 +408,22 @@ public sealed partial class AppController
         }
     }
 
+    internal void CloseEdgeCapsulePreviewForBodySessionReset(PaperWindow window)
+    {
+        if (IsEdgeCapsulePreviewOwner(window))
+        {
+            // A protocol 1.8 preview can own controls from the body session that is about to be
+            // replaced. End the controller session and restore queue placement before that tree is
+            // disposed, otherwise the edge host can retain a dead native/Web mini view.
+            CloseEdgeCapsulePreview(animate: false, arrange: true);
+        }
+
+        // Also repair a locally staged request if the controller session was already removed (for
+        // example during shutdown). Apply the compact state synchronously enough to precede the
+        // next render, then sever the final visual-tree reference while the session is still alive.
+        window.ResetEdgeCapsulePreviewForBodySessionChange();
+    }
+
     internal bool IsEdgeCapsulePreviewOwner(PaperWindow window) =>
         _edgeCapsulePreviewSession is { } session &&
         string.Equals(

--- a/EdgeCapsuleHost.Preview.cs
+++ b/EdgeCapsuleHost.Preview.cs
@@ -14,6 +14,10 @@ internal sealed partial class EdgeCapsuleHost
     private Border? _previewContentLayer;
     private FrameworkElement? _previewContent;
     private bool _previewVisible;
+    private bool _previewInteractiveCaptureLease;
+    private long _previewInteractiveCaptureGraceUntil;
+
+    private const int PreviewInteractiveCaptureGraceMilliseconds = 250;
 
     public bool IsPreviewPointerCaptureActive
     {
@@ -24,15 +28,54 @@ internal sealed partial class EdgeCapsuleHost
                 return false;
             }
 
-            return Mouse.Captured is DependencyObject captured &&
-                IsDescendantOfPreview(captured);
+            var captured = Mouse.Captured as DependencyObject;
+            if (captured != null && IsDescendantOfPreview(captured))
+            {
+                return true;
+            }
+
+            if (!_previewInteractiveCaptureLease)
+            {
+                return false;
+            }
+
+            // ComboBox, ContextMenu and similar controls move capture into a separate Popup HWND,
+            // so it is no longer a visual descendant of the mini tree. A lease armed by the
+            // initiating pointer gesture lets that same-dispatcher capture keep the preview open.
+            if (captured != null && ReferenceEquals(captured.Dispatcher, Dispatcher))
+            {
+                return true;
+            }
+            if (Mouse.LeftButton == MouseButtonState.Pressed ||
+                Mouse.RightButton == MouseButtonState.Pressed ||
+                Environment.TickCount64 <= _previewInteractiveCaptureGraceUntil)
+            {
+                return true;
+            }
+
+            _previewInteractiveCaptureLease = false;
+            return false;
         }
+    }
+
+    private void ArmPreviewInteractiveCaptureLease()
+    {
+        if (_disposed || !_previewVisible)
+        {
+            return;
+        }
+
+        _previewInteractiveCaptureLease = true;
+        _previewInteractiveCaptureGraceUntil =
+            Environment.TickCount64 + PreviewInteractiveCaptureGraceMilliseconds;
     }
 
     public bool OwnsPreviewContent(FrameworkElement content) =>
         !_disposed &&
         ReferenceEquals(_previewContent, content) &&
         ReferenceEquals(content.Parent, _previewContentLayer);
+
+    public bool HasPreviewContent => !_disposed && _previewContent != null;
 
     // Stage and prepare the final-size preview tree before the visual transaction begins. The
     // viewport changes size during the shell animation, but the content tree itself keeps its final
@@ -58,6 +101,12 @@ internal sealed partial class EdgeCapsuleHost
         if (_previewContentLayer == null)
         {
             return;
+        }
+
+        if (!ReferenceEquals(_previewContent, content))
+        {
+            _previewInteractiveCaptureLease = false;
+            _previewInteractiveCaptureGraceUntil = 0;
         }
 
         if (_previewContentLayer.Child != null &&
@@ -99,6 +148,7 @@ internal sealed partial class EdgeCapsuleHost
         }
 
         DetachPreviewContent();
+        ApplyCompactContentProgress(0);
     }
 
     private void EnsurePreviewLayers()
@@ -258,6 +308,8 @@ internal sealed partial class EdgeCapsuleHost
         }
         _previewContent = null;
         _previewVisible = false;
+        _previewInteractiveCaptureLease = false;
+        _previewInteractiveCaptureGraceUntil = 0;
         if (_previewViewportLayer != null)
         {
             _previewViewportLayer.Visibility = Visibility.Collapsed;
@@ -285,14 +337,19 @@ internal sealed partial class EdgeCapsuleHost
             {
                 return false;
             }
+            // The edge host deliberately uses WS_EX_NOACTIVATE. Text editors therefore cannot
+            // acquire keyboard focus here; treating them as background opens the full paper
+            // instead of presenting a control that appears editable but cannot accept typing.
+            if (current is TextBoxBase or PasswordBox)
+            {
+                return false;
+            }
             if (EdgeCapsulePreviewInteraction.GetConsumesPointer(current) ||
                 PaperMiniViewInteraction.GetConsumesPointer(current) ||
                 current is ButtonBase or
-                    TextBoxBase or
                     Selector or
                     ScrollBar or
                     Thumb or
-                    PasswordBox or
                     MenuItem or
                     Hyperlink)
             {

--- a/EdgeCapsuleHost.cs
+++ b/EdgeCapsuleHost.cs
@@ -690,6 +690,7 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
             if (IsPreviewInteractiveSource(
                     e.OriginalSource as DependencyObject))
             {
+                ArmPreviewInteractiveCaptureLease();
                 return;
             }
 
@@ -731,6 +732,8 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
         shell.MouseEnter += (_, _) => callbacks.PointerInvalidated();
         shell.MouseLeave += (_, _) => callbacks.PointerInvalidated();
         content.PreviewMouseLeftButtonDown += (_, e) => BeginContentPointer(e);
+        content.PreviewMouseRightButtonDown += (_, _) =>
+            ArmPreviewInteractiveCaptureLease();
         content.PreviewMouseMove += (_, e) =>
         {
             if (!content.IsMouseCaptured)

--- a/PaperTodo.Plugin.Abstractions/PaperBodyPluginContracts.cs
+++ b/PaperTodo.Plugin.Abstractions/PaperBodyPluginContracts.cs
@@ -174,7 +174,8 @@ public interface IPaperBodyViewMigrationProvider
 
 /// <summary>
 /// Marks a custom mini-view element as owning pointer input. Standard WPF buttons, selectors,
-/// text inputs, scroll bars, thumbs and hyperlinks are detected automatically.
+/// scroll bars, thumbs and hyperlinks are detected automatically. The edge host deliberately does
+/// not take keyboard focus; text editing belongs in the full paper body.
 /// </summary>
 public static class PaperMiniViewInteraction
 {

--- a/PaperWindow.EdgeCapsulePreview.cs
+++ b/PaperWindow.EdgeCapsulePreview.cs
@@ -202,7 +202,22 @@ public sealed partial class PaperWindow
         NotifyEdgeCapsulePreviewVisibility(
             _edgeCapsulePreviewRequest,
             visible: false);
+        _edgeCapsulePreviewRequest = null;
         _edgeCapsuleHost?.ClearPreviewContent();
+    }
+
+    internal void ResetEdgeCapsulePreviewForBodySessionChange()
+    {
+        if (!IsEdgeCapsulePreviewOpen &&
+            _edgeCapsulePreviewRequest == null &&
+            _edgeCapsuleHost?.HasPreviewContent != true)
+        {
+            return;
+        }
+
+        SetEdgeCapsulePreviewClosed(animate: false);
+        FlushEdgeCapsulePreviewCompactPresentation();
+        ClearEdgeCapsulePreviewContent();
     }
 
     private static void NotifyEdgeCapsulePreviewVisibility(

--- a/PaperWindow.PluginBodies.cs
+++ b/PaperWindow.PluginBodies.cs
@@ -697,6 +697,9 @@ public sealed partial class PaperWindow
     {
         var generation = _bodySessionGeneration;
         var providerId = NormalizeBodyProviderId(_paper.BodyProviderId);
+        // The edge host may currently own a protocol 1.8 mini tree created by this exact session.
+        // Restore compact presentation and detach that tree before invalidating or disposing it.
+        _controller.CloseEdgeCapsulePreviewForBodySessionReset(this);
         // A protocol 1.8 migration preview may temporarily parent the one real body view. Restore
         // it while the session is still current, before Commit/Dispose tears down that view tree.
         ResetPluginMiniViewCache();

--- a/plugin-samples/PaperTodo.Plugin.OfficialClockWeb/web/mini.html
+++ b/plugin-samples/PaperTodo.Plugin.OfficialClockWeb/web/mini.html
@@ -126,7 +126,15 @@
       ].filter(Boolean).join(' · ');
       $('date').textContent = date;
       $('date').hidden = !date;
-      const elapsed = Number(parts.hour) * 3600 + Number(parts.minute) * 60 + Number(parts.second);
+      // Day progress must use a 24-hour clock even when the visible clock is formatted as 12-hour.
+      // Otherwise (for example) 5 PM is incorrectly measured as 5/24 through the day.
+      const dayParts = Object.fromEntries(new Intl.DateTimeFormat('en-GB', {
+        timeZone: zoneMap[settings.timeZone],
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+        hourCycle: 'h23'
+      }).formatToParts(now).map(part => [part.type, part.value]));
+      const elapsed = (Number(dayParts.hour) % 24) * 3600 +
+        Number(dayParts.minute) * 60 + Number(dayParts.second);
       $('progress').style.width = `${Math.min(100, Math.max(0, elapsed / 864))}%`;
       $('track').hidden = !settings.showDayProgress;
     }

--- a/plugin-samples/README.md
+++ b/plugin-samples/README.md
@@ -150,7 +150,7 @@ private sealed class Session : IPaperBodySession, IPaperMiniViewProvider
 }
 ```
 
-专属原生迷你界面只接受纯 WPF，不接受 `Window`、`HwndHost`、`WindowsFormsHost`、WebView2 或已挂载控件。`OnMiniViewVisibilityChanged(false)` 会在收起开始时停止交互，但宿主仍要用最后一帧完成动画，因此插件只能暂停刷新，不能立即清空或折叠整棵迷你树。标准 WPF 按钮、输入框、选择器、滚动条、拖块和链接会自动取得输入；其他自定义命中元素可调用 `PaperMiniViewInteraction.SetConsumesPointer(element, true)`。
+专属原生迷你界面只接受纯 WPF，不接受 `Window`、`HwndHost`、`WindowsFormsHost`、WebView2 或已挂载控件。`OnMiniViewVisibilityChanged(false)` 会在收起开始时停止交互，但宿主仍要用最后一帧完成动画，因此插件只能暂停刷新，不能立即清空或折叠整棵迷你树。标准 WPF 按钮、选择器、滚动条、拖块和链接会自动取得鼠标输入；其他自定义命中元素可调用 `PaperMiniViewInteraction.SetConsumesPointer(element, true)`。边缘宿主不会取得键盘焦点，因此迷你界面不得依赖文本输入；点击输入框会按背景点击处理并打开完整纸片，文本编辑应放在正文界面。
 
 ### 原生正文迁移
 
@@ -179,7 +179,7 @@ Web 插件可在清单中声明同一 `entry` 静态目录下的 `miniEntry`。�
 
 宿主先同步显示放大的 1.6 胶囊，迷你 WebView2 初始化期间不会出现空卡。迷你页收到 `initialize` 后完成首轮布局，再显式调用 `papertodo.mini.ready()`；宿主会等到下一渲染帧才替换回退层。初始化、导航、脚本失败或页面始终未声明就绪时都继续保留放大胶囊；若就绪消息恰好落在收起期间，宿主只记录结果，下一次移入后才切换界面。
 
-迷你页与正文获得同一份 `state`、`settings`、主题和权限；`window.papertodo.surface` 与 `initialize.surface` 分别为 `mini` 或 `body`，共用脚本可以据此选择布局。任何一侧 `saveState` 后都会通知另一侧 `stateChanged`。接收方应只把 `stateChanged` 应用到自己的控件，不要在事件处理器里原样回写 `saveState`；只有用户操作或真实业务变化才写回，否则两棵页面会形成回声。迷你页还可使用 `paper`、`body.openExternal` 与 `workspace.request()`；`miniVisibilityChanged` 用于暂停隐藏后的计时器或动画。`visible: false` 从收起动画开始时发送，页面应停止输入和刷新，但要保留最后一次 DOM 绘制，不能立即清空根节点。宿主状态始终是真相来源，不应让正文页和迷你页各自保存互相覆盖的私有副本。
+迷你页与正文获得同一份 `state`、`settings`、主题和权限；`window.papertodo.surface` 与 `initialize.surface` 分别为 `mini` 或 `body`，共用脚本可以据此选择布局。任何一侧 `saveState` 后都会通知另一侧 `stateChanged`。接收方应只把 `stateChanged` 应用到自己的控件，不要在事件处理器里原样回写 `saveState`；只有用户操作或真实业务变化才写回，否则两棵页面会形成回声。迷你页还可使用 `paper`、`body.openExternal` 与 `workspace.request()`；`miniVisibilityChanged` 用于暂停隐藏后的计时器或动画。`visible: false` 从收起动画开始时发送，页面应停止输入和刷新，但要保留最后一次 DOM 绘制，不能立即清空根节点。边缘窗口不会取得键盘焦点，Web 迷你页也只能设计为鼠标交互界面，不应放置需要键盘输入的表单。宿主状态始终是真相来源，不应让正文页和迷你页各自保存互相覆盖的私有副本。
 
 需要在纸片折叠为可见胶囊后继续运行的插件，必须声明 `"requires": ["backgroundUpdates"]`。未声明时，宿主会在完整正文不显示时通知插件暂停运行；未知的必需能力会拒绝加载。
 

--- a/plugins/official.clock.web/web/mini.html
+++ b/plugins/official.clock.web/web/mini.html
@@ -126,7 +126,15 @@
       ].filter(Boolean).join(' · ');
       $('date').textContent = date;
       $('date').hidden = !date;
-      const elapsed = Number(parts.hour) * 3600 + Number(parts.minute) * 60 + Number(parts.second);
+      // Day progress must use a 24-hour clock even when the visible clock is formatted as 12-hour.
+      // Otherwise (for example) 5 PM is incorrectly measured as 5/24 through the day.
+      const dayParts = Object.fromEntries(new Intl.DateTimeFormat('en-GB', {
+        timeZone: zoneMap[settings.timeZone],
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+        hourCycle: 'h23'
+      }).formatToParts(now).map(part => [part.type, part.value]));
+      const elapsed = (Number(dayParts.hour) % 24) * 3600 +
+        Number(dayParts.minute) * 60 + Number(dayParts.second);
       $('progress').style.width = `${Math.min(100, Math.max(0, elapsed / 864))}%`;
       $('track').hidden = !settings.showDayProgress;
     }


### PR DESCRIPTION
## 修改内容

- 在插件正文会话重载或销毁前，同步关闭边缘预览并解绑 1.8 迷你视图，避免宿主持有已失效的原生或 Web 内容树。
- 为 `ComboBox`、`ContextMenu` 等独立 Popup HWND 增加短时交互租约，避免操作弹出层时预览意外收起。
- 明确边缘宿主为无键盘焦点界面：文本输入改为打开完整纸片，并同步修正文档与协议注释。
- 时钟 Web 示例改用 24 小时时间计算日进度，并保持源码与运行时 `mini.html` 完全一致。

## 原因

1.8 迷你视图可能来自正在被替换的插件会话；旧内容树若未先解绑，会留下失效视图。WPF Popup 又运行在独立 HWND 中，单纯判断视觉树后代会把合法交互误认为鼠标已经离开。另外，可见时钟允许 12 小时显示，但日进度不能复用 12 小时的小时值。

## 校验

- `git diff --check`
- 两份时钟 `mini.html` 字节一致
- 两份内联 JavaScript 均通过 Node 语法解析
- 远端提交树与本地提交树 SHA 完全一致
- 当前环境没有 .NET SDK，完整 C# 编译交给 GitHub Actions