### PR TITLE
fix: keep persisted UI language for the whole process

### DIFF
--- a/App.StartupCulture.cs
+++ b/App.StartupCulture.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace PaperTodo;
+
+public partial class App
+{
+    static App()
+    {
+        // OnStartup is async void. Setting CurrentUICulture only inside that async execution
+        // context can be restored to the OS culture when control returns to the WPF Dispatcher.
+        // Establish the persisted UI culture on the root UI thread before App is constructed,
+        // InitializeComponent runs, or any Dispatcher work is queued. The existing OnStartup
+        // application remains a harmless idempotent re-apply during normal UI startup.
+        if (!McpBridge.IsRequested(Environment.GetCommandLineArgs()))
+        {
+            ApplyStartupCulturePreference(UiLanguages.LoadPersistedPreference());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- establish the persisted PaperTodo UI culture in `App`'s static initialization, before WPF constructs the application or queues Dispatcher work
- keep the existing `OnStartup` culture application as an idempotent re-apply
- skip the UI-culture bootstrap for `--mcp`, preserving the previous MCP startup behavior

## Why

`App.OnStartup` is `async void`. Applying `CultureInfo.CurrentUICulture` only inside that async execution context can leave the root WPF Dispatcher execution context on the OS culture. This matches the observed behavior: startup-created master capsule text can initially use the configured language, while later-created menus/settings use the system language, and the master capsule switches back after a state refresh.

## Scope

Only adds `App.StartupCulture.cs`. No EdgeCapsule presentation/animation files, plugin contracts, or runtime language hot-switching are changed.