### PR TITLE
胶囊标题在迷你预览切换时 50ms 渐隐渐显

### DIFF
--- a/EdgeCapsuleHost.Preview.cs
+++ b/EdgeCapsuleHost.Preview.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Animation;
 using PaperTodo.Plugin;
 
 namespace PaperTodo;
@@ -16,9 +17,11 @@ internal sealed partial class EdgeCapsuleHost
     private int _previewContentStageGeneration;
     private bool _previewVisible;
     private bool _previewInteractiveCaptureLease;
+    private bool _compactLabelSuppressedForPreview;
     private long _previewInteractiveCaptureGraceUntil;
 
     private const int PreviewInteractiveCaptureGraceMilliseconds = 250;
+    private const int CompactLabelFadeMilliseconds = 50;
 
     public bool IsPreviewPointerCaptureActive
     {
@@ -343,6 +346,10 @@ internal sealed partial class EdgeCapsuleHost
             _previewContentLayer != null &&
             _previewContent != null;
         _previewVisible = retainPreview && hasContent;
+        if (_previewVisible)
+        {
+            SetCompactLabelSuppressedForPreview(true);
+        }
 
         if (_previewContentLayer != null)
         {
@@ -427,6 +434,40 @@ internal sealed partial class EdgeCapsuleHost
                 : Brushes.Transparent;
     }
 
+    private void SetCompactLabelSuppressedForPreview(bool suppressed)
+    {
+        if (_compactLabelSuppressedForPreview == suppressed)
+        {
+            return;
+        }
+
+        _compactLabelSuppressedForPreview = suppressed;
+        var targetOpacity = suppressed ? 0d : 1d;
+        var currentOpacity = Math.Clamp(Label.Opacity, 0, 1);
+
+        // Keep the final value as the base value, then animate from the currently rendered value.
+        // Reversing within 50 ms therefore continues smoothly instead of jumping back to an older
+        // animation endpoint.
+        Label.BeginAnimation(UIElement.OpacityProperty, null);
+        Label.Opacity = targetOpacity;
+        if (Math.Abs(currentOpacity - targetOpacity) <= 0.001)
+        {
+            return;
+        }
+
+        Label.BeginAnimation(
+            UIElement.OpacityProperty,
+            new DoubleAnimation
+            {
+                From = currentOpacity,
+                To = targetOpacity,
+                Duration = new Duration(
+                    TimeSpan.FromMilliseconds(CompactLabelFadeMilliseconds)),
+                FillBehavior = FillBehavior.Stop
+            },
+            HandoffBehavior.SnapshotAndReplace);
+    }
+
     private bool DetachPreviewContent()
     {
         int detachGeneration;
@@ -470,6 +511,7 @@ internal sealed partial class EdgeCapsuleHost
             }
             _previewViewportLayer.IsHitTestVisible = false;
         }
+        SetCompactLabelSuppressedForPreview(false);
         return IsPreviewContentStageCurrent(detachGeneration);
     }
 

--- a/EdgeCapsuleHost.Preview.cs
+++ b/EdgeCapsuleHost.Preview.cs
@@ -350,6 +350,13 @@ internal sealed partial class EdgeCapsuleHost
         {
             SetCompactLabelSuppressedForPreview(true);
         }
+        else if (!retainPreview)
+        {
+            // Restore only when the shell itself has reached the compact frame. Content cleanup can
+            // happen earlier during cancellation/replacement and must not make the title reappear
+            // on a still-expanded or still-shrinking surface.
+            SetCompactLabelSuppressedForPreview(false);
+        }
 
         if (_previewContentLayer != null)
         {
@@ -511,7 +518,6 @@ internal sealed partial class EdgeCapsuleHost
             }
             _previewViewportLayer.IsHitTestVisible = false;
         }
-        SetCompactLabelSuppressedForPreview(false);
         return IsPreviewContentStageCurrent(detachGeneration);
     }
 


### PR DESCRIPTION
## 改动
- 迷你预览开始扩展的第一帧，外层胶囊标题启动 50ms 渐隐。
- 展开稳定态与整个收回动画期间，标题保持隐藏，不再跟着尺寸变化移动。
- 几何真正回到普通胶囊最终帧后，标题再用 50ms 渐显恢复。
- 只处理标题本身；迷你内容、图标、现有预览交叉淡化和尺寸动画保持不变。

## 目的
避免外层胶囊名在迷你窗口扩展/收缩时跟着窗口移动，从而与迷你窗口内自己的标题短暂重叠，产生“双标题”的违和感。

## 边界
- 快速打开/反向切换时，从当前透明度继续过渡，避免跳变。
- 渐显以“已经回到普通胶囊几何”为准，而不是以预览内容是否被清理为准，避免异常取消/插件替换时标题提前出现在仍然扩大的窗口上。