### PR TITLE
修复边缘浏览物理输入授权与关闭时序

### DIFF
--- a/AppController.EdgeCapsulePreviewPointerInput.cs
+++ b/AppController.EdgeCapsulePreviewPointerInput.cs
@@ -1,0 +1,371 @@
+using System.Diagnostics;
+using System.Windows.Threading;
+
+namespace PaperTodo;
+
+public sealed partial class AppController
+{
+    private readonly record struct EdgeCapsulePreviewPhysicalLinger(
+        string OwnerPaperId,
+        bool Predictive,
+        long EnteredTimestamp,
+        DeviceScreenPoint StableAnchor,
+        long StableSinceTimestamp,
+        long? DirectionAwaySinceTimestamp);
+
+    private EdgeCapsulePreviewPhysicalLinger?
+        _edgeCapsulePreviewPhysicalLinger;
+    private DispatcherTimer? _edgeCapsulePreviewPhysicalLingerTimer;
+
+    /// <summary>
+    /// Physical pointer authority for edge-preview input. Host/native input may prove that the
+    /// pointer is inside a real applied rectangle even while the Presenter's cosmetic hover bit is
+    /// stale. The first card may therefore open from a verified physical hit; an existing session
+    /// still uses the normal 50 ms / 2-DIP transfer contract.
+    /// </summary>
+    internal void NotifyEdgeCapsulePreviewPhysicalPointer(
+        PaperWindow inputWindow,
+        DeviceScreenPoint? pointer)
+    {
+        if (IsExiting)
+        {
+            ResetEdgeCapsulePreviewPhysicalLinger();
+            return;
+        }
+
+        var session = _edgeCapsulePreviewSession;
+        if (session == null)
+        {
+            ResetEdgeCapsulePreviewPhysicalLinger();
+            if (!pointer.HasValue)
+            {
+                return;
+            }
+
+            var point = pointer.Value;
+            ClearEdgeCapsulePreviewLayoutSuppressionWhenPointerMoves(point);
+            if (!inputWindow.CanEnterEdgeCapsulePreview ||
+                !inputWindow.IsEdgeCapsuleInteractiveAt(point) ||
+                IsEdgeCapsulePreviewLayoutSuppressedFor(inputWindow))
+            {
+                CancelEdgeCapsulePreviewActivationIntent(
+                    inputWindow.EdgeCapsulePreviewPaperId);
+                return;
+            }
+
+            if (!inputWindow.IsEdgeCapsulePointerOver)
+            {
+                TraceEdgeCapsulePreview(
+                    $"physical hit recovery target={EdgeCapsulePreviewTraceId(inputWindow.EdgeCapsulePreviewPaperId)} " +
+                    $"pointer={point.X},{point.Y}");
+            }
+
+            AdvanceEdgeCapsulePreviewActivationIntent(
+                null,
+                inputWindow,
+                point);
+            return;
+        }
+
+        if (!pointer.HasValue ||
+            !_windows.TryGetValue(session.OwnerPaperId, out var owner) ||
+            !owner.CanEnterEdgeCapsulePreview)
+        {
+            ResetEdgeCapsulePreviewPhysicalLinger();
+            return;
+        }
+
+        var current = pointer.Value;
+        ClearEdgeCapsulePreviewLayoutSuppressionWhenPointerMoves(current);
+        if (owner.EdgeCapsulePreviewPointerCaptureActive)
+        {
+            CancelEdgeCapsulePreviewActivationIntent();
+            CancelQueuedEdgeCapsulePreviewClose();
+            ResetEdgeCapsulePreviewCorridorExitIntent();
+            ResetEdgeCapsulePreviewPhysicalLinger();
+            return;
+        }
+
+        ObserveEdgeCapsulePreviewPointer(owner, current);
+        var resolution = ResolveEdgeCapsulePreviewPointer(session, current);
+        if (resolution.OwnerContains)
+        {
+            CancelEdgeCapsulePreviewActivationIntent();
+            CancelQueuedEdgeCapsulePreviewClose();
+            ResetEdgeCapsulePreviewCorridorExitIntent();
+            ResetEdgeCapsulePreviewPhysicalLinger();
+            RememberEdgeCapsulePreviewPointerResolution(session, current);
+            return;
+        }
+
+        if (resolution.Target != null)
+        {
+            CancelQueuedEdgeCapsulePreviewClose();
+            ResetEdgeCapsulePreviewCorridorExitIntent();
+            ResetEdgeCapsulePreviewPhysicalLinger();
+            if (IsEdgeCapsulePreviewLayoutSuppressedFor(resolution.Target))
+            {
+                CancelEdgeCapsulePreviewActivationIntent();
+                RememberEdgeCapsulePreviewPointerResolution(session, current);
+                return;
+            }
+
+            AdvanceEdgeCapsulePreviewActivationIntent(
+                session,
+                resolution.Target,
+                current);
+            return;
+        }
+
+        CancelEdgeCapsulePreviewActivationIntent();
+        ResetEdgeCapsulePreviewCorridorExitIntent();
+        var predictive = State.ExperimentalEdgeCapsuleHoverIntent;
+        if (!predictive && !resolution.CorridorContains)
+        {
+            ResetEdgeCapsulePreviewPhysicalLinger();
+            RememberEdgeCapsulePreviewPointerResolution(session, current);
+            TraceEdgeCapsulePreview(
+                $"physical corridor exit owner={EdgeCapsulePreviewTraceId(session.OwnerPaperId)} " +
+                $"predictive=False pointer={current.X},{current.Y}");
+            QueueEdgeCapsulePreviewClose(
+                owner,
+                session.OwnerPaperId,
+                EdgeCapsulePreviewCloseReason.OutsideCorridor);
+            return;
+        }
+
+        CancelQueuedEdgeCapsulePreviewClose();
+        AdvanceEdgeCapsulePreviewPhysicalLinger(
+            owner,
+            session,
+            current,
+            predictive,
+            resolution.CorridorContains);
+        RememberEdgeCapsulePreviewPointerResolution(session, current);
+    }
+
+    private void AdvanceEdgeCapsulePreviewPhysicalLinger(
+        PaperWindow owner,
+        EdgeCapsulePreviewLayoutSession session,
+        DeviceScreenPoint pointer,
+        bool predictive,
+        bool corridorContains)
+    {
+        var now = Stopwatch.GetTimestamp();
+        var linger = _edgeCapsulePreviewPhysicalLinger;
+        var firstSample = !linger.HasValue ||
+            !string.Equals(
+                linger.Value.OwnerPaperId,
+                session.OwnerPaperId,
+                StringComparison.Ordinal) ||
+            linger.Value.Predictive != predictive;
+        var current = firstSample
+            ? new EdgeCapsulePreviewPhysicalLinger(
+                session.OwnerPaperId,
+                predictive,
+                now,
+                pointer,
+                now,
+                null)
+            : linger!.Value;
+
+        double dpiScaleX;
+        double dpiScaleY;
+        if (owner.TryGetEdgeCapsuleAppliedGeometry(out var ownerGeometry))
+        {
+            dpiScaleX = ownerGeometry.DpiScaleX;
+            dpiScaleY = ownerGeometry.DpiScaleY;
+        }
+        else if (WindowWorkAreaHelper.TryGetMonitorGeometryAtDeviceScreenPoint(
+                pointer,
+                out var monitor))
+        {
+            dpiScaleX = monitor.DpiScaleX;
+            dpiScaleY = monitor.DpiScaleY;
+        }
+        else
+        {
+            ResetEdgeCapsulePreviewPhysicalLinger();
+            return;
+        }
+
+        if (predictive && EdgeCapsulePreviewPointerMovedBeyondTolerance(
+                current.StableAnchor,
+                pointer,
+                dpiScaleX,
+                dpiScaleY))
+        {
+            current = current with
+            {
+                StableAnchor = pointer,
+                StableSinceTimestamp = now
+            };
+        }
+
+        var enteredElapsed = Stopwatch.GetElapsedTime(
+            current.EnteredTimestamp,
+            now).TotalMilliseconds;
+        var stableElapsed = Stopwatch.GetElapsedTime(
+            current.StableSinceTimestamp,
+            now).TotalMilliseconds;
+        var directionAwayElapsed = current.DirectionAwaySinceTimestamp.HasValue
+            ? Stopwatch.GetElapsedTime(
+                current.DirectionAwaySinceTimestamp.Value,
+                now).TotalMilliseconds
+            : 0;
+
+        EdgeCapsuleCorridorExitDecision decision;
+        if (!predictive)
+        {
+            decision = enteredElapsed >=
+                EdgeCapsulePreviewFixedCorridorCloseMilliseconds
+                ? EdgeCapsuleCorridorExitDecision.CloseForIdle
+                : EdgeCapsuleCorridorExitDecision.KeepAlive;
+        }
+        else
+        {
+            Span<DeviceScreenRect> keepAliveBounds =
+                session.QueuePaperIds.Count <= 32
+                    ? stackalloc DeviceScreenRect[session.QueuePaperIds.Count]
+                    : new DeviceScreenRect[session.QueuePaperIds.Count];
+            var keepAliveCount = 0;
+            foreach (var paperId in session.QueuePaperIds)
+            {
+                if (!_windows.TryGetValue(paperId, out var candidate) ||
+                    !candidate.CanEnterEdgeCapsulePreview ||
+                    !candidate.TryGetEdgeCapsuleInteractiveGeometry(
+                        out var geometry))
+                {
+                    continue;
+                }
+
+                keepAliveBounds[keepAliveCount++] = geometry.Bounds;
+            }
+
+            decision = _edgeCapsulePreviewIntentPredictor.EvaluateCorridorExit(
+                State.ExperimentalEdgeCapsuleHoverIntentSensitivity,
+                keepAliveBounds.Slice(0, keepAliveCount),
+                pointer,
+                directionAwayElapsed,
+                stableElapsed);
+        }
+
+        if (firstSample)
+        {
+            TraceEdgeCapsulePreview(
+                $"physical linger enter owner={EdgeCapsulePreviewTraceId(session.OwnerPaperId)} " +
+                $"predictive={predictive} corridor={corridorContains} " +
+                $"pointer={pointer.X},{pointer.Y}");
+        }
+
+        switch (decision)
+        {
+            case EdgeCapsuleCorridorExitDecision.ConfirmDirectionExit:
+                current = current with
+                {
+                    DirectionAwaySinceTimestamp =
+                        current.DirectionAwaySinceTimestamp ?? now
+                };
+                break;
+
+            case EdgeCapsuleCorridorExitDecision.CloseForDirection:
+            case EdgeCapsuleCorridorExitDecision.CloseForIdle:
+                TraceEdgeCapsulePreview(
+                    $"physical linger close owner={EdgeCapsulePreviewTraceId(session.OwnerPaperId)} " +
+                    $"reason={decision} predictive={predictive} corridor={corridorContains} " +
+                    $"enteredMs={enteredElapsed:F1} awayMs={directionAwayElapsed:F1} " +
+                    $"stableMs={stableElapsed:F1} pointer={pointer.X},{pointer.Y}");
+                QueueEdgeCapsulePreviewClose(
+                    owner,
+                    session.OwnerPaperId,
+                    EdgeCapsulePreviewCloseReason.CorridorIntent);
+                ResetEdgeCapsulePreviewPhysicalLinger();
+                return;
+
+            default:
+                current = current with
+                {
+                    DirectionAwaySinceTimestamp = null
+                };
+                break;
+        }
+
+        _edgeCapsulePreviewPhysicalLinger = current;
+        ScheduleEdgeCapsulePreviewPhysicalLinger(owner, now);
+    }
+
+    private void ScheduleEdgeCapsulePreviewPhysicalLinger(
+        PaperWindow owner,
+        long now)
+    {
+        if (_edgeCapsulePreviewPhysicalLinger is not { } linger)
+        {
+            return;
+        }
+
+        var closeMilliseconds = linger.Predictive
+            ? _edgeCapsulePreviewIntentPredictor.CorridorIdleCloseMilliseconds(
+                State.ExperimentalEdgeCapsuleHoverIntentSensitivity)
+            : EdgeCapsulePreviewFixedCorridorCloseMilliseconds;
+        var elapsed = Stopwatch.GetElapsedTime(
+            linger.Predictive
+                ? linger.StableSinceTimestamp
+                : linger.EnteredTimestamp,
+            now).TotalMilliseconds;
+        var remaining = Math.Max(1, closeMilliseconds - elapsed);
+        var next = Math.Min(
+            EdgeCapsulePreviewCorridorTrackingIntervalMilliseconds,
+            remaining);
+
+        if (_edgeCapsulePreviewPhysicalLingerTimer == null)
+        {
+            _edgeCapsulePreviewPhysicalLingerTimer = new DispatcherTimer(
+                DispatcherPriority.Input,
+                owner.Dispatcher);
+            _edgeCapsulePreviewPhysicalLingerTimer.Tick +=
+                OnEdgeCapsulePreviewPhysicalLingerTimerTick;
+        }
+
+        _edgeCapsulePreviewPhysicalLingerTimer.Stop();
+        _edgeCapsulePreviewPhysicalLingerTimer.Interval =
+            TimeSpan.FromMilliseconds(next);
+        _edgeCapsulePreviewPhysicalLingerTimer.Start();
+    }
+
+    private void OnEdgeCapsulePreviewPhysicalLingerTimerTick(
+        object? sender,
+        EventArgs e)
+    {
+        _edgeCapsulePreviewPhysicalLingerTimer?.Stop();
+        if (IsExiting ||
+            _edgeCapsulePreviewPhysicalLinger is not { } linger ||
+            _edgeCapsulePreviewSession is not { } session ||
+            !string.Equals(
+                linger.OwnerPaperId,
+                session.OwnerPaperId,
+                StringComparison.Ordinal) ||
+            !_windows.TryGetValue(session.OwnerPaperId, out var owner) ||
+            !owner.CanEnterEdgeCapsulePreview ||
+            owner.EdgeCapsulePreviewPointerCaptureActive)
+        {
+            ResetEdgeCapsulePreviewPhysicalLinger();
+            return;
+        }
+
+        if (!WindowNative.TryGetCursorScreenPosition(out var pointer))
+        {
+            ScheduleEdgeCapsulePreviewPhysicalLinger(
+                owner,
+                Stopwatch.GetTimestamp());
+            return;
+        }
+
+        NotifyEdgeCapsulePreviewPhysicalPointer(owner, pointer);
+    }
+
+    private void ResetEdgeCapsulePreviewPhysicalLinger()
+    {
+        _edgeCapsulePreviewPhysicalLinger = null;
+        _edgeCapsulePreviewPhysicalLingerTimer?.Stop();
+    }
+}

--- a/EdgeCapsuleHost.cs
+++ b/EdgeCapsuleHost.cs
@@ -62,7 +62,6 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
     private const int WmMouseMove = 0x0200;
     private const int WmNcMouseMove = 0x00A0;
     private const int WmNcHitTest = 0x0084;
-    private const double PreviewPointerTrackingIntervalMilliseconds = 24;
     private static readonly IntPtr HtTransparent = new(-1);
     private readonly EdgeCapsuleHostOptions _options;
     private EdgeCapsuleHostCallbacks? _callbacks;
@@ -739,60 +738,9 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
         var content = ContentArea;
         var close = CloseArea;
         var closeGlyph = CloseGlyph;
-        DispatcherTimer? previewPointerTrackingTimer = null;
-
-        void StopPreviewPointerTracking()
-        {
-            previewPointerTrackingTimer?.Stop();
-        }
-
-        void StartPreviewPointerTracking()
-        {
-            if (_disposed ||
-                _appliedFrame.Surface != EdgeCapsuleSurfaceKind.DockedPreview ||
-                content.IsMouseCaptured)
-            {
-                return;
-            }
-
-            if (previewPointerTrackingTimer == null)
-            {
-                previewPointerTrackingTimer = new DispatcherTimer(
-                    DispatcherPriority.Input,
-                    Window.Dispatcher)
-                {
-                    Interval = TimeSpan.FromMilliseconds(
-                        PreviewPointerTrackingIntervalMilliseconds)
-                };
-                previewPointerTrackingTimer.Tick += (_, _) =>
-                {
-                    if (_disposed ||
-                        _callbacks == null ||
-                        _appliedFrame.Surface != EdgeCapsuleSurfaceKind.DockedPreview ||
-                        content.IsMouseCaptured)
-                    {
-                        StopPreviewPointerTracking();
-                        return;
-                    }
-
-                    // Empty corridor pixels are HTTRANSPARENT and therefore cannot keep generating
-                    // routed mouse moves. While this one preview is open, wake only its own pointer
-                    // reconciliation so the controller can notice a real corridor exit promptly.
-                    callbacks.PointerInvalidated();
-                    if (WindowNative.TryGetCursorScreenPosition(out var pointer) &&
-                        ContainsScreenPoint(pointer))
-                    {
-                        StopPreviewPointerTracking();
-                    }
-                };
-            }
-
-            previewPointerTrackingTimer.Start();
-        }
 
         void BeginContentPointer(MouseButtonEventArgs e)
         {
-            StopPreviewPointerTracking();
             if (IsPreviewInteractiveSource(
                     e.OriginalSource as DependencyObject))
             {
@@ -840,22 +788,11 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
                 close.Background = Brushes.Transparent;
             }
         };
-        shell.MouseEnter += (_, _) =>
-        {
-            StopPreviewPointerTracking();
-            callbacks.PointerInvalidated();
-        };
-        shell.MouseLeave += (_, _) =>
-        {
-            callbacks.PointerInvalidated();
-            StartPreviewPointerTracking();
-        };
+        shell.MouseEnter += (_, _) => callbacks.PointerInvalidated();
+        shell.MouseLeave += (_, _) => callbacks.PointerInvalidated();
         content.PreviewMouseLeftButtonDown += (_, e) => BeginContentPointer(e);
         content.PreviewMouseRightButtonDown += (_, _) =>
-        {
-            StopPreviewPointerTracking();
             ArmPreviewInteractiveCaptureLease();
-        };
         content.PreviewMouseMove += (_, e) =>
         {
             if (!content.IsMouseCaptured)

--- a/PaperWindow.EdgeCapsule.cs
+++ b/PaperWindow.EdgeCapsule.cs
@@ -312,6 +312,9 @@ public sealed partial class PaperWindow
     private void InvalidateEdgeCapsulePointerFromHostInput()
     {
         _controller.InvalidateEdgeCapsulePreviewPointerResolution();
+        _controller.NotifyEdgeCapsulePreviewPhysicalPointer(
+            this,
+            CaptureEdgeCapsulePointerPosition());
         var dispatcher = _edgeCapsuleHost?.Dispatcher ?? Dispatcher;
         _edgeCapsule.InvalidateBeforeNextRender(
             EdgeCapsuleDirty.Pointer,
@@ -404,7 +407,7 @@ public sealed partial class PaperWindow
         {
             _controller.NotifyEdgeCapsulePointerOverChanged(this, pointerOver);
         }
-        _controller.NotifyEdgeCapsulePreviewPointerSample(this, pointer);
+        _controller.NotifyEdgeCapsulePreviewPhysicalPointer(this, pointer);
     }
 
     internal void PublishEdgeCapsuleVisualTransactionNotifications() =>

--- a/PaperWindow.EdgeCapsule.cs
+++ b/PaperWindow.EdgeCapsule.cs
@@ -92,6 +92,14 @@ public sealed partial class PaperWindow
         IntPtr lParam,
         ref bool handled)
     {
+        // WM_MOUSELEAVE / WM_NCMOUSELEAVE are the authoritative boundary signal for the real host.
+        // WPF can raise MouseLeave while the physical point is still inside the applied rectangle;
+        // consume the native leave as well so that a later genuine exit cannot be lost.
+        if (msg is 0x02A3 or 0x02A2)
+        {
+            InvalidateEdgeCapsulePointerFromHostInput();
+        }
+
         // The slot host is not a paper window. In particular it must not inherit the paper's
         // snap/maximize WM_GETMINMAXINFO handling or minimum tracking size. It only participates
         // in display-metric refresh and then lets WPF process the native message normally.


### PR DESCRIPTION
## 现象
最新 `edge-preview-trace(6).log` 证明 #67 的三个目标都没有真正收口：

1. 目标 HWND 已经真实命中、`hitTest=True`、资格正常，甚至 `hwndUnder/rootUnder` 都是目标 HWND，但 Presenter 的 `PointerOverSurface` 仍可长期为 false，导致没有 activation intent。
2. 预测开启时大量关闭直接走 `OutsideCorridor`，预测器根本没有参与；上一版只调方向确认毫秒数，因此没有触及实际失败链。
3. 预测关闭时，日志可见真实离开后约 3 秒才发现已经在外面：透明空白区没有持续输入，旧检查只在截止点才重新读鼠标。

## 本次修复
- 新增物理指针权威入口：Host/WPF 输入只要能给出当前物理坐标，就直接交给浏览控制器；首次打开不再依赖 Presenter 的 `PointerOverSurface` 恢复。
- 已有 owner 时仍严格保留 50 ms + 2 DIP 的切换门槛，预测器仍是负向保护，不能抢开目标。
- 预测关闭：静态 `rect-union + 窄连接桥` 走廊内固定 3 秒；真正离开走廊立即关闭。
- 预测开启：离开当前卡后，不再因为静态走廊一瞬间为 false 就立即关闭；进入物理离开态后以 24 ms 读取轨迹，若投影仍会到达任一可浏览胶囊则保活，明显离开才走方向确认，停住则走当前 idle 延时。
- `WM_MOUSELEAVE / WM_NCMOUSELEAVE` 接入正式输入链，避免 WPF 提前误报一次 MouseLeave 后真正物理离开无人处理。
- 删除 #67 新增的 Host 级 WPF-Leave 24 ms 计时器，避免两套采样器竞争；现在只保留 Controller 的一套离开态计时器。
- 不修改走廊几何，不恢复进程级全局扫描，不改变 50 ms / 2 DIP，不再调整五档预测参数。

## 采样范围
新的 24 ms 检查不是常驻轮询：鼠标仍在当前展开卡、命中下一张、发生捕获/拖拽、owner 变化或预览关闭时都会停止；只在“当前卡外且没有命中目标”的短暂状态运行。

## 日志辅助
新增仅在状态切换时输出的：
- `physical hit recovery`
- `physical linger enter`
- `physical corridor exit`
- `physical linger close`
用于下一轮实机日志直接确认三条行为是否走到正确分支。