### PR TITLE
修复 1.8 插件浏览内容与胶囊标题动画

### DIFF
--- a/EdgeCapsuleHost.Preview.cs
+++ b/EdgeCapsuleHost.Preview.cs
@@ -18,12 +18,9 @@ internal sealed partial class EdgeCapsuleHost
     private bool _previewVisible;
     private bool _previewInteractiveCaptureLease;
     private bool _compactLabelSuppressedForPreview;
-    private bool _compactLabelRestoreScheduledForPreviewClose;
     private readonly TranslateTransform _compactContentAnchorTransform = new();
     private double _compactContentAnchorWidthDip = double.NaN;
     private double _compactContentAnchorCloseWidthDip = double.NaN;
-    private double _lastPreviewProgress;
-    private double _lastPreviewCloseWidthDip;
     private long _previewInteractiveCaptureGraceUntil;
 
     private const int PreviewInteractiveCaptureGraceMilliseconds = 250;
@@ -348,9 +345,15 @@ internal sealed partial class EdgeCapsuleHost
             1);
 
         var previousPreviewVisible = _previewVisible;
-        var previousPreviewProgress = _lastPreviewProgress;
-        var previousCloseWidth = _lastPreviewCloseWidthDip;
+        var previousPreviewProgress = _previewViewportLayer?.Opacity ?? 0;
         var currentCloseWidth = _appliedCloseWidth;
+        var previousCloseWidth = _appliedFrame.Visible
+            ? EdgeCapsuleGeometry.CloseWidthForAppliedDeviceWidth(
+                _appliedFrame.Bounds.Width,
+                _appliedFrame.BodyWindowWidthDevice,
+                _appliedFrame.DpiScaleX,
+                _appliedFrame.MaximumCloseWidthDip)
+            : currentCloseWidth;
         var hasContent =
             _previewViewportLayer != null &&
             _previewContentLayer != null &&
@@ -373,6 +376,7 @@ internal sealed partial class EdgeCapsuleHost
         if (_previewVisible)
         {
             if (closingPreview &&
+                _compactLabelSuppressedForPreview &&
                 TryRetargetCompactContentAnchorForPreviewClose(
                     previousPreviewProgress,
                     previewProgress,
@@ -388,17 +392,9 @@ internal sealed partial class EdgeCapsuleHost
         else if (!retainPreview)
         {
             RestoreCompactContentAnchor();
-            if (_compactLabelRestoreScheduledForPreviewClose)
-            {
-                // The close animation already owns the final 35 ms fade. Do not replace that
-                // compositor animation on the final compact frame.
-                _compactLabelRestoreScheduledForPreviewClose = false;
-                _compactLabelSuppressedForPreview = false;
-            }
-            else
-            {
-                SetCompactLabelSuppressedForPreview(false);
-            }
+            // If the last-35-ms fade is already running, its logical state is unsuppressed and this
+            // is a no-op; the final compact frame therefore cannot restart or truncate that fade.
+            SetCompactLabelSuppressedForPreview(false);
         }
 
         if (_previewContentLayer != null)
@@ -427,9 +423,6 @@ internal sealed partial class EdgeCapsuleHost
         {
             return false;
         }
-
-        _lastPreviewProgress = _previewVisible ? previewProgress : 0;
-        _lastPreviewCloseWidthDip = _previewVisible ? currentCloseWidth : 0;
 
         if (!retainPreview && hasContent)
         {
@@ -479,10 +472,9 @@ internal sealed partial class EdgeCapsuleHost
         double previousCloseWidth,
         double currentCloseWidth)
     {
-        if (_compactLabelRestoreScheduledForPreviewClose ||
-            previousPreviewProgress <= 0.0001)
+        if (previousPreviewProgress <= 0.0001)
         {
-            return _compactLabelRestoreScheduledForPreviewClose;
+            return false;
         }
 
         // Every interpolated field uses the same eased transition progress. On a close, preview
@@ -602,13 +594,11 @@ internal sealed partial class EdgeCapsuleHost
 
     private void SetCompactLabelSuppressedForPreview(bool suppressed)
     {
-        if (_compactLabelSuppressedForPreview == suppressed &&
-            !_compactLabelRestoreScheduledForPreviewClose)
+        if (_compactLabelSuppressedForPreview == suppressed)
         {
             return;
         }
 
-        _compactLabelRestoreScheduledForPreviewClose = false;
         _compactLabelSuppressedForPreview = suppressed;
         var targetOpacity = suppressed ? 0d : 1d;
         var currentOpacity = Math.Clamp(Label.Opacity, 0, 1);
@@ -639,8 +629,7 @@ internal sealed partial class EdgeCapsuleHost
         double previousPreviewProgress,
         double previewProgress)
     {
-        if (_compactLabelRestoreScheduledForPreviewClose ||
-            !_compactLabelSuppressedForPreview ||
+        if (!_compactLabelSuppressedForPreview ||
             previousPreviewProgress <= 0.0001)
         {
             return;
@@ -660,7 +649,6 @@ internal sealed partial class EdgeCapsuleHost
             0,
             remainingMilliseconds - CompactLabelFadeMilliseconds);
 
-        _compactLabelRestoreScheduledForPreviewClose = true;
         _compactLabelSuppressedForPreview = false;
         Label.BeginAnimation(UIElement.OpacityProperty, null);
         Label.Opacity = 1;
@@ -715,8 +703,6 @@ internal sealed partial class EdgeCapsuleHost
         }
         _previewContent = null;
         _previewVisible = false;
-        _lastPreviewProgress = 0;
-        _lastPreviewCloseWidthDip = 0;
         _previewInteractiveCaptureLease = false;
         _previewInteractiveCaptureGraceUntil = 0;
         RestoreCompactContentAnchor();

--- a/EdgeCapsuleHost.Preview.cs
+++ b/EdgeCapsuleHost.Preview.cs
@@ -19,8 +19,11 @@ internal sealed partial class EdgeCapsuleHost
     private bool _previewInteractiveCaptureLease;
     private bool _compactLabelSuppressedForPreview;
     private bool _compactLabelRestoreScheduledForPreviewClose;
+    private readonly TranslateTransform _compactContentAnchorTransform = new();
     private double _compactContentAnchorWidthDip = double.NaN;
+    private double _compactContentAnchorCloseWidthDip = double.NaN;
     private double _lastPreviewProgress;
+    private double _lastPreviewCloseWidthDip;
     private long _previewInteractiveCaptureGraceUntil;
 
     private const int PreviewInteractiveCaptureGraceMilliseconds = 250;
@@ -346,6 +349,8 @@ internal sealed partial class EdgeCapsuleHost
 
         var previousPreviewVisible = _previewVisible;
         var previousPreviewProgress = _lastPreviewProgress;
+        var previousCloseWidth = _lastPreviewCloseWidthDip;
+        var currentCloseWidth = _appliedCloseWidth;
         var hasContent =
             _previewViewportLayer != null &&
             _previewContentLayer != null &&
@@ -367,13 +372,18 @@ internal sealed partial class EdgeCapsuleHost
 
         if (_previewVisible)
         {
-            ApplyCompactContentAnchor(frame);
-            if (closingPreview)
+            if (closingPreview &&
+                TryRetargetCompactContentAnchorForPreviewClose(
+                    previousPreviewProgress,
+                    previewProgress,
+                    previousCloseWidth,
+                    currentCloseWidth))
             {
                 ScheduleCompactLabelRestoreForPreviewClose(
                     previousPreviewProgress,
                     previewProgress);
             }
+            ApplyCompactContentAnchor(frame);
         }
         else if (!retainPreview)
         {
@@ -419,6 +429,7 @@ internal sealed partial class EdgeCapsuleHost
         }
 
         _lastPreviewProgress = _previewVisible ? previewProgress : 0;
+        _lastPreviewCloseWidthDip = _previewVisible ? currentCloseWidth : 0;
 
         if (!retainPreview && hasContent)
         {
@@ -435,6 +446,10 @@ internal sealed partial class EdgeCapsuleHost
 
     private void CaptureCompactContentAnchor(EdgeCapsulePresentationFrame frame)
     {
+        if (!double.IsFinite(_compactContentAnchorCloseWidthDip))
+        {
+            _compactContentAnchorCloseWidthDip = _appliedCloseWidth;
+        }
         if (double.IsFinite(_compactContentAnchorWidthDip) &&
             _compactContentAnchorWidthDip > 0)
         {
@@ -458,10 +473,52 @@ internal sealed partial class EdgeCapsuleHost
                 ContentGrid.Margin.Left - ContentGrid.Margin.Right);
     }
 
+    private bool TryRetargetCompactContentAnchorForPreviewClose(
+        double previousPreviewProgress,
+        double previewProgress,
+        double previousCloseWidth,
+        double currentCloseWidth)
+    {
+        if (_compactLabelRestoreScheduledForPreviewClose ||
+            previousPreviewProgress <= 0.0001)
+        {
+            return _compactLabelRestoreScheduledForPreviewClose;
+        }
+
+        // Every interpolated field uses the same eased transition progress. On a close, preview
+        // height remaining and close-width distance to the target therefore share the same ratio.
+        // Solve the target close width from the first two closing samples, then move the invisible
+        // compact title to that final screen position before its last-35-ms fade begins.
+        var remainingRatio = Math.Clamp(
+            previewProgress / previousPreviewProgress,
+            0,
+            1);
+        var denominator = 1 - remainingRatio;
+        if (denominator <= 0.0001)
+        {
+            return false;
+        }
+
+        var targetCloseWidth =
+            (currentCloseWidth - previousCloseWidth * remainingRatio) /
+            denominator;
+        if (!double.IsFinite(targetCloseWidth))
+        {
+            return false;
+        }
+
+        _compactContentAnchorCloseWidthDip = Math.Clamp(
+            targetCloseWidth,
+            0,
+            Math.Max(0, _maximumCloseWidth));
+        return true;
+    }
+
     private void ApplyCompactContentAnchor(EdgeCapsulePresentationFrame frame)
     {
         if (!double.IsFinite(_compactContentAnchorWidthDip) ||
-            _compactContentAnchorWidthDip <= 0)
+            _compactContentAnchorWidthDip <= 0 ||
+            !double.IsFinite(_compactContentAnchorCloseWidthDip))
         {
             CaptureCompactContentAnchor(frame);
         }
@@ -472,11 +529,28 @@ internal sealed partial class EdgeCapsuleHost
             ? HorizontalAlignment.Left
             : HorizontalAlignment.Right;
         ContentGrid.VerticalAlignment = VerticalAlignment.Top;
+
+        var closeWidthDelta = _appliedCloseWidth - _compactContentAnchorCloseWidthDip;
+        _compactContentAnchorTransform.X = frame.Edge == EdgeCapsuleEdge.Left
+            ? -closeWidthDelta
+            : closeWidthDelta;
+        _compactContentAnchorTransform.Y = 0;
+        if (!ReferenceEquals(ContentGrid.RenderTransform, _compactContentAnchorTransform))
+        {
+            ContentGrid.RenderTransform = _compactContentAnchorTransform;
+        }
     }
 
     private void RestoreCompactContentAnchor()
     {
         _compactContentAnchorWidthDip = double.NaN;
+        _compactContentAnchorCloseWidthDip = double.NaN;
+        _compactContentAnchorTransform.X = 0;
+        _compactContentAnchorTransform.Y = 0;
+        if (ReferenceEquals(ContentGrid.RenderTransform, _compactContentAnchorTransform))
+        {
+            ContentGrid.RenderTransform = null;
+        }
         ContentGrid.Width = double.NaN;
         ContentGrid.Height = double.NaN;
         ContentGrid.HorizontalAlignment = HorizontalAlignment.Stretch;
@@ -642,6 +716,7 @@ internal sealed partial class EdgeCapsuleHost
         _previewContent = null;
         _previewVisible = false;
         _lastPreviewProgress = 0;
+        _lastPreviewCloseWidthDip = 0;
         _previewInteractiveCaptureLease = false;
         _previewInteractiveCaptureGraceUntil = 0;
         RestoreCompactContentAnchor();

--- a/EdgeCapsuleHost.Preview.cs
+++ b/EdgeCapsuleHost.Preview.cs
@@ -18,10 +18,13 @@ internal sealed partial class EdgeCapsuleHost
     private bool _previewVisible;
     private bool _previewInteractiveCaptureLease;
     private bool _compactLabelSuppressedForPreview;
+    private bool _compactLabelRestoreScheduledForPreviewClose;
+    private double _compactContentAnchorWidthDip = double.NaN;
+    private double _lastPreviewProgress;
     private long _previewInteractiveCaptureGraceUntil;
 
     private const int PreviewInteractiveCaptureGraceMilliseconds = 250;
-    private const int CompactLabelFadeMilliseconds = 50;
+    private const int CompactLabelFadeMilliseconds = 35;
 
     public bool IsPreviewPointerCaptureActive
     {
@@ -341,21 +344,51 @@ internal sealed partial class EdgeCapsuleHost
             0,
             1);
 
+        var previousPreviewVisible = _previewVisible;
+        var previousPreviewProgress = _lastPreviewProgress;
         var hasContent =
             _previewViewportLayer != null &&
             _previewContentLayer != null &&
             _previewContent != null;
         _previewVisible = retainPreview && hasContent;
+
+        var openingPreview = _previewVisible &&
+            (!previousPreviewVisible ||
+             previewProgress > previousPreviewProgress + 0.0001);
+        var closingPreview = _previewVisible &&
+            previousPreviewVisible &&
+            previewProgress + 0.0001 < previousPreviewProgress;
+
+        if (openingPreview)
+        {
+            CaptureCompactContentAnchor(frame);
+            SetCompactLabelSuppressedForPreview(true);
+        }
+
         if (_previewVisible)
         {
-            SetCompactLabelSuppressedForPreview(true);
+            ApplyCompactContentAnchor(frame);
+            if (closingPreview)
+            {
+                ScheduleCompactLabelRestoreForPreviewClose(
+                    previousPreviewProgress,
+                    previewProgress);
+            }
         }
         else if (!retainPreview)
         {
-            // Restore only when the shell itself has reached the compact frame. Content cleanup can
-            // happen earlier during cancellation/replacement and must not make the title reappear
-            // on a still-expanded or still-shrinking surface.
-            SetCompactLabelSuppressedForPreview(false);
+            RestoreCompactContentAnchor();
+            if (_compactLabelRestoreScheduledForPreviewClose)
+            {
+                // The close animation already owns the final 35 ms fade. Do not replace that
+                // compositor animation on the final compact frame.
+                _compactLabelRestoreScheduledForPreviewClose = false;
+                _compactLabelSuppressedForPreview = false;
+            }
+            else
+            {
+                SetCompactLabelSuppressedForPreview(false);
+            }
         }
 
         if (_previewContentLayer != null)
@@ -375,16 +408,17 @@ internal sealed partial class EdgeCapsuleHost
             return false;
         }
 
-        // Keep one painted tree on both ends of the transition. At the opening compact frame the
-        // staged preview has not necessarily completed its first WPF layout/render pass yet; while
-        // closing, the compact tree must already be ready to replace it. Mirroring this short
-        // cross-fade prevents either visibility hand-off from becoming a blank frame.
+        // Compact content stays layout-resident so closing never pays a fresh layout cost. The
+        // label has its own fixed-position 35 ms opacity channel; only the icon/custom compact
+        // content continues to use the preview progress cross-fade.
         ApplyCompactContentProgress(
             _previewVisible ? previewProgress : 0);
         if (!IsPreviewContentStageCurrent(presentationContentGeneration))
         {
             return false;
         }
+
+        _lastPreviewProgress = _previewVisible ? previewProgress : 0;
 
         if (!retainPreview && hasContent)
         {
@@ -397,6 +431,56 @@ internal sealed partial class EdgeCapsuleHost
             }
         }
         return true;
+    }
+
+    private void CaptureCompactContentAnchor(EdgeCapsulePresentationFrame frame)
+    {
+        if (double.IsFinite(_compactContentAnchorWidthDip) &&
+            _compactContentAnchorWidthDip > 0)
+        {
+            return;
+        }
+
+        var actualWidth = ContentGrid.ActualWidth;
+        if (double.IsFinite(actualWidth) && actualWidth > 0.5)
+        {
+            _compactContentAnchorWidthDip = actualWidth;
+            return;
+        }
+
+        var source = _appliedFrame.Visible
+            ? _appliedFrame
+            : frame;
+        var sourceScaleX = Math.Max(1, source.DpiScaleX);
+        _compactContentAnchorWidthDip = Math.Max(
+            1,
+            source.BodyWindowWidthDevice / sourceScaleX -
+                ContentGrid.Margin.Left - ContentGrid.Margin.Right);
+    }
+
+    private void ApplyCompactContentAnchor(EdgeCapsulePresentationFrame frame)
+    {
+        if (!double.IsFinite(_compactContentAnchorWidthDip) ||
+            _compactContentAnchorWidthDip <= 0)
+        {
+            CaptureCompactContentAnchor(frame);
+        }
+
+        ContentGrid.Width = Math.Max(1, _compactContentAnchorWidthDip);
+        ContentGrid.Height = _options.BodyHeight;
+        ContentGrid.HorizontalAlignment = frame.Edge == EdgeCapsuleEdge.Left
+            ? HorizontalAlignment.Left
+            : HorizontalAlignment.Right;
+        ContentGrid.VerticalAlignment = VerticalAlignment.Top;
+    }
+
+    private void RestoreCompactContentAnchor()
+    {
+        _compactContentAnchorWidthDip = double.NaN;
+        ContentGrid.Width = double.NaN;
+        ContentGrid.Height = double.NaN;
+        ContentGrid.HorizontalAlignment = HorizontalAlignment.Stretch;
+        ContentGrid.VerticalAlignment = VerticalAlignment.Center;
     }
 
     private void ApplyPreviewLayerState(
@@ -420,11 +504,12 @@ internal sealed partial class EdgeCapsuleHost
         var progress = Math.Clamp(previewProgress, 0, 1);
         var compactOpacity = 1 - progress;
 
-        // Keep compact content in layout at opacity zero. It can then return on a closing or Snap
-        // frame without paying a Collapsed -> Visible layout gap; the preview layer remains above
-        // it and owns input as soon as the cross-fade starts.
+        // Keep compact content in layout. The label must not inherit preview-progress opacity or it
+        // would visually travel with the expanding/shrinking card; its independent animation below
+        // is the only opacity channel allowed to affect it.
         ContentGrid.Visibility = Visibility.Visible;
-        ContentGrid.Opacity = compactOpacity;
+        ContentGrid.Opacity = 1;
+        Icon.Opacity = compactOpacity;
         ContentGrid.IsHitTestVisible = progress <= 0.001;
         if (_pluginContentLayer != null)
         {
@@ -443,18 +528,19 @@ internal sealed partial class EdgeCapsuleHost
 
     private void SetCompactLabelSuppressedForPreview(bool suppressed)
     {
-        if (_compactLabelSuppressedForPreview == suppressed)
+        if (_compactLabelSuppressedForPreview == suppressed &&
+            !_compactLabelRestoreScheduledForPreviewClose)
         {
             return;
         }
 
+        _compactLabelRestoreScheduledForPreviewClose = false;
         _compactLabelSuppressedForPreview = suppressed;
         var targetOpacity = suppressed ? 0d : 1d;
         var currentOpacity = Math.Clamp(Label.Opacity, 0, 1);
 
-        // Keep the final value as the base value, then animate from the currently rendered value.
-        // Reversing within 50 ms therefore continues smoothly instead of jumping back to an older
-        // animation endpoint.
+        // The compact title never scales with the preview card. It remains on the compact anchor
+        // and only changes opacity over this short independent animation.
         Label.BeginAnimation(UIElement.OpacityProperty, null);
         Label.Opacity = targetOpacity;
         if (Math.Abs(currentOpacity - targetOpacity) <= 0.001)
@@ -472,6 +558,59 @@ internal sealed partial class EdgeCapsuleHost
                     TimeSpan.FromMilliseconds(CompactLabelFadeMilliseconds)),
                 FillBehavior = FillBehavior.Stop
             },
+            HandoffBehavior.SnapshotAndReplace);
+    }
+
+    private void ScheduleCompactLabelRestoreForPreviewClose(
+        double previousPreviewProgress,
+        double previewProgress)
+    {
+        if (_compactLabelRestoreScheduledForPreviewClose ||
+            !_compactLabelSuppressedForPreview ||
+            previousPreviewProgress <= 0.0001)
+        {
+            return;
+        }
+
+        // Preview geometry uses EaseOutCubic. During a close, normalized height remaining is
+        // remainingTime^3, so cube-rooting the first observed progress ratio recovers the remaining
+        // fraction of the 200 ms preview transition without introducing a second timing source.
+        var remainingFraction = Math.Cbrt(Math.Clamp(
+            previewProgress / previousPreviewProgress,
+            0,
+            1));
+        var remainingMilliseconds = Math.Max(
+            1,
+            EdgeCapsuleLayout.SlotMoveMilliseconds * remainingFraction);
+        var fadeStartMilliseconds = Math.Max(
+            0,
+            remainingMilliseconds - CompactLabelFadeMilliseconds);
+
+        _compactLabelRestoreScheduledForPreviewClose = true;
+        _compactLabelSuppressedForPreview = false;
+        Label.BeginAnimation(UIElement.OpacityProperty, null);
+        Label.Opacity = 1;
+
+        var animation = new DoubleAnimationUsingKeyFrames
+        {
+            Duration = new Duration(
+                TimeSpan.FromMilliseconds(remainingMilliseconds)),
+            FillBehavior = FillBehavior.Stop
+        };
+        animation.KeyFrames.Add(new DiscreteDoubleKeyFrame(
+            0,
+            KeyTime.FromTimeSpan(TimeSpan.Zero)));
+        animation.KeyFrames.Add(new DiscreteDoubleKeyFrame(
+            0,
+            KeyTime.FromTimeSpan(
+                TimeSpan.FromMilliseconds(fadeStartMilliseconds))));
+        animation.KeyFrames.Add(new LinearDoubleKeyFrame(
+            1,
+            KeyTime.FromTimeSpan(
+                TimeSpan.FromMilliseconds(remainingMilliseconds))));
+        Label.BeginAnimation(
+            UIElement.OpacityProperty,
+            animation,
             HandoffBehavior.SnapshotAndReplace);
     }
 
@@ -502,8 +641,10 @@ internal sealed partial class EdgeCapsuleHost
         }
         _previewContent = null;
         _previewVisible = false;
+        _lastPreviewProgress = 0;
         _previewInteractiveCaptureLease = false;
         _previewInteractiveCaptureGraceUntil = 0;
+        RestoreCompactContentAnchor();
         if (_previewViewportLayer != null)
         {
             _previewViewportLayer.Visibility = Visibility.Collapsed;

--- a/PaperWindow.PluginMiniView.cs
+++ b/PaperWindow.PluginMiniView.cs
@@ -66,16 +66,22 @@ public sealed partial class PaperWindow
                     size),
                 visible => NotifyNativePluginMiniViewVisibility(
                     nativeProvider,
-                    visible),
-                DeferContentCreation: true);
+                    visible));
         }
 
         if (_paperBodyHost.Current is WebPaperBodySession webSession &&
             webSession.HasMiniEntry)
         {
+            // A declared 1.8 mini surface is itself the preview content. Do not paint an enlarged
+            // 1.6/1.7 capsule while the WebView is becoming ready; that compatibility fallback is
+            // only the final preview for plugins that did not declare a 1.8 mini surface.
             return webSession.DescribeMiniView(
-                context,
-                BuildPluginCapsuleEdgePreviewContent);
+                    context,
+                    static (_, _) => new Grid { Background = Brushes.Transparent })
+                with
+                {
+                    DeferContentCreation = false
+                };
         }
 
         if (_bodyDescriptor?.Kind == PaperBodyPluginKind.Native &&
@@ -85,9 +91,17 @@ public sealed partial class PaperWindow
                 context,
                 out var migrationDescriptor))
         {
-            return migrationDescriptor;
+            // Migration is also an explicitly declared 1.8 preview capability. Stage its real
+            // preview wrapper in the opening transaction instead of showing the old capsule first
+            // and replacing it on a later background dispatcher turn.
+            return migrationDescriptor with
+            {
+                DeferContentCreation = false
+            };
         }
 
+        // No 1.8 preview capability: the enlarged 1.7/1.6/plain capsule is the final preview, not
+        // an intermediate loading view that will later be replaced.
         return DescribePluginCapsuleFallback(context);
     }
 


### PR DESCRIPTION
## 改动

- 协议 1.8 原生 mini 直接创建并进入浏览态，不再先显示 1.6/1.7 fallback 后延迟替换。
- Web 1.8 mini 直接挂载真实 Web mini 宿主；初始化期间只保留透明底，不再显示放大的旧胶囊。未声明 1.8 的插件仍以现有 1.7/1.6/plain fallback 作为最终浏览内容。
- WPF 正文迁移不再走外层 deferred fallback 替换。
- 胶囊原标题与浏览态尺寸动画解耦：进入浏览态时固定在原紧凑位置/尺寸做 35ms 渐隐；收回时保持隐藏，并在现有 200ms EaseOutCubic 回收动画最后 35ms 于紧凑锚点渐显。
- `Label` 不再继承 `previewProgress` 的父级透明度；图标和插件自定义紧凑内容仍沿用原有过渡。

## 原因

此前 1.8 插件会先画一棵放大的旧胶囊/fallback，再在首帧后以 Background 优先级创建真实内容；UI 线程被 HWND 动画提交占用时，真实内容常到动画结束后才替换。原标题同时位于随浏览卡扩展的 ContentGrid 中，并叠加 previewProgress 与独立淡出两套透明度，因此会跟随浏览卡移动/变化。

## 目标行为

- 有 1.8：普通胶囊直接过渡到真实 1.8 浏览内容，没有中间旧胶囊。
- 无 1.8：兼容 fallback 本身就是最终浏览内容。
- 标题展开只做 35ms 原地渐隐；收回只在最后 35ms、最终紧凑位置渐显。
