### PR TITLE
修复边缘浏览唤醒与走廊关闭规则

### DIFF
--- a/EdgeCapsuleHost.cs
+++ b/EdgeCapsuleHost.cs
@@ -150,11 +150,22 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
         {
             return;
         }
+
         var window = Window;
-        window.SourceInitialized += (_, _) =>
+        var attached = false;
+        void AttachToCurrentSource()
         {
+            if (_disposed || attached ||
+                PresentationSource.FromVisual(window) is not HwndSource source)
+            {
+                return;
+            }
+
+            // SetInteractionLocked/SetExperimentalPassive may have created the HWND before this
+            // method was called. Attach immediately when a source already exists, while keeping
+            // SourceInitialized as the normal first-creation path. This mirrors the diagnostics
+            // hook and prevents a live host from permanently missing native pointer wake-ups.
             WindowNative.ApplyNoActivateStyle(window);
-            // Lock/passive state can be set before WPF creates this host's HWND.
             WindowNative.SetInputPassthrough(
                 window,
                 _interactionLocked || _experimentalPassive);
@@ -162,13 +173,14 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
             {
                 WindowNative.ApplyBottomZOrder(window);
             }
-            if (PresentationSource.FromVisual(window) is HwndSource source)
-            {
-                source.AddHook(OnNativeMessage);
-                source.AddHook(hook);
-            }
-        };
+            source.AddHook(OnNativeMessage);
+            source.AddHook(hook);
+            attached = true;
+        }
+
+        window.SourceInitialized += (_, _) => AttachToCurrentSource();
         window.Deactivated += (_, _) => deactivated();
+        AttachToCurrentSource();
     }
 
     /// <summary>

--- a/EdgeCapsuleHost.cs
+++ b/EdgeCapsuleHost.cs
@@ -62,6 +62,7 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
     private const int WmMouseMove = 0x0200;
     private const int WmNcMouseMove = 0x00A0;
     private const int WmNcHitTest = 0x0084;
+    private const double PreviewPointerTrackingIntervalMilliseconds = 24;
     private static readonly IntPtr HtTransparent = new(-1);
     private readonly EdgeCapsuleHostOptions _options;
     private EdgeCapsuleHostCallbacks? _callbacks;
@@ -738,9 +739,60 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
         var content = ContentArea;
         var close = CloseArea;
         var closeGlyph = CloseGlyph;
+        DispatcherTimer? previewPointerTrackingTimer = null;
+
+        void StopPreviewPointerTracking()
+        {
+            previewPointerTrackingTimer?.Stop();
+        }
+
+        void StartPreviewPointerTracking()
+        {
+            if (_disposed ||
+                _appliedFrame.Surface != EdgeCapsuleSurfaceKind.DockedPreview ||
+                content.IsMouseCaptured)
+            {
+                return;
+            }
+
+            if (previewPointerTrackingTimer == null)
+            {
+                previewPointerTrackingTimer = new DispatcherTimer(
+                    DispatcherPriority.Input,
+                    Window.Dispatcher)
+                {
+                    Interval = TimeSpan.FromMilliseconds(
+                        PreviewPointerTrackingIntervalMilliseconds)
+                };
+                previewPointerTrackingTimer.Tick += (_, _) =>
+                {
+                    if (_disposed ||
+                        _callbacks == null ||
+                        _appliedFrame.Surface != EdgeCapsuleSurfaceKind.DockedPreview ||
+                        content.IsMouseCaptured)
+                    {
+                        StopPreviewPointerTracking();
+                        return;
+                    }
+
+                    // Empty corridor pixels are HTTRANSPARENT and therefore cannot keep generating
+                    // routed mouse moves. While this one preview is open, wake only its own pointer
+                    // reconciliation so the controller can notice a real corridor exit promptly.
+                    callbacks.PointerInvalidated();
+                    if (WindowNative.TryGetCursorScreenPosition(out var pointer) &&
+                        ContainsScreenPoint(pointer))
+                    {
+                        StopPreviewPointerTracking();
+                    }
+                };
+            }
+
+            previewPointerTrackingTimer.Start();
+        }
 
         void BeginContentPointer(MouseButtonEventArgs e)
         {
+            StopPreviewPointerTracking();
             if (IsPreviewInteractiveSource(
                     e.OriginalSource as DependencyObject))
             {
@@ -788,11 +840,22 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
                 close.Background = Brushes.Transparent;
             }
         };
-        shell.MouseEnter += (_, _) => callbacks.PointerInvalidated();
-        shell.MouseLeave += (_, _) => callbacks.PointerInvalidated();
+        shell.MouseEnter += (_, _) =>
+        {
+            StopPreviewPointerTracking();
+            callbacks.PointerInvalidated();
+        };
+        shell.MouseLeave += (_, _) =>
+        {
+            callbacks.PointerInvalidated();
+            StartPreviewPointerTracking();
+        };
         content.PreviewMouseLeftButtonDown += (_, e) => BeginContentPointer(e);
         content.PreviewMouseRightButtonDown += (_, _) =>
+        {
+            StopPreviewPointerTracking();
             ArmPreviewInteractiveCaptureLease();
+        };
         content.PreviewMouseMove += (_, e) =>
         {
             if (!content.IsMouseCaptured)

--- a/EdgeCapsuleHoverIntent.cs
+++ b/EdgeCapsuleHoverIntent.cs
@@ -256,9 +256,8 @@ internal sealed class EdgeCapsuleHoverIntentPredictor
             motion.SignedVerticalSpeedDipPerMillisecond < 0
             ? pointer.Y - targetBounds.Top
             : targetBounds.Bottom - pointer.Y;
-        var distanceToExitDip = Math.Max(0, distanceToExitDevice) /
-            _dpiScaleY;
-        var timeToExit = distanceToExitDip /
+        var distanceToExitDip = distanceToExitDevice / _dpiScaleY;
+        var timeToExit = Math.Max(0, distanceToExitDip) /
             motion.RecentVerticalSpeedDipPerMillisecond;
 
         // menu-aim style negative protection: a coherent, non-braking trajectory that will leave

--- a/EdgeCapsuleHoverIntent.cs
+++ b/EdgeCapsuleHoverIntent.cs
@@ -47,7 +47,7 @@ internal sealed class EdgeCapsuleHoverIntentPredictor
         MinimumDirectionConsistency: 0.76,
         MinimumVerticalDominance: 0.60,
         CorridorExit: new CorridorExitProfile(
-            0.060, 0.62, 320, 12, 90, 1200));
+            0.060, 0.62, 320, 12, 250, 1200));
 
     private static readonly IntentSensitivityProfile HighProfile = new(
         Initial: new IntentProfile(8, 8, 32, 80, 180),
@@ -57,7 +57,7 @@ internal sealed class EdgeCapsuleHoverIntentPredictor
         MinimumDirectionConsistency: 0.72,
         MinimumVerticalDominance: 0.55,
         CorridorExit: new CorridorExitProfile(
-            0.075, 0.68, 400, 16, 120, 1500));
+            0.075, 0.68, 400, 16, 300, 1500));
 
     private static readonly IntentSensitivityProfile MediumProfile = new(
         Initial: new IntentProfile(8, 10, 36, 90, 200),
@@ -67,7 +67,7 @@ internal sealed class EdgeCapsuleHoverIntentPredictor
         MinimumDirectionConsistency: 0.68,
         MinimumVerticalDominance: 0.50,
         CorridorExit: new CorridorExitProfile(
-            0.090, 0.74, 500, 20, 160, 2000));
+            0.090, 0.74, 500, 20, 400, 2000));
 
     // "Low" describes activation sensitivity: it applies longer waits and recognizes less
     // pronounced residual motion as pass-through risk, so stopping must be more deliberate.
@@ -79,7 +79,7 @@ internal sealed class EdgeCapsuleHoverIntentPredictor
         MinimumDirectionConsistency: 0.64,
         MinimumVerticalDominance: 0.45,
         CorridorExit: new CorridorExitProfile(
-            0.110, 0.79, 640, 24, 220, 2700));
+            0.110, 0.79, 640, 24, 500, 2700));
 
     private static readonly IntentSensitivityProfile VeryLowProfile = new(
         Initial: new IntentProfile(12, 18, 54, 135, 300),
@@ -89,7 +89,7 @@ internal sealed class EdgeCapsuleHoverIntentPredictor
         MinimumDirectionConsistency: 0.60,
         MinimumVerticalDominance: 0.40,
         CorridorExit: new CorridorExitProfile(
-            0.140, 0.84, 800, 30, 300, 3800));
+            0.140, 0.84, 800, 30, 650, 3800));
 
     private readonly PointerSample[] _samples =
         new PointerSample[SampleCapacity];
@@ -256,8 +256,9 @@ internal sealed class EdgeCapsuleHoverIntentPredictor
             motion.SignedVerticalSpeedDipPerMillisecond < 0
             ? pointer.Y - targetBounds.Top
             : targetBounds.Bottom - pointer.Y;
-        var distanceToExitDip = distanceToExitDevice / _dpiScaleY;
-        var timeToExit = Math.Max(0, distanceToExitDip) /
+        var distanceToExitDip = Math.Max(0, distanceToExitDevice) /
+            _dpiScaleY;
+        var timeToExit = distanceToExitDip /
             motion.RecentVerticalSpeedDipPerMillisecond;
 
         // menu-aim style negative protection: a coherent, non-braking trajectory that will leave


### PR DESCRIPTION
## 问题 1：偶发不激活浏览态
最新输入日志抓到目标胶囊 HWND 已经真实命中、资格正常，但 Presenter 的 PointerOverSurface 仍为 false，导致没有建立浏览意图。

根因是 `EdgeCapsuleHost.AttachNativeHooks` 过去只等 `SourceInitialized` 安装正式原生钩子；若 HWND 已被前置样式处理提前创建，就会永久错过该事件。现在注册时会立即尝试绑定已有 `HwndSource`，未创建时仍走 `SourceInitialized`，并防止重复绑定。

## 问题 2：走廊关闭规则
按当前产品规则收口：
- 鼠标预测开启：空白走廊内先预测轨迹。若投影仍朝向可浏览胶囊则继续保活；方向性关闭不能再近似瞬时触发，五档方向确认改为约 250 / 300 / 400 / 500 / 650 ms。停住仍按现有五档空白区 idle 延时关闭。
- 鼠标预测关闭：仍在空白走廊内固定 3 秒关闭；一旦真正离开完整走廊，应立即关闭，不能一直等到 3 秒终点才发现已经出界。

## 实现
- 当前预览卡的鼠标离开真实卡面后，仅该 host 临时以 24 ms 周期唤醒自己的指针采样。
- 该采样用于透明空白走廊，因为这些像素是 `HTTRANSPARENT`，不会继续产生 WPF 鼠标移动。
- 回到当前卡、开始捕获、切换/收起或 host 销毁后停止；不恢复进程级全局扫描，也不恢复所有 Presenter 的逐帧鼠标轮询。
- 保留现有 `rect-union + 窄连接桥` 走廊几何、50 ms + 2 DIP 切换门槛和其它浏览规则。

## 验证
- 补丁只涉及 `EdgeCapsuleHost.cs` 与 `EdgeCapsuleHoverIntent.cs`。
- 首版原生钩子修复已通过 PR Build 与 edge refinement checks；最新提交触发的新一轮 CI 继续验证。