### PR TITLE
收敛边缘预览追帧与无效原生提交

### DIFF
--- a/EdgeCapsuleFrameScheduler.cs
+++ b/EdgeCapsuleFrameScheduler.cs
@@ -13,6 +13,12 @@ namespace PaperTodo;
 internal sealed class EdgeCapsuleFrameScheduler
 {
     private static readonly ConditionalWeakTable<Dispatcher, EdgeCapsuleFrameScheduler> Schedulers = new();
+    // A real 240 Hz frame is about 4.17 ms apart. Rendering callbacks that arrive within 2 ms of
+    // the previous scheduler completion are therefore catch-up/burst work, not useful new display
+    // opportunities. Drop only those bursts; the next real callback samples transitions from the
+    // current Stopwatch time so no intermediate animation state is replayed.
+    private static readonly long MinimumPostFrameIdleTimestampTicks =
+        Math.Max(1, (long)Math.Ceiling(Stopwatch.Frequency * 0.002));
 
     private readonly Dispatcher _dispatcher;
     private readonly List<EdgeCapsulePresenter> _presenters = new();
@@ -22,10 +28,12 @@ internal sealed class EdgeCapsuleFrameScheduler
     private bool _acceptingPostCommitCallbacks;
     private int _pendingLoadedReconciles;
     private TimeSpan? _lastRenderingTime;
+    private long _lastFrameCompletedTimestamp;
 #if DEBUG
     private long _lastRenderingTimestamp;
     private long _debugFrameSequence;
     private int _suppressedDuplicateRenderingCallbacks;
+    private int _suppressedBurstRenderingCallbacks;
 #endif
 
     private EdgeCapsuleFrameScheduler(Dispatcher dispatcher)
@@ -114,8 +122,18 @@ internal sealed class EdgeCapsuleFrameScheduler
         }
         _lastRenderingTime = renderingTime;
 
+        var callbackStartedAt = Stopwatch.GetTimestamp();
+        if (_lastFrameCompletedTimestamp != 0 &&
+            callbackStartedAt - _lastFrameCompletedTimestamp <
+                MinimumPostFrameIdleTimestampTicks)
+        {
 #if DEBUG
-        var callbackStartedAt = EdgeCapsulePerformanceDiagnostics.Timestamp();
+            _suppressedBurstRenderingCallbacks++;
+#endif
+            return;
+        }
+
+#if DEBUG
         var frameSequence = ++_debugFrameSequence;
         var frameGapMilliseconds = _lastRenderingTimestamp == 0
             ? 0
@@ -126,7 +144,9 @@ internal sealed class EdgeCapsuleFrameScheduler
         var debugInitialCount = 0;
         var debugGroupCount = 0;
         var duplicateRenderingCallbacks = _suppressedDuplicateRenderingCallbacks;
+        var burstRenderingCallbacks = _suppressedBurstRenderingCallbacks;
         _suppressedDuplicateRenderingCallbacks = 0;
+        _suppressedBurstRenderingCallbacks = 0;
         var renderingTimeMilliseconds = renderingTime?.TotalMilliseconds ?? -1;
 #endif
         _isTicking = true;
@@ -173,12 +193,14 @@ internal sealed class EdgeCapsuleFrameScheduler
                 $"scheduler.frame sequence={frameSequence} " +
                 $"totalMs={EdgeCapsulePerformanceDiagnostics.ElapsedMilliseconds(callbackStartedAt):F3} " +
                 $"gapMs={frameGapMilliseconds:F3} renderMs={renderingTimeMilliseconds:F3} " +
-                $"duplicateCallbacks={duplicateRenderingCallbacks} presenters={debugInitialCount} " +
-                $"groups={debugGroupCount} loadedPending={_pendingLoadedReconciles}");
+                $"duplicateCallbacks={duplicateRenderingCallbacks} burstCallbacks={burstRenderingCallbacks} " +
+                $"presenters={debugInitialCount} groups={debugGroupCount} " +
+                $"loadedPending={_pendingLoadedReconciles}");
 #endif
             _acceptingPostCommitCallbacks = false;
             _postCommitCallbacks.Clear();
             _isTicking = false;
+            _lastFrameCompletedTimestamp = Stopwatch.GetTimestamp();
             StopWhenEmpty();
         }
     }
@@ -464,9 +486,11 @@ internal sealed class EdgeCapsuleFrameScheduler
             CompositionTarget.Rendering -= OnRendering;
             _renderingSubscribed = false;
             _lastRenderingTime = null;
+            _lastFrameCompletedTimestamp = 0;
 #if DEBUG
             _lastRenderingTimestamp = 0;
             _suppressedDuplicateRenderingCallbacks = 0;
+            _suppressedBurstRenderingCallbacks = 0;
 #endif
         }
     }

--- a/PaperWindow.Note.cs
+++ b/PaperWindow.Note.cs
@@ -339,38 +339,42 @@ public sealed partial class PaperWindow
                 return;
             }
 
-            TraceNoteRender($"ShowPreview before isPreviewing={isPreviewing} boxPreview={box.IsPreviewMode}");
+            var alreadyPreviewing = isPreviewing && box.IsPreviewMode;
+            TraceNoteRender($"ShowPreview before isPreviewing={isPreviewing} boxPreview={box.IsPreviewMode} already={alreadyPreviewing}");
             box.ClearImageSelection();
             box.SelectionLength = 0;
-            box.SetPreviewMode(true);
-            box.ContextMenu = _notePreviewContextMenu ??= BuildPaperContextMenu();
-            isPreviewing = true;
-            // Focus can be cleared by the caller before preview mode is entered. Defer the
-            // decision until WPF has finished the current focus transition, then park focus
-            // on the active window only when no child control has claimed it. This keeps the
-            // window-level ESC handler available without stealing focus from title editing.
-            var deferredWorkGeneration = _noteDeferredWorkGeneration;
-            Dispatcher.BeginInvoke(
-                (Action)(() =>
-                {
-                    if (!IsCurrentNoteDeferredWork(
-                            presenterGeneration,
-                            deferredWorkGeneration,
-                            box))
+            if (!alreadyPreviewing)
+            {
+                box.SetPreviewMode(true);
+                box.ContextMenu = _notePreviewContextMenu ??= BuildPaperContextMenu();
+                isPreviewing = true;
+                // Focus can be cleared by the caller before preview mode is entered. Defer the
+                // decision until WPF has finished the current focus transition, then park focus
+                // on the active window only when no child control has claimed it. This keeps the
+                // window-level ESC handler available without stealing focus from title editing.
+                var deferredWorkGeneration = _noteDeferredWorkGeneration;
+                Dispatcher.BeginInvoke(
+                    (Action)(() =>
                     {
-                        return;
-                    }
+                        if (!IsCurrentNoteDeferredWork(
+                                presenterGeneration,
+                                deferredWorkGeneration,
+                                box))
+                        {
+                            return;
+                        }
 
-                    if (isPreviewing &&
-                        IsActive &&
-                        !IsKeyboardFocusWithin &&
-                        !IsPaperContextMenuInteractionActive)
-                    {
-                        Focus();
-                    }
-                }),
-                System.Windows.Threading.DispatcherPriority.Input);
-            TraceNoteRender($"ShowPreview after isPreviewing={isPreviewing} boxPreview={box.IsPreviewMode}");
+                        if (isPreviewing &&
+                            IsActive &&
+                            !IsKeyboardFocusWithin &&
+                            !IsPaperContextMenuInteractionActive)
+                        {
+                            Focus();
+                        }
+                    }),
+                    System.Windows.Threading.DispatcherPriority.Input);
+            }
+            TraceNoteRender($"ShowPreview after isPreviewing={isPreviewing} boxPreview={box.IsPreviewMode} already={alreadyPreviewing}");
         }
 
         _showNotePreview = ShowPreview;

--- a/WindowNative.cs
+++ b/WindowNative.cs
@@ -453,18 +453,37 @@ internal static class WindowNative
             }
         }
 
+        if (handle == IntPtr.Zero)
+        {
+            return false;
+        }
+
 #if DEBUG
-        var positionChanged = false;
-        var sizeChanged = false;
-        if (handle != IntPtr.Zero && GetWindowRect(handle, out var before))
+        var immediateStartedAt = EdgeCapsulePerformanceDiagnostics.Timestamp();
+#endif
+        var positionChanged = true;
+        var sizeChanged = true;
+        if (GetWindowRect(handle, out var before))
         {
             positionChanged = before.Left != bounds.Left || before.Top != bounds.Top;
             sizeChanged = before.Right - before.Left != bounds.Width ||
                 before.Bottom - before.Top != bounds.Height;
-        }
-        var immediateStartedAt = EdgeCapsulePerformanceDiagnostics.Timestamp();
+            if (!positionChanged && !sizeChanged)
+            {
+#if DEBUG
+                EdgeCapsulePerformanceDiagnostics.Trace(
+                    $"native.window phase=immediate-skip hwnd=0x{handle.ToInt64():X} " +
+                    $"outcome=noop " +
+                    $"callMs={EdgeCapsulePerformanceDiagnostics.ElapsedMilliseconds(immediateStartedAt):F3} " +
+                    $"positionChanged=false sizeChanged=false " +
+                    $"visibilityChanged=false zOrderChanged=false " +
+                    $"bounds={bounds.Left},{bounds.Top},{bounds.Width}x{bounds.Height}");
 #endif
-        var applied = handle != IntPtr.Zero && SetWindowPos(
+                return true;
+            }
+        }
+
+        var applied = SetWindowPos(
             handle,
             IntPtr.Zero,
             bounds.Left,
@@ -473,16 +492,13 @@ internal static class WindowNative
             bounds.Height,
             SwpNoZOrder | SwpNoActivate | SwpNoOwnerZOrder);
 #if DEBUG
-        if (handle != IntPtr.Zero)
-        {
-            EdgeCapsulePerformanceDiagnostics.Trace(
-                $"native.window phase=immediate-set hwnd=0x{handle.ToInt64():X} " +
-                $"outcome={(applied ? "success" : "failed")} " +
-                $"callMs={EdgeCapsulePerformanceDiagnostics.ElapsedMilliseconds(immediateStartedAt):F3} " +
-                $"positionChanged={positionChanged} sizeChanged={sizeChanged} " +
-                $"visibilityChanged=false zOrderChanged=false " +
-                $"bounds={bounds.Left},{bounds.Top},{bounds.Width}x{bounds.Height}");
-        }
+        EdgeCapsulePerformanceDiagnostics.Trace(
+            $"native.window phase=immediate-set hwnd=0x{handle.ToInt64():X} " +
+            $"outcome={(applied ? "success" : "failed")} " +
+            $"callMs={EdgeCapsulePerformanceDiagnostics.ElapsedMilliseconds(immediateStartedAt):F3} " +
+            $"positionChanged={positionChanged} sizeChanged={sizeChanged} " +
+            $"visibilityChanged=false zOrderChanged=false " +
+            $"bounds={bounds.Left},{bounds.Top},{bounds.Width}x{bounds.Height}");
 #endif
         return applied;
     }


### PR DESCRIPTION
## 改动

- 丢弃上一帧刚完成后 2ms 内出现的边缘胶囊追赶型 Rendering 回调；正常 240Hz 约 4.17ms 帧间隔不受限制，并新增 `burstCallbacks` 性能日志。
- `TrySetWindowDeviceBounds` 在非批量路径下先核对真实 HWND 矩形；位置和尺寸完全不变时跳过 `SetWindowPos`，日志记为 `phase=immediate-skip`。
- Markdown 已经处于预览态时，不再重复执行 `SetPreviewMode(true)`、上下文菜单重绑和重复排队焦点回调；仍保留清除图片/文本选择的行为。

## 边界

- 不改变鼠标预测、浏览判定、关闭判定或动画曲线。
- 不做 `DeferWindowPos / EndDeferWindowPos` 与直接 `SetWindowPos` 的 A/B；这项留到低风险优化验证完成后再单独实验。

## 背景

新性能日志已把主要原生卡点定位到 `EndDeferWindowPos`，同时还暴露了阻塞后的短间隔追帧、无变化 immediate SetWindowPos 以及少量重复 Markdown 预览切换。本 PR 先收敛这些低风险项，保持后续 A/B 实验干净。