### PR TITLE
恢复向上浏览切换的尾部回填

### DIFF
--- a/EdgeCapsulePreview.cs
+++ b/EdgeCapsulePreview.cs
@@ -245,19 +245,22 @@ internal static class EdgeCapsulePreviewLayoutCoordinator
         }
         else if (newIndex < oldIndex)
         {
-            // Moving upward: keep the target's upper anchor fixed and grow downward. Existing lower
-            // gaps are retained; followers move only if the expanded target would overlap them.
-            var minimumTop = newIndex > 0
-                ? tops[newIndex - 1] + compactHeight + gap
-                : baseTops[newIndex];
-            tops[newIndex] = Math.Max(currentTops[newIndex], minimumTop);
-            PushFollowingMembers(
+            // Moving upward cannot invert any crossed member. Compact from the new owner downward
+            // so followers fill space released by a taller old card. The downward branch above
+            // intentionally remains anchored because compacting below a skipped target can make a
+            // follower appear to pass that target during the shared transition.
+            for (var index = 0; index <= newIndex; index++)
+            {
+                tops[index] = baseTops[index];
+            }
+            PlaceFollowingMembers(
                 tops,
                 currentTops,
                 newIndex,
                 newHeight,
                 compactHeight,
-                gap);
+                gap,
+                retainExistingGaps: false);
         }
         else
         {
@@ -308,7 +311,24 @@ internal static class EdgeCapsulePreviewLayoutCoordinator
         int ownerIndex,
         double ownerHeight,
         double compactHeight,
-        double gap)
+        double gap) =>
+        PlaceFollowingMembers(
+            tops,
+            currentTops,
+            ownerIndex,
+            ownerHeight,
+            compactHeight,
+            gap,
+            retainExistingGaps: true);
+
+    private static void PlaceFollowingMembers(
+        double[] tops,
+        double[] currentTops,
+        int ownerIndex,
+        double ownerHeight,
+        double compactHeight,
+        double gap,
+        bool retainExistingGaps)
     {
         for (var index = ownerIndex + 1; index < tops.Length; index++)
         {
@@ -316,7 +336,9 @@ internal static class EdgeCapsulePreviewLayoutCoordinator
                 ? ownerHeight
                 : compactHeight;
             var minimumTop = tops[index - 1] + previousHeight + gap;
-            tops[index] = Math.Max(currentTops[index], minimumTop);
+            tops[index] = retainExistingGaps
+                ? Math.Max(currentTops[index], minimumTop)
+                : minimumTop;
         }
     }
 

--- a/PaperTodo.csproj
+++ b/PaperTodo.csproj
@@ -55,6 +55,9 @@
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4078.44" />
     <PackageReference Include="ModelContextProtocol" Version="2.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="EdgeRefinementChecks" />
+  </ItemGroup>
   <!-- WinForms pulls System.Drawing into global usings; keep WPF type names unambiguous. -->
   <ItemGroup>
     <Using Remove="System.Drawing" />

--- a/scripts/edge-refinement-tests/EdgeRefinementChecks.csproj
+++ b/scripts/edge-refinement-tests/EdgeRefinementChecks.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="HoverIntentSensitivityTestShim.cs" />
+    <Compile Include="PreviewTransferLayoutRegression.cs" />
     <Compile Include="..\..\ScreenGeometry.cs" Link="ScreenGeometry.cs" />
     <Compile Include="..\..\EdgeCapsulePreviewCorridor.cs" Link="EdgeCapsulePreviewCorridor.cs" />
     <Compile Include="..\..\EdgeCapsulePreviewExitPolicy.cs" Link="EdgeCapsulePreviewExitPolicy.cs" />

--- a/scripts/edge-refinement-tests/PreviewTransferLayoutRegression.cs
+++ b/scripts/edge-refinement-tests/PreviewTransferLayoutRegression.cs
@@ -1,0 +1,88 @@
+extern alias PaperTodoApp;
+
+using System.Runtime.CompilerServices;
+
+namespace PaperTodo;
+
+internal static class PreviewTransferLayoutRegression
+{
+    [ModuleInitializer]
+    internal static void Run()
+    {
+        var papers = new[]
+        {
+            new PaperTodoApp::PaperTodo.PaperData { Id = "A" },
+            new PaperTodoApp::PaperTodo.PaperData { Id = "B" },
+            new PaperTodoApp::PaperTodo.PaperData { Id = "C" },
+            new PaperTodoApp::PaperTodo.PaperData { Id = "D" },
+            new PaperTodoApp::PaperTodo.PaperData { Id = "E" },
+            new PaperTodoApp::PaperTodo.PaperData { Id = "F" }
+        };
+
+        var queue = new PaperTodoApp::PaperTodo.EdgeCapsuleQueue(
+            "|right",
+            papers,
+            HasMaster: false);
+        var placements = new Dictionary<
+            string,
+            PaperTodoApp::PaperTodo.EdgeCapsulePlacement>(StringComparer.Ordinal);
+        for (var index = 0; index < papers.Length; index++)
+        {
+            placements[papers[index].Id] =
+                new PaperTodoApp::PaperTodo.EdgeCapsulePlacement(
+                    index,
+                    VisualOffset: 0,
+                    SlotCount: papers.Length);
+        }
+
+        var plan = new PaperTodoApp::PaperTodo.EdgeCapsuleQueuePlan(
+            new[] { queue },
+            placements);
+        const double compactHeight =
+            PaperTodoApp::PaperTodo.PaperLayoutDefaults.CapsuleHeight;
+        const double gap = 4;
+
+        var dSession =
+            PaperTodoApp::PaperTodo.EdgeCapsulePreviewLayoutCoordinator.OpenOrTransfer(
+                plan,
+                previous: null,
+                queueKey: "|right",
+                ownerPaperId: "D",
+                size: new PaperTodoApp::PaperTodo.EdgeCapsulePreviewSize(220, 190),
+                compactHeightDip: compactHeight,
+                gapDip: gap)
+            ?? throw new InvalidOperationException("D preview layout should open.");
+
+        var dTailOffset = dSession.TopOffsetsDip["E"];
+        if (dTailOffset <= 0 ||
+            Math.Abs(dSession.TopOffsetsDip["F"] - dTailOffset) > 0.001)
+        {
+            throw new InvalidOperationException(
+                "D preview should displace E/F together before the upward-transfer check.");
+        }
+
+        var cSession =
+            PaperTodoApp::PaperTodo.EdgeCapsulePreviewLayoutCoordinator.OpenOrTransfer(
+                plan,
+                previous: dSession,
+                queueKey: "|right",
+                ownerPaperId: "C",
+                size: new PaperTodoApp::PaperTodo.EdgeCapsulePreviewSize(220, 120),
+                compactHeightDip: compactHeight,
+                gapDip: gap)
+            ?? throw new InvalidOperationException("C preview layout should open.");
+
+        var compactedOffset = cSession.TopOffsetsDip["D"];
+        if (compactedOffset >= dTailOffset - 0.001)
+        {
+            throw new InvalidOperationException(
+                "D→C must reclaim space released by the old D preview.");
+        }
+        if (Math.Abs(cSession.TopOffsetsDip["E"] - compactedOffset) > 0.001 ||
+            Math.Abs(cSession.TopOffsetsDip["F"] - compactedOffset) > 0.001)
+        {
+            throw new InvalidOperationException(
+                "D→C must compact E/F with D instead of retaining the old D-preview gap.");
+        }
+    }
+}


### PR DESCRIPTION
## 根因

上一轮只恢复了“目标胶囊锚定、不从鼠标下跑走”，但向上切换仍沿用了更早的 `retainExistingGaps=true` 逻辑，导致旧 owner 收起后，后方胶囊仍保留旧预览留下的空隙。

回归前 `3895ce7` 的最终规则是：
- 向下切换：保留目标下锚点，避免目标从鼠标下移动。
- 向上切换：从新 owner 往下重新紧密排布，回收旧 owner 释放的空间。

## 修复

- 恢复回归前向上切换分支：`retainExistingGaps=false`。
- D→C 时，D 收起后，D/E/F 会按 C 的新预览高度一起重新紧密排布；E/F 不再卡在 D 展开时留下的旧偏移。
- 向下切换的锚定规则保持不变，因此上一轮修复的“切到最后一个 F 后 F 自己上移导致失焦”不会被重新引入。

## 回归检查

新增真实布局协调器检查：先让 D 以 190 DIP 展开，再切到 120 DIP 的 C；断言 D/E/F 必须一起回收到同一新偏移，且 E/F 的偏移必须小于 D 展开阶段的旧偏移。该检查直接调用 PaperTodo 的 `EdgeCapsulePreviewLayoutCoordinator`，不复制布局算法。
