### PR TITLE
Measure fixed-host resource usage

### DIFF
--- a/EdgeCapsuleHost.cs
+++ b/EdgeCapsuleHost.cs
@@ -64,6 +64,9 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
     private const int WmNcHitTest = 0x0084;
     private static readonly IntPtr HtTransparent = new(-1);
     private readonly EdgeCapsuleHostOptions _options;
+#if DEBUG
+    private readonly long _diagnosticResourceId;
+#endif
     private EdgeCapsuleHostCallbacks? _callbacks;
     private Brush _hoverBrush;
     private Brush _textBrush;
@@ -111,6 +114,11 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
         TextBlock label)
     {
         _options = options;
+#if DEBUG
+        _diagnosticResourceId =
+            EdgeCapsulePerformanceDiagnostics.RegisterTransparentHost(
+                options.DiagnosticId);
+#endif
         _hoverBrush = options.HoverBrush;
         _textBrush = options.StrongTextBrush;
         _weakTextBrush = options.TextBrush;
@@ -250,6 +258,9 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
 
         if (!frame.Visible)
         {
+#if DEBUG
+            var previousHostBounds = _appliedFrame.HostBounds;
+#endif
             if (window.IsVisible)
             {
                 window.Hide();
@@ -276,6 +287,12 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
             }
             _appliedFrame = EdgeCapsulePresentationFrame.Hidden;
 #if DEBUG
+            EdgeCapsulePerformanceDiagnostics.UpdateTransparentHost(
+                _diagnosticResourceId,
+                _options.DiagnosticId,
+                previousHostBounds,
+                shown: false,
+                "hidden");
             TraceApply("hidden");
 #endif
             return true;
@@ -521,6 +538,16 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
             WindowNative.ApplyBottomZOrder(window);
         }
 #if DEBUG
+        EdgeCapsulePerformanceDiagnostics.UpdateTransparentHost(
+            _diagnosticResourceId,
+            _options.DiagnosticId,
+            nativeHostBounds,
+            window.IsVisible,
+            firstShow
+                ? "shown"
+                : nativeBoundsChanged
+                    ? "bounds-changed"
+                    : "visibility-changed");
         TraceApply("success");
 #endif
         return true;
@@ -1438,6 +1465,11 @@ internal sealed partial class EdgeCapsuleHost : IDisposable
         _disposed = true;
         Window.Content = null;
         Window.Close();
+#if DEBUG
+        EdgeCapsulePerformanceDiagnostics.UnregisterTransparentHost(
+            _diagnosticResourceId,
+            _options.DiagnosticId);
+#endif
         _callbacks = null;
         _appliedEdge = null;
     }

--- a/EdgeCapsulePerformanceDiagnostics.cs
+++ b/EdgeCapsulePerformanceDiagnostics.cs
@@ -17,16 +17,48 @@ internal static class EdgeCapsulePerformanceDiagnostics
         string FileName,
         string Text);
 
+    private readonly record struct TransparentHostResource(
+        string DiagnosticId,
+        DeviceScreenRect Bounds,
+        bool Shown);
+
+    private readonly record struct TransparentHostTotals(
+        int RegisteredCount,
+        int BoundedCount,
+        int ShownCount,
+        long PixelArea,
+        long RgbaEstimateBytes);
+
+    private readonly record struct ProcessMemorySnapshot(
+        long PrivateBytes,
+        long WorkingSetBytes,
+        long ManagedHeapBytes,
+        int HandleCount);
+
     private const int MaximumQueuedLines = 12_000;
     private const int MaximumFlushBatch = 512;
+    private const int ResourceFirstSampleDelayMilliseconds = 150;
+    private const int ResourceSettledSampleDelayMilliseconds = 1_850;
     private static readonly ConcurrentQueue<DiagnosticLine> PendingLines = new();
     private static readonly Timer FlushTimer = new(
         static _ => FlushPendingLines(),
         null,
         Timeout.Infinite,
         Timeout.Infinite);
+    private static readonly object ResourceGate = new();
+    private static readonly Dictionary<long, TransparentHostResource>
+        TransparentHosts = new();
+    private static readonly Timer ResourceSampleTimer = new(
+        static _ => SampleTransparentHostResources(),
+        null,
+        Timeout.Infinite,
+        Timeout.Infinite);
     private static int _pendingLineCount;
     private static int _flushScheduled;
+    private static long _nextTransparentHostId;
+    private static long _resourceGeneration;
+    private static int _resourceSamplePhase;
+    private static ProcessMemorySnapshot? _resourceBaseline;
 #endif
 
     internal static long Timestamp()
@@ -69,6 +101,129 @@ internal static class EdgeCapsulePerformanceDiagnostics
         return value[..Math.Min(6, value.Length)];
     }
 
+    internal static long RegisterTransparentHost(string diagnosticId)
+    {
+#if DEBUG
+        ProcessMemorySnapshot? baseline = null;
+        lock (ResourceGate)
+        {
+            if (_resourceBaseline == null)
+            {
+                baseline = CaptureProcessMemory();
+                _resourceBaseline = baseline;
+            }
+        }
+
+        if (baseline.HasValue)
+        {
+            TraceResourceSnapshot(
+                "baseline-before-first-host",
+                generation: 0,
+                default,
+                baseline.Value,
+                baseline.Value);
+        }
+
+        var hostId = Interlocked.Increment(ref _nextTransparentHostId);
+        TransparentHostTotals totals;
+        long generation;
+        lock (ResourceGate)
+        {
+            TransparentHosts[hostId] = new TransparentHostResource(
+                diagnosticId,
+                default,
+                false);
+            generation = ScheduleResourceSamplesLocked();
+            totals = CalculateTransparentHostTotalsLocked();
+        }
+        TraceTransparentHost(
+            "registered",
+            hostId,
+            diagnosticId,
+            default,
+            shown: false,
+            totals,
+            generation);
+        return hostId;
+#else
+        return 0;
+#endif
+    }
+
+    internal static void UpdateTransparentHost(
+        long hostId,
+        string diagnosticId,
+        DeviceScreenRect bounds,
+        bool shown,
+        string reason)
+    {
+#if DEBUG
+        if (hostId <= 0)
+        {
+            return;
+        }
+
+        TransparentHostTotals totals;
+        long generation;
+        lock (ResourceGate)
+        {
+            if (!TransparentHosts.TryGetValue(hostId, out var previous) ||
+                (previous.Bounds == bounds && previous.Shown == shown))
+            {
+                return;
+            }
+
+            TransparentHosts[hostId] = new TransparentHostResource(
+                diagnosticId,
+                bounds,
+                shown);
+            generation = ScheduleResourceSamplesLocked();
+            totals = CalculateTransparentHostTotalsLocked();
+        }
+        TraceTransparentHost(
+            reason,
+            hostId,
+            diagnosticId,
+            bounds,
+            shown,
+            totals,
+            generation);
+#endif
+    }
+
+    internal static void UnregisterTransparentHost(
+        long hostId,
+        string diagnosticId)
+    {
+#if DEBUG
+        if (hostId <= 0)
+        {
+            return;
+        }
+
+        TransparentHostResource removed;
+        TransparentHostTotals totals;
+        long generation;
+        lock (ResourceGate)
+        {
+            if (!TransparentHosts.Remove(hostId, out removed))
+            {
+                return;
+            }
+            generation = ScheduleResourceSamplesLocked();
+            totals = CalculateTransparentHostTotalsLocked();
+        }
+        TraceTransparentHost(
+            "disposed",
+            hostId,
+            diagnosticId,
+            removed.Bounds,
+            shown: false,
+            totals,
+            generation);
+#endif
+    }
+
     [Conditional("DEBUG")]
     internal static void Trace(string message)
     {
@@ -105,6 +260,164 @@ internal static class EdgeCapsulePerformanceDiagnostics
     }
 
 #if DEBUG
+    private static long ScheduleResourceSamplesLocked()
+    {
+        var generation = ++_resourceGeneration;
+        _resourceSamplePhase = 0;
+        try
+        {
+            ResourceSampleTimer.Change(
+                ResourceFirstSampleDelayMilliseconds,
+                Timeout.Infinite);
+        }
+        catch
+        {
+        }
+        return generation;
+    }
+
+    private static void SampleTransparentHostResources()
+    {
+        try
+        {
+            long generation;
+            int phase;
+            TransparentHostTotals totals;
+            ProcessMemorySnapshot baseline;
+            lock (ResourceGate)
+            {
+                generation = _resourceGeneration;
+                phase = _resourceSamplePhase;
+                if (phase >= 2)
+                {
+                    return;
+                }
+                totals = CalculateTransparentHostTotalsLocked();
+                baseline = _resourceBaseline ?? default;
+            }
+
+            var memory = CaptureProcessMemory();
+            lock (ResourceGate)
+            {
+                if (_resourceGeneration != generation ||
+                    _resourceSamplePhase != phase)
+                {
+                    return;
+                }
+                _resourceSamplePhase++;
+            }
+
+            TraceResourceSnapshot(
+                phase == 0 ? "after-150ms" : "settled-2s",
+                generation,
+                totals,
+                memory,
+                baseline);
+
+            if (phase == 0)
+            {
+                lock (ResourceGate)
+                {
+                    if (_resourceGeneration == generation &&
+                        _resourceSamplePhase == 1)
+                    {
+                        ResourceSampleTimer.Change(
+                            ResourceSettledSampleDelayMilliseconds,
+                            Timeout.Infinite);
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Resource diagnostics must never affect the window lifecycle.
+        }
+    }
+
+    private static TransparentHostTotals CalculateTransparentHostTotalsLocked()
+    {
+        var boundedCount = 0;
+        var shownCount = 0;
+        long pixelArea = 0;
+        foreach (var resource in TransparentHosts.Values)
+        {
+            if (resource.Shown)
+            {
+                shownCount++;
+            }
+            if (resource.Bounds.IsEmpty)
+            {
+                continue;
+            }
+            boundedCount++;
+            pixelArea += (long)resource.Bounds.Width * resource.Bounds.Height;
+        }
+        return new TransparentHostTotals(
+            TransparentHosts.Count,
+            boundedCount,
+            shownCount,
+            pixelArea,
+            pixelArea * 4);
+    }
+
+    private static ProcessMemorySnapshot CaptureProcessMemory()
+    {
+        using var process = Process.GetCurrentProcess();
+        process.Refresh();
+        return new ProcessMemorySnapshot(
+            process.PrivateMemorySize64,
+            process.WorkingSet64,
+            GC.GetTotalMemory(forceFullCollection: false),
+            process.HandleCount);
+    }
+
+    private static void TraceTransparentHost(
+        string action,
+        long hostId,
+        string diagnosticId,
+        DeviceScreenRect bounds,
+        bool shown,
+        TransparentHostTotals totals,
+        long generation)
+    {
+        var pixels = bounds.IsEmpty
+            ? 0
+            : (long)bounds.Width * bounds.Height;
+        Trace(
+            $"resource.host action={action} generation={generation} " +
+            $"hostId={hostId} paper={diagnosticId} shown={shown} " +
+            $"bounds={(bounds.IsEmpty ? \"<none>\" : $\"{bounds.Left},{bounds.Top},{bounds.Width}x{bounds.Height}\")} " +
+            $"pixels={pixels} rgbaEstimateMiB={ToMiB(pixels * 4):F3} " +
+            $"registered={totals.RegisteredCount} bounded={totals.BoundedCount} " +
+            $"shownTotal={totals.ShownCount} totalPixels={totals.PixelArea} " +
+            $"totalRgbaEstimateMiB={ToMiB(totals.RgbaEstimateBytes):F3}");
+    }
+
+    private static void TraceResourceSnapshot(
+        string phase,
+        long generation,
+        TransparentHostTotals totals,
+        ProcessMemorySnapshot memory,
+        ProcessMemorySnapshot baseline)
+    {
+        Trace(
+            $"resource.snapshot phase={phase} generation={generation} " +
+            "scope=process-memory excludesDwmGpu=true " +
+            $"registered={totals.RegisteredCount} bounded={totals.BoundedCount} " +
+            $"shown={totals.ShownCount} totalPixels={totals.PixelArea} " +
+            $"rgbaEstimateMiB={ToMiB(totals.RgbaEstimateBytes):F3} " +
+            $"privateMiB={ToMiB(memory.PrivateBytes):F3} " +
+            $"privateDeltaMiB={ToMiB(memory.PrivateBytes - baseline.PrivateBytes):F3} " +
+            $"workingSetMiB={ToMiB(memory.WorkingSetBytes):F3} " +
+            $"workingSetDeltaMiB={ToMiB(memory.WorkingSetBytes - baseline.WorkingSetBytes):F3} " +
+            $"managedHeapMiB={ToMiB(memory.ManagedHeapBytes):F3} " +
+            $"managedHeapDeltaMiB={ToMiB(memory.ManagedHeapBytes - baseline.ManagedHeapBytes):F3} " +
+            $"handles={memory.HandleCount} handleDelta={memory.HandleCount - baseline.HandleCount}");
+    }
+
+    private static double ToMiB(long bytes) =>
+        bytes / (1024.0 * 1024.0);
+
     private static void Enqueue(string fileName, string line)
     {
         if (Interlocked.Increment(ref _pendingLineCount) > MaximumQueuedLines)


### PR DESCRIPTION
## What changed
- Add Debug-only lifecycle tracking for each fixed transparent edge host.
- Log native bounds, aggregate pixel area, and a 32-bit RGBA surface estimate.
- Sample process private bytes, working set, managed heap, and handle count against a per-run baseline at 150 ms and 2 s after host changes.

## Why
Before reducing the V2 envelope, measure whether fixed transparent hosts materially increase actual process memory as paper count and display resolution grow.

## Impact
No release geometry or animation behavior changes. Instrumentation is compiled only in Debug. Process samples explicitly exclude DWM/GPU memory, so results should be evaluated alongside the theoretical surface-area estimate.

## Validation
- `git diff --check`
- Windows .NET 10 build: passed
- Edge refinement checks: passed
- Pull request build #49: passed