### PR TITLE
修复边缘浏览原生唤醒失步

### DIFF
--- a/EdgeCapsuleNativeWake.cs
+++ b/EdgeCapsuleNativeWake.cs
@@ -1,0 +1,173 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Threading;
+
+namespace PaperTodo;
+
+/// <summary>
+/// Installs the native edge-capsule wake bridge after the WPF dispatcher and controller exist.
+/// The bridge is runtime behavior, not diagnostics: it only repairs the initial no-owner case
+/// where the docked HWND receives real mouse input while the presenter still has a stale
+/// PointerOverSurface=false sample.
+/// </summary>
+internal static class EdgeCapsuleNativeWakeBootstrap
+{
+    private static Timer? _bootstrapTimer;
+    private static int _installQueued;
+
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        try
+        {
+            _bootstrapTimer = new Timer(
+                static _ => TryQueueInstall(),
+                null,
+                TimeSpan.Zero,
+                TimeSpan.FromMilliseconds(250));
+        }
+        catch
+        {
+            // Failure to install the fallback must never affect application startup.
+        }
+    }
+
+    private static void TryQueueInstall()
+    {
+        try
+        {
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher == null ||
+                dispatcher.HasShutdownStarted ||
+                dispatcher.HasShutdownFinished ||
+                Interlocked.Exchange(ref _installQueued, 1) != 0)
+            {
+                return;
+            }
+
+            _ = dispatcher.BeginInvoke(
+                (Action)(() =>
+                {
+                    try
+                    {
+                        var controller = AppController.Current;
+                        if (controller == null)
+                        {
+                            Interlocked.Exchange(ref _installQueued, 0);
+                            return;
+                        }
+
+                        controller.AttachEdgeCapsuleNativeWake();
+                        _bootstrapTimer?.Dispose();
+                        _bootstrapTimer = null;
+                    }
+                    catch
+                    {
+                        Interlocked.Exchange(ref _installQueued, 0);
+                    }
+                }),
+                DispatcherPriority.Background);
+        }
+        catch
+        {
+            Interlocked.Exchange(ref _installQueued, 0);
+        }
+    }
+}
+
+public sealed partial class AppController
+{
+    private const int EdgeCapsuleNativeWakeWmMouseMove = 0x0200;
+    private const int EdgeCapsuleNativeWakeWmNcMouseMove = 0x00A0;
+    private const double EdgeCapsuleNativeWakeRetryMilliseconds = 32;
+
+    private bool _edgeCapsuleNativeWakeAttached;
+    private IntPtr _edgeCapsuleNativeWakeLastHwnd;
+    private long _edgeCapsuleNativeWakeLastTimestamp;
+
+    internal void AttachEdgeCapsuleNativeWake()
+    {
+        if (_edgeCapsuleNativeWakeAttached)
+        {
+            return;
+        }
+
+        _edgeCapsuleNativeWakeAttached = true;
+        ComponentDispatcher.ThreadPreprocessMessage +=
+            OnEdgeCapsuleNativeWakeMessage;
+    }
+
+    private void OnEdgeCapsuleNativeWakeMessage(ref MSG msg, ref bool handled)
+    {
+        if (handled ||
+            IsExiting ||
+            !State.ExperimentalEdgeCapsuleHoverPreview ||
+            _edgeCapsulePreviewSession != null ||
+            (msg.message != EdgeCapsuleNativeWakeWmMouseMove &&
+             msg.message != EdgeCapsuleNativeWakeWmNcMouseMove) ||
+            !WindowNative.TryGetCursorScreenPosition(out var pointer))
+        {
+            return;
+        }
+
+        PaperWindow? target = null;
+        foreach (var window in _windows.Values)
+        {
+            if (window.EdgeCapsuleNativeWakeHandle != msg.hwnd ||
+                window.IsEdgeCapsulePointerOver ||
+                !window.CanEnterEdgeCapsulePreview ||
+                !window.IsEdgeCapsuleInteractiveAt(pointer))
+            {
+                continue;
+            }
+
+            target = window;
+            break;
+        }
+
+        if (target == null)
+        {
+            return;
+        }
+
+        // The native message is already authoritative for occlusion: an obscured underlying HWND
+        // does not receive WM_MOUSEMOVE. The geometry check above additionally excludes the fixed
+        // transparent host reserve, so this fallback has no authority outside the real capsule.
+        var now = Stopwatch.GetTimestamp();
+        if (_edgeCapsuleNativeWakeLastHwnd == msg.hwnd &&
+            _edgeCapsuleNativeWakeLastTimestamp != 0 &&
+            Stopwatch.GetElapsedTime(
+                _edgeCapsuleNativeWakeLastTimestamp,
+                now).TotalMilliseconds < EdgeCapsuleNativeWakeRetryMilliseconds)
+        {
+            return;
+        }
+
+        _edgeCapsuleNativeWakeLastHwnd = msg.hwnd;
+        _edgeCapsuleNativeWakeLastTimestamp = now;
+        TraceEdgeCapsulePreview(
+            $"native wake target={EdgeCapsulePreviewTraceId(target.EdgeCapsulePreviewPaperId)} " +
+            $"pointer={pointer.X},{pointer.Y} hwnd=0x{msg.hwnd.ToInt64():X}");
+        target.InvalidateEdgeCapsulePointerFromNativeWake();
+    }
+}
+
+public sealed partial class PaperWindow
+{
+    internal IntPtr EdgeCapsuleNativeWakeHandle =>
+        _edgeCapsuleHost?.EdgeCapsuleNativeWakeHandle ?? IntPtr.Zero;
+
+    internal void InvalidateEdgeCapsulePointerFromNativeWake() =>
+        InvalidateEdgeCapsulePointerFromHostInput();
+}
+
+internal sealed partial class EdgeCapsuleHost
+{
+    internal IntPtr EdgeCapsuleNativeWakeHandle =>
+        _disposed
+            ? IntPtr.Zero
+            : new WindowInteropHelper(Window).Handle;
+}


### PR DESCRIPTION
## 改动内容

- 增加运行时原生鼠标唤醒桥，只处理“当前没有浏览 owner”时的首次浏览唤醒。
- 当胶囊 HWND 已真实收到 `WM_MOUSEMOVE/WM_NCMOUSEMOVE`，但 Presenter 仍是 `PointerOverSurface=false` 时，触发一次现有指针重算。
- 继续复用原有 `CanEnterEdgeCapsulePreview`、真实交互区域判断、状态机、50ms 稳定切换和视觉事务，不直接强开浏览态。
- 对同一 HWND 的重复兜底做 32ms 限流，避免失败路径形成高频重算。

## 根因

实机日志出现了稳定复现：原生 HWND 持续命中、`hitTest=True`、`eligible=True`，且鼠标实际位于目标窗口，但 Presenter 的 `PointerOverSurface` 长时间保持 false，因此控制器从未创建 activation intent。现有 Host 只在 `DockedResting` 的 WPF `PreviewMouseMove` 中主动补指针重算；`DockedActive`（展开纸片保留的边缘胶囊）没有这层兜底。

## 边界

- 仅在 `_edgeCapsulePreviewSession == null` 时生效，不改变已有浏览态下 A→B 的切换逻辑。
- 原生消息必须来自目标胶囊 HWND，且当前指针必须仍处于已提交的 `InteractiveBounds` 内。
- 被其他窗口遮挡的胶囊不会收到对应鼠标移动消息，因此不会被兜底误激活。

## 验证

- 新文件已回读确认落在 `agent/edge-preview-native-wake`。
- Windows Release build 由 PR Actions 验证。