### PR TITLE
同步紧凑内容渐隐并固定自绘胶囊几何

### DIFF
--- a/EdgeCapsuleHost.PluginContent.cs
+++ b/EdgeCapsuleHost.PluginContent.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 
 namespace PaperTodo;
 
@@ -42,9 +43,10 @@ internal sealed partial class EdgeCapsuleHost
             _pluginContentLayer.Child = content;
         }
         // Keep the compact plugin tree layout-resident for the same reason as ContentGrid: a
-        // closing preview can restore it by opacity without exposing a one-frame empty shell.
+        // closing preview can restore it without exposing a one-frame empty shell. Opacity is bound
+        // to ContentGrid so built-in icon/title and custom capsule content always share the exact
+        // same 35 ms compact fade clock.
         _pluginContentLayer.Visibility = Visibility.Visible;
-        _pluginContentLayer.Opacity = _previewVisible ? 0 : 1;
         ContentArea.ToolTip = toolTip;
     }
 
@@ -59,6 +61,14 @@ internal sealed partial class EdgeCapsuleHost
             ClipToBounds = true,
             Visibility = Visibility.Collapsed
         };
+        BindingOperations.SetBinding(
+            layer,
+            UIElement.OpacityProperty,
+            new Binding(nameof(UIElement.Opacity))
+            {
+                Source = ContentGrid,
+                Mode = BindingMode.OneWay
+            });
         Panel.SetZIndex(layer, 10);
         ContentHost.Children.Add(layer);
         return layer;

--- a/EdgeCapsuleHost.Preview.cs
+++ b/EdgeCapsuleHost.Preview.cs
@@ -20,7 +20,9 @@ internal sealed partial class EdgeCapsuleHost
     private bool _previewInteractiveCaptureLease;
     private bool _compactLabelSuppressedForPreview;
     private readonly TranslateTransform _compactContentAnchorTransform = new();
+    private readonly TranslateTransform _compactPluginContentAnchorTransform = new();
     private double _compactContentAnchorWidthDip = double.NaN;
+    private double _compactPluginContentAnchorWidthDip = double.NaN;
     private double _compactContentAnchorCloseWidthDip = double.NaN;
     private long _previewInteractiveCaptureGraceUntil;
 
@@ -525,21 +527,14 @@ internal sealed partial class EdgeCapsuleHost
         }
         ApplyPreviewViewportClip(frame, bodyHeight);
 
-        // The compact title and the preview's own title-like content must never cross-fade. A
-        // protocol fallback may literally be a uniformly enlarged mirror of the compact capsule,
-        // while built-in previews also render their own heading. Showing both during the same 35 ms
-        // makes two different fixed-size trees look like one label is being scaled. Keep the final
-        // preview tree fully laid out but transparent until the compact label has actually reached
-        // zero opacity. On close the preview stays visible while the compact label's delayed restore
-        // is still at zero, then disappears as soon as that final-position title starts fading in.
-        var previewContentOpacity = _previewVisible && Label.Opacity <= 0.001
-            ? 1d
-            : 0d;
+        // Preview content is already laid out at final size. Reveal it from the first expanding
+        // frame while the fixed-geometry compact content simultaneously performs its 35 ms fade.
+        // The two visual trees may cross-fade; the invariant is that the compact tree itself never
+        // changes scale, width, height or screen anchor during that overlap.
         ApplyPreviewLayerState(
             _previewVisible,
-            previewContentOpacity,
+            _previewVisible ? previewProgress : 0,
             _previewVisible &&
-                previewContentOpacity > 0.001 &&
                 previewProgress > 0.001 &&
                 frame.IsHitTestVisible);
         if (!IsPreviewContentStageCurrent(presentationContentGeneration))
@@ -547,9 +542,8 @@ internal sealed partial class EdgeCapsuleHost
             return false;
         }
 
-        // Compact content stays layout-resident so closing never pays a fresh layout cost. The
-        // label has its own fixed-position 35 ms opacity channel; only the icon/custom compact
-        // content continues to use the preview progress cross-fade.
+        // Compact content stays layout-resident so closing never pays a fresh layout cost. Its
+        // built-in icon/title and optional custom plugin tree share one 35 ms opacity clock.
         ApplyCompactContentProgress(
             _previewVisible ? previewProgress : 0);
         _previewGeometryProgress = _previewVisible ? previewProgress : 0;
@@ -580,28 +574,39 @@ internal sealed partial class EdgeCapsuleHost
             _compactContentAnchorCloseWidthDip =
                 closeWidthOverride ?? _appliedCloseWidth;
         }
-        if (double.IsFinite(_compactContentAnchorWidthDip) &&
-            _compactContentAnchorWidthDip > 0)
-        {
-            return;
-        }
-
-        var actualWidth = ContentGrid.ActualWidth;
-        if (double.IsFinite(actualWidth) && actualWidth > 0.5)
-        {
-            _compactContentAnchorWidthDip = actualWidth;
-            return;
-        }
 
         var source = _appliedFrame.Visible
             ? _appliedFrame
             : frame;
         var sourceScaleX = Math.Max(1, source.DpiScaleX);
-        _compactContentAnchorWidthDip = Math.Max(
-            1,
-            source.BodyWindowWidthDevice / sourceScaleX -
-                _options.WindowChromeMargin -
-                ContentGrid.Margin.Left - ContentGrid.Margin.Right);
+
+        if (!double.IsFinite(_compactContentAnchorWidthDip) ||
+            _compactContentAnchorWidthDip <= 0)
+        {
+            var actualWidth = ContentGrid.ActualWidth;
+            _compactContentAnchorWidthDip =
+                double.IsFinite(actualWidth) && actualWidth > 0.5
+                    ? actualWidth
+                    : Math.Max(
+                        1,
+                        source.BodyWindowWidthDevice / sourceScaleX -
+                            _options.WindowChromeMargin -
+                            ContentGrid.Margin.Left - ContentGrid.Margin.Right);
+        }
+
+        if (_pluginContentLayer?.Child != null &&
+            (!double.IsFinite(_compactPluginContentAnchorWidthDip) ||
+             _compactPluginContentAnchorWidthDip <= 0))
+        {
+            var actualPluginWidth = _pluginContentLayer.ActualWidth;
+            _compactPluginContentAnchorWidthDip =
+                double.IsFinite(actualPluginWidth) && actualPluginWidth > 0.5
+                    ? actualPluginWidth
+                    : Math.Max(
+                        1,
+                        source.BodyWindowWidthDevice / sourceScaleX -
+                            _options.WindowChromeMargin);
+        }
     }
 
     private bool TryRetargetCompactContentAnchorForPreviewClose(
@@ -648,7 +653,10 @@ internal sealed partial class EdgeCapsuleHost
     {
         if (!double.IsFinite(_compactContentAnchorWidthDip) ||
             _compactContentAnchorWidthDip <= 0 ||
-            !double.IsFinite(_compactContentAnchorCloseWidthDip))
+            !double.IsFinite(_compactContentAnchorCloseWidthDip) ||
+            (_pluginContentLayer?.Child != null &&
+             (!double.IsFinite(_compactPluginContentAnchorWidthDip) ||
+              _compactPluginContentAnchorWidthDip <= 0)))
         {
             CaptureCompactContentAnchor(frame);
         }
@@ -661,22 +669,45 @@ internal sealed partial class EdgeCapsuleHost
         ContentGrid.VerticalAlignment = VerticalAlignment.Top;
 
         var closeWidthDelta = _appliedCloseWidth - _compactContentAnchorCloseWidthDip;
-        _compactContentAnchorTransform.X = frame.Edge == EdgeCapsuleEdge.Left
+        var anchorOffsetX = frame.Edge == EdgeCapsuleEdge.Left
             ? -closeWidthDelta
             : closeWidthDelta;
+        _compactContentAnchorTransform.X = anchorOffsetX;
         _compactContentAnchorTransform.Y = 0;
         if (!ReferenceEquals(ContentGrid.RenderTransform, _compactContentAnchorTransform))
         {
             ContentGrid.RenderTransform = _compactContentAnchorTransform;
+        }
+
+        if (_pluginContentLayer?.Child != null)
+        {
+            _pluginContentLayer.Width = Math.Max(1, _compactPluginContentAnchorWidthDip);
+            _pluginContentLayer.Height = _options.BodyHeight;
+            _pluginContentLayer.HorizontalAlignment = frame.Edge == EdgeCapsuleEdge.Left
+                ? HorizontalAlignment.Left
+                : HorizontalAlignment.Right;
+            _pluginContentLayer.VerticalAlignment = VerticalAlignment.Top;
+            _compactPluginContentAnchorTransform.X = anchorOffsetX;
+            _compactPluginContentAnchorTransform.Y = 0;
+            if (!ReferenceEquals(
+                    _pluginContentLayer.RenderTransform,
+                    _compactPluginContentAnchorTransform))
+            {
+                _pluginContentLayer.RenderTransform =
+                    _compactPluginContentAnchorTransform;
+            }
         }
     }
 
     private void RestoreCompactContentAnchor()
     {
         _compactContentAnchorWidthDip = double.NaN;
+        _compactPluginContentAnchorWidthDip = double.NaN;
         _compactContentAnchorCloseWidthDip = double.NaN;
         _compactContentAnchorTransform.X = 0;
         _compactContentAnchorTransform.Y = 0;
+        _compactPluginContentAnchorTransform.X = 0;
+        _compactPluginContentAnchorTransform.Y = 0;
         if (ReferenceEquals(ContentGrid.RenderTransform, _compactContentAnchorTransform))
         {
             ContentGrid.RenderTransform = null;
@@ -685,6 +716,20 @@ internal sealed partial class EdgeCapsuleHost
         ContentGrid.Height = double.NaN;
         ContentGrid.HorizontalAlignment = HorizontalAlignment.Stretch;
         ContentGrid.VerticalAlignment = VerticalAlignment.Center;
+
+        if (_pluginContentLayer != null)
+        {
+            if (ReferenceEquals(
+                    _pluginContentLayer.RenderTransform,
+                    _compactPluginContentAnchorTransform))
+            {
+                _pluginContentLayer.RenderTransform = null;
+            }
+            _pluginContentLayer.Width = double.NaN;
+            _pluginContentLayer.Height = double.NaN;
+            _pluginContentLayer.HorizontalAlignment = HorizontalAlignment.Stretch;
+            _pluginContentLayer.VerticalAlignment = VerticalAlignment.Stretch;
+        }
     }
 
     private void ApplyPreviewLayerState(
@@ -706,21 +751,22 @@ internal sealed partial class EdgeCapsuleHost
     private void ApplyCompactContentProgress(double previewProgress)
     {
         var progress = Math.Clamp(previewProgress, 0, 1);
-        var compactOpacity = 1 - progress;
 
-        // Keep compact content in layout. The label must not inherit preview-progress opacity or it
-        // would visually travel with the expanding/shrinking card; its independent animation below
-        // is the only opacity channel allowed to affect it.
+        // Compact geometry and opacity are independent. ContentGrid is the shared opacity owner for
+        // the built-in icon/title pair; custom plugin content binds to that same opacity. No child is
+        // allowed to derive opacity from previewProgress, otherwise icon/text drift or custom title
+        // scaling becomes visible during the overlap with the expanding preview.
         ContentGrid.Visibility = Visibility.Visible;
-        ContentGrid.Opacity = 1;
-        Icon.Opacity = compactOpacity;
+        Label.BeginAnimation(UIElement.OpacityProperty, null);
+        Icon.BeginAnimation(UIElement.OpacityProperty, null);
+        Label.Opacity = 1;
+        Icon.Opacity = 1;
         ContentGrid.IsHitTestVisible = progress <= 0.001;
         if (_pluginContentLayer != null)
         {
             _pluginContentLayer.Visibility = _pluginContentLayer.Child != null
                 ? Visibility.Visible
                 : Visibility.Collapsed;
-            _pluginContentLayer.Opacity = compactOpacity;
         }
 
         ContentArea.Background = progress > 0.001
@@ -739,18 +785,23 @@ internal sealed partial class EdgeCapsuleHost
 
         _compactLabelSuppressedForPreview = suppressed;
         var targetOpacity = suppressed ? 0d : 1d;
-        var currentOpacity = Math.Clamp(Label.Opacity, 0, 1);
+        var currentOpacity = Math.Clamp(ContentGrid.Opacity, 0, 1);
 
-        // The compact title never scales with the preview card. It remains on the compact anchor
-        // and only changes opacity over this short independent animation.
+        // The compact icon/title pair and optional self-drawn plugin capsule are one visual unit.
+        // ContentGrid owns the 35 ms animation; plugin content binds to the same property. Geometry
+        // is separately pinned to the compact anchor, so fading never changes scale or position.
         Label.BeginAnimation(UIElement.OpacityProperty, null);
-        Label.Opacity = targetOpacity;
+        Icon.BeginAnimation(UIElement.OpacityProperty, null);
+        Label.Opacity = 1;
+        Icon.Opacity = 1;
+        ContentGrid.BeginAnimation(UIElement.OpacityProperty, null);
+        ContentGrid.Opacity = targetOpacity;
         if (Math.Abs(currentOpacity - targetOpacity) <= 0.001)
         {
             return;
         }
 
-        Label.BeginAnimation(
+        ContentGrid.BeginAnimation(
             UIElement.OpacityProperty,
             new DoubleAnimation
             {
@@ -789,7 +840,11 @@ internal sealed partial class EdgeCapsuleHost
 
         _compactLabelSuppressedForPreview = false;
         Label.BeginAnimation(UIElement.OpacityProperty, null);
+        Icon.BeginAnimation(UIElement.OpacityProperty, null);
         Label.Opacity = 1;
+        Icon.Opacity = 1;
+        ContentGrid.BeginAnimation(UIElement.OpacityProperty, null);
+        ContentGrid.Opacity = 1;
 
         var animation = new DoubleAnimationUsingKeyFrames
         {
@@ -808,7 +863,7 @@ internal sealed partial class EdgeCapsuleHost
             1,
             KeyTime.FromTimeSpan(
                 TimeSpan.FromMilliseconds(remainingMilliseconds))));
-        Label.BeginAnimation(
+        ContentGrid.BeginAnimation(
             UIElement.OpacityProperty,
             animation,
             HandoffBehavior.SnapshotAndReplace);


### PR DESCRIPTION
## 修复内容

1. 恢复浏览态与原标题的交叉出现：preview 从展开第一帧就按几何进度开始显现，不再等待紧凑标题 35ms 渐隐结束。
2. 普通 Note/Todo 的图标和文字改为同一个紧凑内容 opacity 通道：`ContentGrid` 统一承担 35ms 渐隐和最后 35ms 渐显，Icon/Label 不再分别走不同进度。
3. 自绘插件胶囊内容与 `ContentGrid.Opacity` 绑定，和普通标题使用同一 35ms 时钟。
4. 自绘插件紧凑树增加独立固定宽度/高度/位置锚点。进入浏览态后保持进入前紧凑几何，只做透明度变化，不再因为 `ContentHost` 扩展而把自绘标题/组件一起拉大。
5. 退出浏览态后恢复自绘层 Stretch 布局；现有 1.8 直接内容、Web 圆角、上下切换布局和 direct HWND 动画路径不变。

## 产品契约

- 紧凑标题/图标/自绘内容可以与浏览态内容交叉出现。
- 紧凑内容始终保持原字号、原尺寸、原屏幕锚点，仅做 35ms opacity 动画。
- 浏览态内容从展开开始就出现，不等待紧凑内容完全消失。
