### PR TITLE
恢复浏览切换锚定并修复 Web 圆角

### DIFF
--- a/AppController.EdgeCapsulePreview.cs
+++ b/AppController.EdgeCapsulePreview.cs
@@ -141,10 +141,12 @@ public sealed partial class AppController
                 $"queue={session.QueueKey}->{currentQueueKey}");
             session = EdgeCapsulePreviewLayoutCoordinator.OpenOrTransfer(
                 basePlan,
+                null,
                 currentQueueKey,
                 session.OwnerPaperId,
                 session.Size,
-                PaperLayoutDefaults.CapsuleHeight);
+                PaperLayoutDefaults.CapsuleHeight,
+                DeepCapsuleGap);
             if (session == null)
             {
                 TraceEdgeCapsulePreview(
@@ -843,10 +845,12 @@ public sealed partial class AppController
         var queueKey = QueueKey(window.EdgeCapsulePreviewPaper);
         var next = EdgeCapsulePreviewLayoutCoordinator.OpenOrTransfer(
             basePlan,
+            previous,
             queueKey,
             window.EdgeCapsulePreviewPaperId,
             request.Size,
-            PaperLayoutDefaults.CapsuleHeight);
+            PaperLayoutDefaults.CapsuleHeight,
+            DeepCapsuleGap);
         if (next == null)
         {
             TraceEdgeCapsulePreview(
@@ -1182,6 +1186,11 @@ public sealed partial class AppController
                 QueueKey(target.EdgeCapsulePreviewPaper),
                 StringComparison.Ordinal);
     }
+
+    private static bool IsEdgeCapsulePreviewLayoutSuppressedFor(
+        EdgeCapsulePreviewPointerAnchor anchor,
+        string queueKey) =>
+        string.Equals(anchor.QueueKey, queueKey, StringComparison.Ordinal);
 
     private static bool IsEdgeCapsulePreviewLayoutSuppressionExpired(
         EdgeCapsulePreviewPointerAnchor anchor) =>

--- a/EdgeCapsuleHost.Preview.cs
+++ b/EdgeCapsuleHost.Preview.cs
@@ -281,6 +281,124 @@ internal sealed partial class EdgeCapsuleHost
         _previewViewportLayer = viewportLayer;
     }
 
+    private void ApplyPreviewViewportClip(
+        EdgeCapsulePresentationFrame frame,
+        double bodyHeight)
+    {
+        if (_previewViewportLayer == null)
+        {
+            return;
+        }
+
+        var dpiScaleX = Math.Max(1, frame.DpiScaleX);
+        var bodyWindowWidthDip = frame.BodyWindowWidthDevice / dpiScaleX;
+        var width = Math.Max(
+            1,
+            bodyWindowWidthDip - _options.WindowChromeMargin);
+        var height = Math.Max(1, bodyHeight);
+        var corners = ContentArea.CornerRadius;
+        var maximumRadius = Math.Min(width, height) / 2;
+        var topLeft = Math.Clamp(corners.TopLeft, 0, maximumRadius);
+        var topRight = Math.Clamp(corners.TopRight, 0, maximumRadius);
+        var bottomRight = Math.Clamp(corners.BottomRight, 0, maximumRadius);
+        var bottomLeft = Math.Clamp(corners.BottomLeft, 0, maximumRadius);
+
+        var clip = new StreamGeometry();
+        using (var geometry = clip.Open())
+        {
+            geometry.BeginFigure(
+                new Point(topLeft, 0),
+                isFilled: true,
+                isClosed: true);
+            geometry.LineTo(
+                new Point(width - topRight, 0),
+                isStroked: true,
+                isSmoothJoin: false);
+            if (topRight > 0)
+            {
+                geometry.ArcTo(
+                    new Point(width, topRight),
+                    new Size(topRight, topRight),
+                    0,
+                    isLargeArc: false,
+                    SweepDirection.Clockwise,
+                    isStroked: true,
+                    isSmoothJoin: false);
+            }
+            else
+            {
+                geometry.LineTo(
+                    new Point(width, 0),
+                    isStroked: true,
+                    isSmoothJoin: false);
+            }
+
+            geometry.LineTo(
+                new Point(width, height - bottomRight),
+                isStroked: true,
+                isSmoothJoin: false);
+            if (bottomRight > 0)
+            {
+                geometry.ArcTo(
+                    new Point(width - bottomRight, height),
+                    new Size(bottomRight, bottomRight),
+                    0,
+                    isLargeArc: false,
+                    SweepDirection.Clockwise,
+                    isStroked: true,
+                    isSmoothJoin: false);
+            }
+            else
+            {
+                geometry.LineTo(
+                    new Point(width, height),
+                    isStroked: true,
+                    isSmoothJoin: false);
+            }
+
+            geometry.LineTo(
+                new Point(bottomLeft, height),
+                isStroked: true,
+                isSmoothJoin: false);
+            if (bottomLeft > 0)
+            {
+                geometry.ArcTo(
+                    new Point(0, height - bottomLeft),
+                    new Size(bottomLeft, bottomLeft),
+                    0,
+                    isLargeArc: false,
+                    SweepDirection.Clockwise,
+                    isStroked: true,
+                    isSmoothJoin: false);
+            }
+            else
+            {
+                geometry.LineTo(
+                    new Point(0, height),
+                    isStroked: true,
+                    isSmoothJoin: false);
+            }
+
+            geometry.LineTo(
+                new Point(0, topLeft),
+                isStroked: true,
+                isSmoothJoin: false);
+            if (topLeft > 0)
+            {
+                geometry.ArcTo(
+                    new Point(topLeft, 0),
+                    new Size(topLeft, topLeft),
+                    0,
+                    isLargeArc: false,
+                    SweepDirection.Clockwise,
+                    isStroked: true,
+                    isSmoothJoin: false);
+            }
+        }
+        clip.Freeze();
+        _previewViewportLayer.Clip = clip;
+    }
+
     private bool ApplyPreviewPresentation(
         EdgeCapsulePresentationFrame frame)
     {
@@ -403,6 +521,7 @@ internal sealed partial class EdgeCapsuleHost
                 ? HorizontalAlignment.Left
                 : HorizontalAlignment.Right;
         }
+        ApplyPreviewViewportClip(frame, bodyHeight);
         ApplyPreviewLayerState(
             _previewVisible,
             _previewVisible ? previewProgress : 0,

--- a/EdgeCapsulePreview.cs
+++ b/EdgeCapsulePreview.cs
@@ -142,17 +142,19 @@ internal sealed record EdgeCapsulePreviewLayoutSession(
 
 /// <summary>
 /// Pure preview placement policy. The compact queue remains the base plan. During one browsing
-/// session only the owner has a non-standard height. Every endpoint is a tightly packed queue;
-/// shared transition progress then preserves the same gap between every adjacent pair in flight.
+/// session only the owner has a non-standard height; transfers reuse the old preview space and keep
+/// the newly hovered capsule anchored on the pointer side. Full compaction happens only on exit.
 /// </summary>
 internal static class EdgeCapsulePreviewLayoutCoordinator
 {
     public static EdgeCapsulePreviewLayoutSession? OpenOrTransfer(
         EdgeCapsuleQueuePlan basePlan,
+        EdgeCapsulePreviewLayoutSession? previous,
         string queueKey,
         string ownerPaperId,
         EdgeCapsulePreviewSize size,
-        double compactHeightDip)
+        double compactHeightDip,
+        double gapDip)
     {
         var queue = basePlan.Queues.FirstOrDefault(item =>
             string.Equals(item.Key, queueKey, StringComparison.Ordinal));
@@ -169,18 +171,103 @@ internal static class EdgeCapsulePreviewLayoutCoordinator
         }
 
         var compactHeight = Math.Max(1, compactHeightDip);
-        var paperIds = papers.Select(paper => paper.Id).ToArray();
-        var newHeight = Math.Max(compactHeight, size.HeightDip);
-        var expansion = newHeight - compactHeight;
+        var gap = Math.Max(0, gapDip);
+        var slotHeight = compactHeight + gap;
+        var baseTops = papers
+            .Select(paper =>
+                basePlan.Placements[paper.Id].VisualIndex * slotHeight)
+            .ToArray();
+        var currentTops = baseTops.ToArray();
 
-        // Accepted temporary 1.8 behavior: preview browsing preserves the queue-relative motion
-        // even when a tall card or its followers extend beyond the monitor work area. Do not clamp
-        // the card height or shrink the whole corridor here; that policy needs a separate design.
+        var paperIds = papers.Select(paper => paper.Id).ToArray();
+        var sameQueue = previous != null &&
+            string.Equals(previous.QueueKey, queueKey, StringComparison.Ordinal) &&
+            previous.QueuePaperIds.SequenceEqual(
+                paperIds,
+                StringComparer.Ordinal);
+        var oldIndex = -1;
+        if (sameQueue)
+        {
+            for (var index = 0; index < papers.Count; index++)
+            {
+                currentTops[index] += previous!.TopOffsetsDip
+                    .GetValueOrDefault(papers[index].Id);
+            }
+            oldIndex = IndexOf(papers, previous!.OwnerPaperId);
+        }
+
+        var newHeight = Math.Max(compactHeight, size.HeightDip);
+        var tops = currentTops.ToArray();
+
+        // Preview browsing deliberately keeps queue-relative motion even if a tall card or its
+        // followers extend beyond the monitor work area. Do not clamp the card height or shrink the
+        // whole corridor here; the important invariant is that a transfer does not move the target
+        // out from under a stationary pointer.
+        if (oldIndex < 0)
+        {
+            tops[newIndex] = baseTops[newIndex];
+            PushFollowingMembers(
+                tops,
+                currentTops,
+                newIndex,
+                newHeight,
+                compactHeight,
+                gap);
+        }
+        else if (newIndex > oldIndex)
+        {
+            // Moving downward: compact only the released upper side. Keep the lower anchor of the
+            // newly hovered capsule (and everything below it) where it already is, then grow the new
+            // preview upward into the space released by the old owner.
+            for (var index = 0; index < newIndex; index++)
+            {
+                tops[index] = baseTops[index];
+            }
+
+            var nextTop = newIndex + 1 < papers.Count
+                ? currentTops[newIndex + 1]
+                : currentTops[newIndex] + compactHeight + gap;
+            var proposedTop = nextTop - gap - newHeight;
+            var anchoredTop = Math.Min(
+                proposedTop,
+                currentTops[newIndex]);
+            var minimumTop = newIndex > 0
+                ? tops[newIndex - 1] + compactHeight + gap
+                : baseTops[newIndex];
+            tops[newIndex] = Math.Max(anchoredTop, minimumTop);
+            PushFollowingMembers(
+                tops,
+                currentTops,
+                newIndex,
+                newHeight,
+                compactHeight,
+                gap);
+        }
+        else if (newIndex < oldIndex)
+        {
+            // Moving upward: keep the target's upper anchor fixed and grow downward. Existing lower
+            // gaps are retained; followers move only if the expanded target would overlap them.
+            var minimumTop = newIndex > 0
+                ? tops[newIndex - 1] + compactHeight + gap
+                : baseTops[newIndex];
+            tops[newIndex] = Math.Max(currentTops[newIndex], minimumTop);
+            PushFollowingMembers(
+                tops,
+                currentTops,
+                newIndex,
+                newHeight,
+                compactHeight,
+                gap);
+        }
+        else
+        {
+            return previous! with { Size = size };
+        }
 
         var offsets = new Dictionary<string, double>(StringComparer.Ordinal);
         for (var index = 0; index < papers.Count; index++)
         {
-            offsets[papers[index].Id] = index > newIndex ? expansion : 0;
+            offsets[papers[index].Id] = tops[index] - baseTops[index];
         }
 
         return new EdgeCapsulePreviewLayoutSession(
@@ -213,6 +300,24 @@ internal static class EdgeCapsulePreviewLayoutCoordinator
         }
 
         return new EdgeCapsuleQueuePlan(basePlan.Queues, placements);
+    }
+
+    private static void PushFollowingMembers(
+        double[] tops,
+        double[] currentTops,
+        int ownerIndex,
+        double ownerHeight,
+        double compactHeight,
+        double gap)
+    {
+        for (var index = ownerIndex + 1; index < tops.Length; index++)
+        {
+            var previousHeight = index - 1 == ownerIndex
+                ? ownerHeight
+                : compactHeight;
+            var minimumTop = tops[index - 1] + previousHeight + gap;
+            tops[index] = Math.Max(currentTops[index], minimumTop);
+        }
     }
 
     private static int IndexOf(IReadOnlyList<PaperData> papers, string paperId)


### PR DESCRIPTION
## 改动

- 恢复边缘浏览最初的切换布局语义：同队列 A→B 切换会复用旧 owner 留下的预览空间，不再把新 owner 强制拉回紧凑基准槽位。
- 向下切换时只收紧目标上方已释放区域，新 owner 保持下锚点并向上扩展；向上切换时保持上锚点并向下扩展。下面的胶囊只有发生重叠时才继续移动，完整归位只发生在退出浏览态。
- 队列成员/队列键发生变化时不复用旧 offsets，仍从当前基准队列重新建立会话，避免把失效布局带进新队列。
- 给宿主 preview viewport 增加真实的圆角几何裁切，直接复用 ContentArea 当前左右边圆角语义。WebView2、WPF 1.8、Markdown/Todo 等预览内容统一受宿主裁切，不依赖插件 CSS。

## 修复问题

1. A-F 队列中，从任意浏览态移动到最后一个 F 后，F 不再因为自己向上归位而从静止鼠标下跑走并触发 OutsideTransferRectangle 关闭。
2. Web 1.8 浏览态不再把内容画满四个直角；靠屏幕侧保持直角，外露侧按胶囊宿主圆角裁切。

## 不变项

- 不修改现有 50ms/2 DIP 转移门槛、预测算法或硬边界关闭规则。
- 不重新引入 1.8 fallback/deferred 中间态。
- 不改上一轮 35ms 标题渐隐/渐显逻辑。