### PR TITLE
移除边缘预览误杀真实渲染帧的 2ms 过滤

### DIFF
--- a/EdgeCapsuleFrameScheduler.cs
+++ b/EdgeCapsuleFrameScheduler.cs
@@ -13,12 +13,6 @@ namespace PaperTodo;
 internal sealed class EdgeCapsuleFrameScheduler
 {
     private static readonly ConditionalWeakTable<Dispatcher, EdgeCapsuleFrameScheduler> Schedulers = new();
-    // A real 240 Hz frame is about 4.17 ms apart. Rendering callbacks that arrive within 2 ms of
-    // the previous scheduler completion are therefore catch-up/burst work, not useful new display
-    // opportunities. Drop only those bursts; the next real callback samples transitions from the
-    // current Stopwatch time so no intermediate animation state is replayed.
-    private static readonly long MinimumPostFrameIdleTimestampTicks =
-        Math.Max(1, (long)Math.Ceiling(Stopwatch.Frequency * 0.002));
 
     private readonly Dispatcher _dispatcher;
     private readonly List<EdgeCapsulePresenter> _presenters = new();
@@ -28,12 +22,10 @@ internal sealed class EdgeCapsuleFrameScheduler
     private bool _acceptingPostCommitCallbacks;
     private int _pendingLoadedReconciles;
     private TimeSpan? _lastRenderingTime;
-    private long _lastFrameCompletedTimestamp;
 #if DEBUG
     private long _lastRenderingTimestamp;
     private long _debugFrameSequence;
     private int _suppressedDuplicateRenderingCallbacks;
-    private int _suppressedBurstRenderingCallbacks;
 #endif
 
     private EdgeCapsuleFrameScheduler(Dispatcher dispatcher)
@@ -122,18 +114,8 @@ internal sealed class EdgeCapsuleFrameScheduler
         }
         _lastRenderingTime = renderingTime;
 
-        var callbackStartedAt = Stopwatch.GetTimestamp();
-        if (_lastFrameCompletedTimestamp != 0 &&
-            callbackStartedAt - _lastFrameCompletedTimestamp <
-                MinimumPostFrameIdleTimestampTicks)
-        {
 #if DEBUG
-            _suppressedBurstRenderingCallbacks++;
-#endif
-            return;
-        }
-
-#if DEBUG
+        var callbackStartedAt = EdgeCapsulePerformanceDiagnostics.Timestamp();
         var frameSequence = ++_debugFrameSequence;
         var frameGapMilliseconds = _lastRenderingTimestamp == 0
             ? 0
@@ -144,9 +126,7 @@ internal sealed class EdgeCapsuleFrameScheduler
         var debugInitialCount = 0;
         var debugGroupCount = 0;
         var duplicateRenderingCallbacks = _suppressedDuplicateRenderingCallbacks;
-        var burstRenderingCallbacks = _suppressedBurstRenderingCallbacks;
         _suppressedDuplicateRenderingCallbacks = 0;
-        _suppressedBurstRenderingCallbacks = 0;
         var renderingTimeMilliseconds = renderingTime?.TotalMilliseconds ?? -1;
 #endif
         _isTicking = true;
@@ -193,14 +173,12 @@ internal sealed class EdgeCapsuleFrameScheduler
                 $"scheduler.frame sequence={frameSequence} " +
                 $"totalMs={EdgeCapsulePerformanceDiagnostics.ElapsedMilliseconds(callbackStartedAt):F3} " +
                 $"gapMs={frameGapMilliseconds:F3} renderMs={renderingTimeMilliseconds:F3} " +
-                $"duplicateCallbacks={duplicateRenderingCallbacks} burstCallbacks={burstRenderingCallbacks} " +
-                $"presenters={debugInitialCount} groups={debugGroupCount} " +
-                $"loadedPending={_pendingLoadedReconciles}");
+                $"duplicateCallbacks={duplicateRenderingCallbacks} presenters={debugInitialCount} " +
+                $"groups={debugGroupCount} loadedPending={_pendingLoadedReconciles}");
 #endif
             _acceptingPostCommitCallbacks = false;
             _postCommitCallbacks.Clear();
             _isTicking = false;
-            _lastFrameCompletedTimestamp = Stopwatch.GetTimestamp();
             StopWhenEmpty();
         }
     }
@@ -486,11 +464,9 @@ internal sealed class EdgeCapsuleFrameScheduler
             CompositionTarget.Rendering -= OnRendering;
             _renderingSubscribed = false;
             _lastRenderingTime = null;
-            _lastFrameCompletedTimestamp = 0;
 #if DEBUG
             _lastRenderingTimestamp = 0;
             _suppressedDuplicateRenderingCallbacks = 0;
-            _suppressedBurstRenderingCallbacks = 0;
 #endif
         }
     }


### PR DESCRIPTION
## 改动

- 移除“上一帧完成后 2ms 内的 Rendering 回调直接丢弃”的追帧过滤。
- 保留按 `RenderingTime` 去重同一渲染时刻重复回调的逻辑。
- 不改 `immediate-skip`、Markdown 预览去重、鼠标预测、浏览判定、动画曲线或原生批量提交路径。

## 原因

新性能日志显示该 2ms 规则会在 WPF 实际约 8.33ms 的 Rendering 节奏下误杀真实下一帧：有 burst 的执行帧常出现约 25ms 的 `RenderingTime` 跳变，等于在原生提交已经导致掉帧后又主动再丢一帧。

本 PR 只撤掉这个有风险的启发式，为后续纯位置 `EndDeferWindowPos` / `SetWindowPos` A/B 保持干净基线。