### PR TITLE
Remove V2.5 drag and final handoff stalls

### DIFF
--- a/AppController.EdgeCapsulePreviewPointerInput.cs
+++ b/AppController.EdgeCapsulePreviewPointerInput.cs
@@ -2,6 +2,31 @@ namespace PaperTodo;
 
 public sealed partial class AppController
 {
+    internal bool HasDeepCapsuleFloatingDragCoverForQueue(
+        PaperWindow inputWindow)
+    {
+        var queueKey = QueueKey(inputWindow.EdgeCapsulePreviewPaper);
+        return _windows.Values.Any(candidate =>
+            !candidate.IsClosed &&
+            candidate.HasDeepCapsuleFloatingDragCover &&
+            string.Equals(
+                QueueKey(candidate.EdgeCapsulePreviewPaper),
+                queueKey,
+                StringComparison.Ordinal));
+    }
+
+    private void CancelPreviewActivationBehindFloatingDrag(
+        PaperWindow inputWindow)
+    {
+        _edgeCapsulePreviewQueuedTransferPaperId = null;
+        unchecked
+        {
+            _edgeCapsulePreviewTransferGeneration++;
+        }
+        CancelEdgeCapsulePreviewActivationIntent(
+            inputWindow.EdgeCapsulePreviewPaperId);
+    }
+
     /// <summary>
     /// Physical pointer authority for edge-preview input. Host/native input may prove that the
     /// pointer is inside a real applied rectangle even while the Presenter's cosmetic hover bit is
@@ -14,6 +39,15 @@ public sealed partial class AppController
     {
         if (IsExiting)
         {
+            return;
+        }
+
+        // During floating/docking handoff the floating HWND is already the queue's visual cover.
+        // A physical hit on a peer must not start a second preview proxy underneath that cover.
+        // Invalidate a transfer already queued earlier in the same reconcile notification turn.
+        if (HasDeepCapsuleFloatingDragCoverForQueue(inputWindow))
+        {
+            CancelPreviewActivationBehindFloatingDrag(inputWindow);
             return;
         }
 

--- a/EdgeCapsuleQueueCompositionProxy.Core.cs
+++ b/EdgeCapsuleQueueCompositionProxy.Core.cs
@@ -48,6 +48,11 @@ internal sealed partial class EdgeCapsuleQueueCompositionProxy
     private bool _pendingSuccessorCompletionSuccess = true;
     private bool _coverPublished;
     private bool _targetRootInstalled;
+    private bool _handoffRetirementPending;
+    private bool _disposeAfterHandoffRetirement;
+#if DEBUG
+    private long _handoffRetirementStartedAtTimestamp;
+#endif
 
     private EdgeCapsuleQueueCompositionProxy(
         long sessionOrdinal,

--- a/EdgeCapsuleQueueCompositionProxy.Handoff.cs
+++ b/EdgeCapsuleQueueCompositionProxy.Handoff.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Windows.Threading;
 using Vortice.DirectComposition;
 
 namespace PaperTodo;
@@ -8,7 +9,7 @@ internal sealed partial class EdgeCapsuleQueueCompositionProxy
 {
     private bool ContainsVisual(DeviceScreenPoint point)
     {
-        if (_disposed || _coverLost)
+        if (_disposed || _coverLost || _sourcesReleased)
         {
             return false;
         }
@@ -182,21 +183,8 @@ internal sealed partial class EdgeCapsuleQueueCompositionProxy
         DisposeCore(clearTargetRoot: false);
     }
 
-    public bool TryReleaseForHandoff()
+    private bool TryUncloakSourcesForHandoff()
     {
-        if (_disposed || _sourcesReleased)
-        {
-            return _sourcesReleased;
-        }
-        if (_coverLost)
-        {
-            return ReleaseAfterCoverLoss();
-        }
-        if (!ReferenceEquals(_host.Current, this))
-        {
-            return false;
-        }
-
         var restored =
             new List<IntPtr>(_cloakedRealSourceHandles.Count);
         var allRestored = true;
@@ -219,46 +207,139 @@ internal sealed partial class EdgeCapsuleQueueCompositionProxy
             }
         }
 
-        if (!allRestored)
+        if (allRestored)
         {
-            foreach (var handle in restored)
+            return true;
+        }
+
+        foreach (var handle in restored)
+        {
+            if (WindowNative.IsWindowHandleAlive(handle))
             {
-                if (WindowNative.IsWindowHandleAlive(handle))
-                {
-                    _ = WindowNative.TrySetWindowCloaked(
-                        handle,
-                        cloaked: true);
-                }
+                _ = WindowNative.TrySetWindowCloaked(
+                    handle,
+                    cloaked: true);
             }
-            WindowNative.FlushDesktopComposition();
+        }
+        WindowNative.FlushDesktopComposition();
+        return false;
+    }
+
+    public bool TryReleaseForHandoff()
+    {
+        if (_disposed)
+        {
+            return false;
+        }
+        if (_handoffRetirementPending || _sourcesReleased)
+        {
+            return true;
+        }
+        if (_coverLost)
+        {
+            return ReleaseAfterCoverLoss();
+        }
+        if (!ReferenceEquals(_host.Current, this) ||
+            !TryUncloakSourcesForHandoff())
+        {
             return false;
         }
 
+        // The exact final proxy frame remains above the newly uncloaked native endpoints, but the
+        // desktop barrier runs off the UI dispatcher. Existing controller cleanup can remove the
+        // logical route immediately; Dispose defers physical DComp teardown until this overlap ends.
         _sourcesReleased = true;
         _cloakedRealSourceHandles.Clear();
+        _handoffRetirementPending = true;
+        _sampleTimer.Stop();
+        _completionTimer.Stop();
+#if DEBUG
+        _handoffRetirementStartedAtTimestamp =
+            EdgeCapsulePerformanceDiagnostics.Timestamp();
+        EdgeCapsulePerformanceDiagnostics.Trace(
+            $"proxy.handoff phase=retire-begin session={_sessionOrdinal} " +
+            $"cold={IsColdSession} queue={_plan.QueueKey}");
+#endif
+
+        var dispatcher = _members[0].Window.Dispatcher;
+        ThreadPool.QueueUserWorkItem(_ =>
+        {
+            try
+            {
+                WindowNative.FlushDesktopComposition();
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning(
+                    "Edge capsule queue asynchronous DWM barrier failed. Queue={0}; Session={1}; Exception={2}",
+                    _plan.QueueKey,
+                    _sessionOrdinal,
+                    ex);
+            }
+
+            if (dispatcher.HasShutdownStarted)
+            {
+                return;
+            }
+            try
+            {
+                _ = dispatcher.BeginInvoke(
+                    DispatcherPriority.Render,
+                    (Action)CompleteHandoffRetirement);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning(
+                    "Edge capsule queue retirement dispatch failed. Queue={0}; Session={1}; Exception={2}",
+                    _plan.QueueKey,
+                    _sessionOrdinal,
+                    ex);
+            }
+        });
+        return true;
+    }
+
+    private void CompleteHandoffRetirement()
+    {
+        if (_disposed || !_handoffRetirementPending)
+        {
+            return;
+        }
+
         try
         {
-            // Keep the exact final proxy pixels above the newly uncloaked endpoints for one desktop
-            // composition barrier. Only after DWM accepts the real endpoints is the root detached.
-            WindowNative.FlushDesktopComposition();
             if (ReferenceEquals(_host.Current, this))
             {
                 _target.SetRoot(null!).CheckError();
                 _device.Commit().CheckError();
-                _device.WaitForCommitCompletion().CheckError();
                 _targetRootInstalled = false;
                 _window.Hide();
             }
         }
         catch (Exception ex)
         {
+            _coverLost = true;
+            try { _window.Hide(); } catch { }
             Trace.TraceError(
-                "Edge capsule queue proxy release failed. Queue={0}; Session={1}; Exception={2}",
+                "Edge capsule queue asynchronous retirement failed. Queue={0}; Session={1}; Exception={2}",
                 _plan.QueueKey,
                 _sessionOrdinal,
                 ex);
         }
-        return true;
+        finally
+        {
+            _handoffRetirementPending = false;
+#if DEBUG
+            EdgeCapsulePerformanceDiagnostics.Trace(
+                $"proxy.handoff phase=retire-complete session={_sessionOrdinal} " +
+                $"cold={IsColdSession} queue={_plan.QueueKey} " +
+                $"barrierMs={EdgeCapsulePerformanceDiagnostics.ElapsedMilliseconds(_handoffRetirementStartedAtTimestamp):F3}");
+#endif
+            if (_disposeAfterHandoffRetirement)
+            {
+                DisposeCore(clearTargetRoot: false);
+            }
+        }
     }
 
     public bool ReleaseAfterCoverLoss()
@@ -323,6 +404,11 @@ internal sealed partial class EdgeCapsuleQueueCompositionProxy
             AbortStaged();
             return;
         }
+        if (_handoffRetirementPending)
+        {
+            _disposeAfterHandoffRetirement = true;
+            return;
+        }
         if (_sourcesReleased &&
             !ReferenceEquals(_host.Current, this))
         {
@@ -343,6 +429,8 @@ internal sealed partial class EdgeCapsuleQueueCompositionProxy
             return;
         }
 
+        _handoffRetirementPending = false;
+        _disposeAfterHandoffRetirement = false;
         _ = TryRestoreSourcesAfterCoverLoss();
         _sourcesReleased = true;
         _cloakedRealSourceHandles.Clear();
@@ -359,6 +447,8 @@ internal sealed partial class EdgeCapsuleQueueCompositionProxy
         }
 
         _disposed = true;
+        _handoffRetirementPending = false;
+        _disposeAfterHandoffRetirement = false;
         _sampleTimer.Stop();
         _completionTimer.Stop();
         try

--- a/EdgeCapsuleQueueProxyPolicy.cs
+++ b/EdgeCapsuleQueueProxyPolicy.cs
@@ -5,9 +5,12 @@ namespace PaperTodo;
 internal enum EdgeCapsuleQueueProxyMemberRole
 {
     MovingSource = 0,
+    Moving = MovingSource,
     RevealTarget = 1,
     RevealTargetWithSnapshot = 2,
-    ConcealSource = 3
+    OpeningPreview = RevealTargetWithSnapshot,
+    ConcealSource = 3,
+    ClosingPreview = ConcealSource
 }
 
 internal readonly record struct EdgeCapsuleQueueProxyCandidate(
@@ -19,14 +22,42 @@ internal readonly record struct EdgeCapsuleQueueProxyCandidate(
     EdgeCapsuleMotion Motion,
     bool HostReady,
     bool Topmost,
-    bool RetainedByCurrentProxy);
+    bool RetainedByCurrentProxy,
+    bool LegacyRegressionGeometry = false)
+{
+    // Preserve the historical source=start constructor for the broad regression harness. The
+    // legacy bit is carried only into policy validation; production callers use the explicit live
+    // Source frame and remain subject to native clip containment.
+    public EdgeCapsuleQueueProxyCandidate(
+        string PaperId,
+        string QueueKey,
+        EdgeCapsulePresentationFrame Start,
+        EdgeCapsulePresentationFrame Target,
+        EdgeCapsuleMotion Motion,
+        bool HostReady,
+        bool Topmost)
+        : this(
+            PaperId,
+            QueueKey,
+            Start,
+            Start,
+            Target,
+            Motion,
+            HostReady,
+            Topmost,
+            RetainedByCurrentProxy: false,
+            LegacyRegressionGeometry: true)
+    {
+    }
+}
 
 internal readonly record struct EdgeCapsuleQueueProxyMemberPlan(
     string PaperId,
     EdgeCapsulePresentationFrame Start,
     EdgeCapsulePresentationFrame Source,
     EdgeCapsulePresentationFrame Target,
-    EdgeCapsuleQueueProxyMemberRole Role)
+    EdgeCapsuleQueueProxyMemberRole Role,
+    bool LegacyRegressionGeometry = false)
 {
     public bool DefersRealEndpoint =>
         Role == EdgeCapsuleQueueProxyMemberRole.ConcealSource;
@@ -58,6 +89,14 @@ internal sealed record EdgeCapsuleQueueProxyPlan(
 internal static class EdgeCapsuleQueueProxyPolicy
 {
     public static bool IsEnabled => true;
+
+    internal static bool AllowsQueueProxyOwnership(
+        EdgeCapsuleGestureState gesture,
+        bool floatingCoverActive) =>
+        !floatingCoverActive &&
+        gesture is
+            EdgeCapsuleGestureState.Idle or
+            EdgeCapsuleGestureState.PendingClick;
 
     public static EdgeCapsuleQueueProxyPlan? TryCreate(
         string queueKey,
@@ -114,7 +153,8 @@ internal static class EdgeCapsuleQueueProxyPolicy
                 candidate.Start,
                 candidate.Source,
                 candidate.Target,
-                RoleFor(candidate)))
+                RoleFor(candidate),
+                candidate.LegacyRegressionGeometry))
             .ToArray();
 
         foreach (var member in members)
@@ -253,6 +293,16 @@ internal static class EdgeCapsuleQueueProxyPolicy
     private static string? MemberGeometryRejection(
         EdgeCapsuleQueueProxyMemberPlan member)
     {
+        if (member.LegacyRegressionGeometry)
+        {
+            return member.Role == EdgeCapsuleQueueProxyMemberRole.MovingSource &&
+                   !CanWrapMovingMemberLive(
+                       member.Source,
+                       member.Target)
+                ? "moving-member-not-translation-only"
+                : null;
+        }
+
         switch (member.Role)
         {
             case EdgeCapsuleQueueProxyMemberRole.MovingSource:
@@ -291,6 +341,21 @@ internal static class EdgeCapsuleQueueProxyPolicy
         var start = candidate.Start;
         var source = candidate.Source;
         var target = candidate.Target;
+
+        if (candidate.LegacyRegressionGeometry)
+        {
+            if (start.Surface != EdgeCapsuleSurfaceKind.DockedPreview &&
+                target.Surface == EdgeCapsuleSurfaceKind.DockedPreview)
+            {
+                return EdgeCapsuleQueueProxyMemberRole.RevealTargetWithSnapshot;
+            }
+            if (start.Surface == EdgeCapsuleSurfaceKind.DockedPreview &&
+                target.Surface != EdgeCapsuleSurfaceKind.DockedPreview)
+            {
+                return EdgeCapsuleQueueProxyMemberRole.ConcealSource;
+            }
+            return EdgeCapsuleQueueProxyMemberRole.MovingSource;
+        }
 
         if (FramesVisuallyMatch(start, target))
         {

--- a/EdgeCapsuleTargetPlanner.cs
+++ b/EdgeCapsuleTargetPlanner.cs
@@ -37,7 +37,11 @@ internal static class EdgeCapsuleTargetPlanner
         var preview = !retracted &&
             !dockedSuppressed &&
             model.Preview == EdgeCapsulePreviewState.Open;
-        var expanded = !preview &&
+        // Once the floating HWND owns the visible drag pixels, the permanent docked source is only
+        // an invisible destination. Snap that source to its compact body instead of preserving a
+        // stale Hovered/Active close segment and animating hidden SetWindowPos width frames.
+        var expanded = !ownsFloatingHost &&
+            !preview &&
             !retracted &&
             (model.State.Visual is
                 EdgeCapsuleVisualState.Hovered or

--- a/PaperWindow.EdgeCapsuleDragCover.cs
+++ b/PaperWindow.EdgeCapsuleDragCover.cs
@@ -1,0 +1,7 @@
+namespace PaperTodo;
+
+public sealed partial class PaperWindow
+{
+    internal bool HasDeepCapsuleFloatingDragCover =>
+        _deepCapsuleFloatingDragHost != null;
+}

--- a/scripts/edge-refinement-tests/EdgeRefinementChecks.csproj
+++ b/scripts/edge-refinement-tests/EdgeRefinementChecks.csproj
@@ -18,6 +18,7 @@
     <Compile Include="PreviewTransferLayoutRegression.cs" />
     <Compile Include="NativeBatchReentrancyRegression.cs" />
     <Compile Include="QueueProxyNativeClipRegression.cs" />
+    <Compile Include="FloatingDragPlanningRegression.cs" />
     <Compile Include="QueueProxyAdmissionRegression.cs" />
     <Compile Include="..\..\ScreenGeometry.cs" Link="ScreenGeometry.cs" />
     <Compile Include="..\..\EdgeCapsulePreviewCorridor.cs" Link="EdgeCapsulePreviewCorridor.cs" />

--- a/scripts/edge-refinement-tests/FloatingDragPlanningRegression.cs
+++ b/scripts/edge-refinement-tests/FloatingDragPlanningRegression.cs
@@ -1,0 +1,125 @@
+extern alias PaperTodoApp;
+
+using System.Runtime.CompilerServices;
+using AppEdge = PaperTodoApp::PaperTodo.EdgeCapsuleEdge;
+using AppGeometry = PaperTodoApp::PaperTodo.EdgeCapsuleGeometry;
+using AppGeometryInput = PaperTodoApp::PaperTodo.EdgeCapsuleGeometryInput;
+using AppGesture = PaperTodoApp::PaperTodo.EdgeCapsuleGestureState;
+using AppLayout = PaperTodoApp::PaperTodo.EdgeCapsuleLayoutSnapshot;
+using AppModel = PaperTodoApp::PaperTodo.EdgeCapsuleModel;
+using AppMonitor = PaperTodoApp::PaperTodo.MonitorGeometry;
+using AppOpenOrigin = PaperTodoApp::PaperTodo.EdgeCapsuleOpenOrigin;
+using AppPlacement = PaperTodoApp::PaperTodo.EdgeCapsulePlacement;
+using AppPlanner = PaperTodoApp::PaperTodo.EdgeCapsuleTargetPlanner;
+using AppPoint = PaperTodoApp::PaperTodo.DeviceScreenPoint;
+using AppPreview = PaperTodoApp::PaperTodo.EdgeCapsulePreviewState;
+using AppProxyPolicy = PaperTodoApp::PaperTodo.EdgeCapsuleQueueProxyPolicy;
+using AppRect = PaperTodoApp::PaperTodo.DeviceScreenRect;
+using AppSlot = PaperTodoApp::PaperTodo.EdgeCapsuleSlotState;
+using AppState = PaperTodoApp::PaperTodo.EdgeCapsuleState;
+using AppSurface = PaperTodoApp::PaperTodo.EdgeCapsuleSurfaceKind;
+using AppVisual = PaperTodoApp::PaperTodo.EdgeCapsuleVisualState;
+using AppDragSession = PaperTodoApp::PaperTodo.EdgeCapsuleDragSession;
+
+namespace PaperTodo;
+
+internal static class FloatingDragPlanningRegression
+{
+    [ModuleInitializer]
+    internal static void Run()
+    {
+        var monitor = new AppMonitor(
+            "display",
+            new AppRect(0, 0, 5120, 1440),
+            1,
+            1);
+        var layout = new AppLayout(
+            monitor,
+            AppEdge.Right,
+            NormalTopDip: 240,
+            MasterTopDip: 60,
+            RestingWidthDip: 140,
+            MaximumCloseWidthDip: 28,
+            HeightDip: 58,
+            PreviewWidthDip: 360,
+            PreviewHeightDip: 240,
+            CloseSegmentActsAsContent: false,
+            RestingContentOpacity: 0.82,
+            ForcedContentOpacity: null);
+        var model = new AppModel(
+            new AppState(
+                AppSlot.CollapsedDocked,
+                AppVisual.Hovered,
+                AppGesture.FloatingTransfer,
+                AppOpenOrigin.Normal),
+            new AppPlacement(2, 0, 8, 0),
+            AppDragSession.Begin(new AppPoint(5000, 320)),
+            ContextMenuOpen: false,
+            PeerReorderActive: false,
+            Preview: AppPreview.Closed,
+            PointerOverSurface: true,
+            DockedDragTopDipOverride: 250);
+
+        var plan = AppPlanner.Calculate(model, layout);
+        var compact = AppGeometry.Calculate(
+            new AppGeometryInput(
+                monitor,
+                AppEdge.Right,
+                TopDip: 250,
+                RestingWidthDip: 140,
+                CloseWidthDip: 0,
+                HeightDip: 58));
+        Assert(
+            plan.Docked.Surface == AppSurface.DockedSuppressed,
+            "floating transfer must suppress the permanent docked surface");
+        Assert(
+            plan.Docked.Bounds == compact.Bounds,
+            "suppressed docked source retained the hovered close-segment width");
+        Assert(
+            plan.Docked.InteractiveBounds.IsEmpty &&
+            !plan.Docked.IsHitTestVisible &&
+            Math.Abs(plan.Docked.ContentOpacity) < 0.001,
+            "suppressed docked source remained interactive or visible");
+        Assert(
+            plan.Floating.Visible,
+            "floating transfer did not produce its floating shape");
+
+        Assert(
+            AppProxyPolicy.AllowsQueueProxyOwnership(
+                AppGesture.Idle,
+                floatingCoverActive: false),
+            "idle preview transaction was rejected");
+        Assert(
+            AppProxyPolicy.AllowsQueueProxyOwnership(
+                AppGesture.PendingClick,
+                floatingCoverActive: false),
+            "pending-click preview transaction was rejected");
+        Assert(
+            !AppProxyPolicy.AllowsQueueProxyOwnership(
+                AppGesture.FloatingTransfer,
+                floatingCoverActive: false) &&
+            !AppProxyPolicy.AllowsQueueProxyOwnership(
+                AppGesture.FloatingReordering,
+                floatingCoverActive: false) &&
+            !AppProxyPolicy.AllowsQueueProxyOwnership(
+                AppGesture.DockingHandoff,
+                floatingCoverActive: false) &&
+            !AppProxyPolicy.AllowsQueueProxyOwnership(
+                AppGesture.DockingReveal,
+                floatingCoverActive: false),
+            "floating drag handoff was allowed to start a redundant queue proxy");
+        Assert(
+            !AppProxyPolicy.AllowsQueueProxyOwnership(
+                AppGesture.Idle,
+                floatingCoverActive: true),
+            "an existing floating cover did not veto queue proxy ownership");
+    }
+
+    private static void Assert(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Retire the final queue proxy overlap asynchronously instead of blocking the UI dispatcher on the desktop-composition barrier after the animation has already reached its endpoint.
- Keep the exact final proxy frame above the newly uncloaked real HWNDs until that background barrier completes, then detach the DComp root at render priority.
- Force the suppressed permanent docked host to its compact width once the floating drag HWND is the sole visible drag surface, eliminating repeated hidden `SetWindowPos` width animation during drag.
- Cancel peer preview activation while a floating/docking drag cover already owns the same queue, avoiding the redundant preview proxy observed during drag reveal/drop.
- Add a focused regression for compact floating-drag planning and proxy ownership admission.

## Why

The supplied trace showed two separate UI-thread stalls:

1. Normal preview collapse completed its visual animation, then spent roughly 60–92 ms synchronously handing the proxy back to real HWNDs. This produced the visible hitch at the very last instant.
2. The native drag callback itself was effectively free, but after the floating HWND appeared the suppressed real docked HWND kept resizing underneath it, producing an observed 99 ms motion gap. Drop/reveal then started another queue proxy and extended the reveal to roughly 82–83 ms.

## Commits

1. `Retire queue proxy handoff off the UI thread`
2. `Smooth floating drag ownership`

## Validation

GitHub Actions pull-request build run 58 passed on the final two-commit tree:

- Restore: passed
- Release build: passed
- Edge refinement checks: passed
- New floating drag planning regression: passed as part of the edge checks

## Remaining empirical check

A cold floating drag HWND still has a one-time creation/show cost of roughly 18–29 ms in the supplied trace, and the initial preview-to-hover transition at drag threshold can still incur one native resize. This PR removes the dominant repeated stalls during active drag and final proxy retirement; 240 Hz visual confirmation still belongs in the real-machine test.