### PR TITLE
修复浏览标题交接并绕开动画批量窗口卡顿

### DIFF
--- a/EdgeCapsuleFrameScheduler.cs
+++ b/EdgeCapsuleFrameScheduler.cs
@@ -218,6 +218,14 @@ internal sealed class EdgeCapsuleFrameScheduler
         _acceptingPostCommitCallbacks = true;
         var transactionGroupId =
             presenters[0].NativeBatchTransactionGroupId;
+        // A positive transaction id means several physical queues are still completing one
+        // controller-owned visual transaction and need the existing atomic HDWP commit. Ordinary
+        // animation frames have no transaction id: their native host capacity is already settled,
+        // so only X/Y changes remain. Sending those moves through EndDeferWindowPos repeatedly
+        // blocks the UI thread for 10-20+ ms on affected systems; let each HWND use the existing
+        // immediate SetWindowPos path instead. Dispatcher processing stays disabled for the whole
+        // group, so no input or app callback can observe an interleaved logical frame.
+        var useNativeBoundsBatch = transactionGroupId > 0;
 #if DEBUG
         var groupStartedAt = EdgeCapsulePerformanceDiagnostics.Timestamp();
         double reconcileMilliseconds = 0;
@@ -233,6 +241,7 @@ internal sealed class EdgeCapsuleFrameScheduler
         var boundsUnchanged = 0;
         var boundsMoveChanges = 0;
         var boundsSizeChanges = 0;
+        var nativeMode = useNativeBoundsBatch ? "batch" : "direct";
 #endif
         try
         {
@@ -243,10 +252,15 @@ internal sealed class EdgeCapsuleFrameScheduler
             bool frameDeferred;
             using (_dispatcher.DisableProcessing())
             {
-                using (var nativeBoundsBatch =
-                    WindowNative.BeginWindowDeviceBoundsBatch(
-                        presenters.Count))
+                WindowNative.WindowDeviceBoundsBatch? nativeBoundsBatch = null;
+                try
                 {
+                    if (useNativeBoundsBatch)
+                    {
+                        nativeBoundsBatch = WindowNative.BeginWindowDeviceBoundsBatch(
+                            presenters.Count);
+                    }
+
                     for (var index = presenters.Count - 1;
                          index >= 0;
                          index--)
@@ -306,17 +320,24 @@ internal sealed class EdgeCapsuleFrameScheduler
                     var nativeCommitStartedAt =
                         EdgeCapsulePerformanceDiagnostics.Timestamp();
 #endif
-                    nativeBatchCommitted = nativeBoundsBatch.Commit();
+                    nativeBatchCommitted = nativeBoundsBatch?.Commit() ?? true;
 #if DEBUG
                     nativeCommitMilliseconds +=
                         EdgeCapsulePerformanceDiagnostics.ElapsedMilliseconds(
                             nativeCommitStartedAt);
-                    boundsRequested = nativeBoundsBatch.RequestedWindowCount;
-                    boundsPending = nativeBoundsBatch.PendingWindowCount;
-                    boundsUnchanged = nativeBoundsBatch.UnchangedWindowCount;
-                    boundsMoveChanges = nativeBoundsBatch.MoveChangeCount;
-                    boundsSizeChanges = nativeBoundsBatch.SizeChangeCount;
+                    if (nativeBoundsBatch != null)
+                    {
+                        boundsRequested = nativeBoundsBatch.RequestedWindowCount;
+                        boundsPending = nativeBoundsBatch.PendingWindowCount;
+                        boundsUnchanged = nativeBoundsBatch.UnchangedWindowCount;
+                        boundsMoveChanges = nativeBoundsBatch.MoveChangeCount;
+                        boundsSizeChanges = nativeBoundsBatch.SizeChangeCount;
+                    }
 #endif
+                }
+                finally
+                {
+                    nativeBoundsBatch?.Dispose();
                 }
 
                 frameDeferred = nativeBatchCommitted &&
@@ -411,7 +432,8 @@ internal sealed class EdgeCapsuleFrameScheduler
                 $"postCommitMs={postCommitMilliseconds:F3} presenters={presenters.Count} " +
                 $"boundsRequested={boundsRequested} boundsPending={boundsPending} " +
                 $"boundsUnchanged={boundsUnchanged} moveChanges={boundsMoveChanges} " +
-                $"sizeChanges={boundsSizeChanges} slowest={slowestPresenter}:{slowestPresenterMilliseconds:F3} " +
+                $"sizeChanges={boundsSizeChanges} nativeMode={nativeMode} " +
+                $"slowest={slowestPresenter}:{slowestPresenterMilliseconds:F3} " +
                 $"transaction={transactionGroupId}");
 #endif
             _acceptingPostCommitCallbacks = false;

--- a/EdgeCapsuleHost.Preview.cs
+++ b/EdgeCapsuleHost.Preview.cs
@@ -16,6 +16,7 @@ internal sealed partial class EdgeCapsuleHost
     private FrameworkElement? _previewContent;
     private int _previewContentStageGeneration;
     private bool _previewVisible;
+    private double _previewGeometryProgress;
     private bool _previewInteractiveCaptureLease;
     private bool _compactLabelSuppressedForPreview;
     private readonly TranslateTransform _compactContentAnchorTransform = new();
@@ -214,7 +215,8 @@ internal sealed partial class EdgeCapsuleHost
         // is content lifecycle work, not a second presentation entry point, and therefore cannot
         // advance geometry from an uncommitted native batch.
         var wasVisible = _previewVisible;
-        var progress = _previewViewportLayer?.Opacity ?? 0;
+        var contentOpacity = _previewViewportLayer?.Opacity ?? 0;
+        var geometryProgress = _previewGeometryProgress;
         var wasHitTestVisible = _previewViewportLayer?.IsHitTestVisible == true;
         if (!StagePreviewContent(content, contentWidthDip, contentHeightDip))
         {
@@ -223,14 +225,14 @@ internal sealed partial class EdgeCapsuleHost
 
         var replacementGeneration = _previewContentStageGeneration;
         _previewVisible = wasVisible;
-        ApplyPreviewLayerState(wasVisible, progress, wasHitTestVisible);
+        ApplyPreviewLayerState(wasVisible, contentOpacity, wasHitTestVisible);
         if (_disposed ||
             replacementGeneration != _previewContentStageGeneration ||
             !OwnsPreviewContent(content))
         {
             return false;
         }
-        ApplyCompactContentProgress(wasVisible ? progress : 0);
+        ApplyCompactContentProgress(wasVisible ? geometryProgress : 0);
         return !_disposed &&
             replacementGeneration == _previewContentStageGeneration &&
             OwnsPreviewContent(content);
@@ -463,7 +465,7 @@ internal sealed partial class EdgeCapsuleHost
             1);
 
         var previousPreviewVisible = _previewVisible;
-        var previousPreviewProgress = _previewViewportLayer?.Opacity ?? 0;
+        var previousPreviewProgress = _previewGeometryProgress;
         var currentCloseWidth = _appliedCloseWidth;
         var previousCloseWidth = _appliedFrame.Visible
             ? EdgeCapsuleGeometry.CloseWidthForAppliedDeviceWidth(
@@ -487,7 +489,7 @@ internal sealed partial class EdgeCapsuleHost
 
         if (openingPreview)
         {
-            CaptureCompactContentAnchor(frame);
+            CaptureCompactContentAnchor(frame, previousCloseWidth);
             SetCompactLabelSuppressedForPreview(true);
         }
 
@@ -522,10 +524,22 @@ internal sealed partial class EdgeCapsuleHost
                 : HorizontalAlignment.Right;
         }
         ApplyPreviewViewportClip(frame, bodyHeight);
+
+        // The compact title and the preview's own title-like content must never cross-fade. A
+        // protocol fallback may literally be a uniformly enlarged mirror of the compact capsule,
+        // while built-in previews also render their own heading. Showing both during the same 35 ms
+        // makes two different fixed-size trees look like one label is being scaled. Keep the final
+        // preview tree fully laid out but transparent until the compact label has actually reached
+        // zero opacity. On close the preview stays visible while the compact label's delayed restore
+        // is still at zero, then disappears as soon as that final-position title starts fading in.
+        var previewContentOpacity = _previewVisible && Label.Opacity <= 0.001
+            ? 1d
+            : 0d;
         ApplyPreviewLayerState(
             _previewVisible,
-            _previewVisible ? previewProgress : 0,
+            previewContentOpacity,
             _previewVisible &&
+                previewContentOpacity > 0.001 &&
                 previewProgress > 0.001 &&
                 frame.IsHitTestVisible);
         if (!IsPreviewContentStageCurrent(presentationContentGeneration))
@@ -538,6 +552,7 @@ internal sealed partial class EdgeCapsuleHost
         // content continues to use the preview progress cross-fade.
         ApplyCompactContentProgress(
             _previewVisible ? previewProgress : 0);
+        _previewGeometryProgress = _previewVisible ? previewProgress : 0;
         if (!IsPreviewContentStageCurrent(presentationContentGeneration))
         {
             return false;
@@ -556,11 +571,14 @@ internal sealed partial class EdgeCapsuleHost
         return true;
     }
 
-    private void CaptureCompactContentAnchor(EdgeCapsulePresentationFrame frame)
+    private void CaptureCompactContentAnchor(
+        EdgeCapsulePresentationFrame frame,
+        double? closeWidthOverride = null)
     {
         if (!double.IsFinite(_compactContentAnchorCloseWidthDip))
         {
-            _compactContentAnchorCloseWidthDip = _appliedCloseWidth;
+            _compactContentAnchorCloseWidthDip =
+                closeWidthOverride ?? _appliedCloseWidth;
         }
         if (double.IsFinite(_compactContentAnchorWidthDip) &&
             _compactContentAnchorWidthDip > 0)
@@ -582,6 +600,7 @@ internal sealed partial class EdgeCapsuleHost
         _compactContentAnchorWidthDip = Math.Max(
             1,
             source.BodyWindowWidthDevice / sourceScaleX -
+                _options.WindowChromeMargin -
                 ContentGrid.Margin.Left - ContentGrid.Margin.Right);
     }
 
@@ -670,7 +689,7 @@ internal sealed partial class EdgeCapsuleHost
 
     private void ApplyPreviewLayerState(
         bool visible,
-        double progress,
+        double opacity,
         bool hitTestVisible)
     {
         if (_previewViewportLayer == null)
@@ -680,7 +699,7 @@ internal sealed partial class EdgeCapsuleHost
 
         _previewViewportLayer.Visibility =
             visible ? Visibility.Visible : Visibility.Collapsed;
-        _previewViewportLayer.Opacity = visible ? progress : 0;
+        _previewViewportLayer.Opacity = visible ? Math.Clamp(opacity, 0, 1) : 0;
         _previewViewportLayer.IsHitTestVisible = visible && hitTestVisible;
     }
 
@@ -822,6 +841,7 @@ internal sealed partial class EdgeCapsuleHost
         }
         _previewContent = null;
         _previewVisible = false;
+        _previewGeometryProgress = 0;
         _previewInteractiveCaptureLease = false;
         _previewInteractiveCaptureGraceUntil = 0;
         RestoreCompactContentAnchor();


### PR DESCRIPTION
## 问题

1. 原胶囊标题虽然已经有独立 35ms opacity 动画，但浏览内容本身也常包含一份标题/胶囊文字；非 1.8 fallback 甚至会用 `VisualBrush Stretch=Uniform` 放大原胶囊。两棵树同时交叉显隐时，视觉上仍像同一个标题随着浏览态被放大/缩小。
2. 最新性能日志显示正常动画阶段的 scheduler group 全部是 `transaction=0,sizeChanges=0`，但仍通过 `EndDeferWindowPos` 提交纯 X/Y 移动，单帧原生提交可达 22ms，并实际产生 25–33ms 的绘制间隔。

## 修复

### 标题
- 把 preview 的“几何进度”和“内容 opacity”拆成两个状态，不再借 `_previewViewportLayer.Opacity` 当几何进度。
- 展开时：真实 preview 内容已经创建并完成最终尺寸布局，但在原标题 35ms 渐隐彻底到 0 之前保持透明；原标题完全消失后，真实浏览内容直接以自己的最终字号/排版出现，只由外壳 viewport 裁切。
- 收回时反向交接：preview 内容保持到原标题最后 35ms 真正开始渐显，再退出，避免两份相同/相似标题叠在一起形成缩放错觉。
- compact 标题锚点改为使用上一帧 close width，并修正 fallback 宽度计算漏减 chrome margin 的 8 DIP，避免第一帧横向漂移。
- 不改变 1.8 内容生命周期：有 1.8 仍然直接创建真实内容，没有重新引入 fallback/deferred 中间态。

### 帧卡顿
- controller-owned 正式视觉事务（`transactionGroupId > 0`）仍保留现有 HDWP/`EndDeferWindowPos` 批量提交，保证事务语义。
- 普通 shared animation frame（无事务 id）不再建立 `WindowDeviceBoundsBatch`，直接走现有 `SetWindowPos` 路径。当前架构下 native host capacity 已在事务阶段确定，正常动画只剩位置移动。
- Dispatcher 在整个 group 内仍 `DisableProcessing`，应用输入/回调不会观察到中间逻辑帧。
- 新日志增加 `nativeMode=direct|batch`，下一轮可直接比较 direct move 的实际 callMs 和 60fps 丢帧情况。

## 保持不变
- 50ms / 2 DIP 转移门槛、预测算法、硬边界关闭规则不变。
- 35ms 原标题渐隐 / 最后 35ms 渐显时序不变。
- PR #79 的上下切换布局与尾部回填规则不变。
- Web 圆角裁切不变。