### PR TITLE
docs: fix broken star history charts

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -279,4 +279,4 @@ Thanks to the [linux.do](https://linux.do/) community.
 
 ## Star History
 
-[![PaperTodo Star History Chart](https://api.star-history.com/svg?repos=snownico0722/PaperTodo&type=Date)](https://star-history.com/#snownico0722/PaperTodo&Date)
+[![PaperTodo Star History Chart](https://star-history.dera.page/svg?repos=snownico0722/PaperTodo&type=Date)](https://star-history.dera.page/#snownico0722/PaperTodo&type=Date)

--- a/README.md
+++ b/README.md
@@ -284,4 +284,4 @@ dotnet build -c Release
 
 ## Star 增长曲线
 
-[![PaperTodo Star 增长曲线](https://api.star-history.com/svg?repos=snownico0722/PaperTodo&type=Date)](https://star-history.com/#snownico0722/PaperTodo&Date)
+[![PaperTodo Star 增长曲线](https://star-history.dera.page/svg?repos=snownico0722/PaperTodo&type=Date)](https://star-history.dera.page/#snownico0722/PaperTodo&type=Date)


### PR DESCRIPTION
The current star history chart is broken in both README versions. Update the chart image and wrapping links so the star history display works again.