### PR TITLE
Fix edge capsule recovery and live bounds

### DIFF
--- a/PaperTodo.Plugin.Abstractions/PaperBodyPluginContracts.cs
+++ b/PaperTodo.Plugin.Abstractions/PaperBodyPluginContracts.cs
@@ -120,7 +120,10 @@ public interface IPaperCapsuleViewProvider
 /// <summary>
 /// Preferred complete edge mini-card size in device-independent pixels. The size includes the
 /// host-owned chrome and close segment. Width and Height must be positive finite numbers; PaperTodo
-/// clamps the requested size only to the usable area of the current monitor.
+/// clamps the requested size only to the usable area of the current monitor. Runtime size changes
+/// are supported, but repeatedly changing the preferred size while a mini is visible is discouraged
+/// because it can force host/native relayout; keep one browsing session geometrically stable when
+/// practical.
 /// </summary>
 public readonly record struct PaperMiniViewSize(double Width, double Height)
 {

--- a/plugin-samples/README.md
+++ b/plugin-samples/README.md
@@ -693,7 +693,7 @@ Edge Mini 是快速浏览 surface。**插件贡献内容，PaperTodo 始终拥�
 320 × 220 DIP
 ```
 
-内置 Todo / Markdown 可以继续使用自己的 renderer envelope 和视觉默认尺寸；这些值不是插件协议限制。Native 插件若在一个已经可见的 bounded host generation 中临时请求更大的 Preferred Size，宿主可能先约束到当前安全 capacity，并把更大的请求留到下一次安全 host generation。插件应把 Preferred Size 当作稳定布局偏好，而不是持续动画参数。
+内置 Todo / Markdown 可以继续使用自己的 renderer envelope 和视觉默认尺寸；这些值不是插件协议限制。Native `PreferredMiniViewSize` 可以随会话状态变化；宿主在没有活动 queue-proxy 事务时可以直接调整 bounded host，如果尺寸变化正好发生在 queue translation 中，增长可能短暂延后到该事务结束。**不推荐在 Mini 已显示时高频改变尺寸，也不要把 Preferred Size 当作动画参数**，因为尺寸变化可能触发宿主/native 重新布局并造成短暂卡顿。
 
 ### 8.2 Native dedicated mini
 

--- a/src/App.EdgeCapsuleComposition.cs
+++ b/src/App.EdgeCapsuleComposition.cs
@@ -6,6 +6,13 @@ public partial class App
 {
     public App()
     {
+        // MCP is a stdio bridge process and never owns GUI edge surfaces. Keep the branch explicit
+        // here rather than relying on AppController.Current remaining null until the idle callback.
+        if (McpBridge.IsRequested(Environment.GetCommandLineArgs()))
+        {
+            return;
+        }
+
         // Pay known DComp publication and WPF HWND first-use costs during startup only when edge
         // browsing is enabled. Users who keep the feature off should not create any prewarm HWNDs
         // or compositor resources just for this path.

--- a/src/EdgeCapsuleQueueCompositionProxy.Routing.cs
+++ b/src/EdgeCapsuleQueueCompositionProxy.Routing.cs
@@ -5,6 +5,8 @@ namespace PaperTodo;
 
 internal sealed partial class EdgeCapsuleQueueCompositionProxy
 {
+    private const int MaximumCompletionRetryCount = 2;
+
     // A queue generation that enters or leaves DockedRetracted is the master collapse-all/release
     // animation. It is purely visual: the master owns the gesture, and moving proxy pixels must
     // never become a temporary mouse owner for the desktop or another application.
@@ -398,8 +400,38 @@ internal sealed partial class EdgeCapsuleQueueCompositionProxy
 
         _finishing = false;
         _completionRetrySuccess = success;
-        _completionRetryCount++;
         _completionTimer.Stop();
+
+        if (_coverLost)
+        {
+            // The normal handoff budget is already exhausted (or the DComp output was lost). Source
+            // reveal is now the only safe authority transition. Keep that emergency recovery paced
+            // at 50 ms if Windows temporarily refuses the uncloak; never turn it into a Send loop.
+            _completionRetrySuccess = false;
+            _completionTimer.Interval = TimeSpan.FromMilliseconds(50);
+            _completionTimer.Start();
+            return;
+        }
+
+        if (_completionRetryCount >= MaximumCompletionRetryCount)
+        {
+            // Two delayed retries are enough for transient WPF/native settlement. After that the
+            // last proxy frame must not become a permanent authority: enter the existing cover-loss
+            // path, which reveals real sources before this broken generation can retire.
+            _coverLost = true;
+            _completionRetrySuccess = false;
+#if DEBUG
+            EdgeCapsulePerformanceDiagnostics.Trace(
+                $"proxy.handoff phase=retry-exhausted session={_sessionOrdinal} " +
+                $"cold={IsColdSession} queue={_plan.QueueKey} " +
+                $"attempts={_completionRetryCount} successTarget={success}");
+#endif
+            _completionTimer.Interval = TimeSpan.FromMilliseconds(50);
+            _completionTimer.Start();
+            return;
+        }
+
+        _completionRetryCount++;
         _completionTimer.Interval = TimeSpan.FromMilliseconds(50);
         _completionTimer.Start();
 #if DEBUG

--- a/src/PaperWindow.EdgeCapsule.cs
+++ b/src/PaperWindow.EdgeCapsule.cs
@@ -69,8 +69,11 @@ public sealed partial class PaperWindow
         return host;
     }
 
-    private void RejectEdgeCapsuleNativeBatchApply() =>
+    private void RejectEdgeCapsuleNativeBatchApply()
+    {
         _edgeCapsuleHost?.RejectNativeBatchApply();
+        ScheduleEdgeCapsuleApplyFailureRecovery();
+    }
 
     private void RecoverDeferredEdgeCapsuleNativeBatchApply()
     {
@@ -366,10 +369,11 @@ public sealed partial class PaperWindow
             return false;
         }
 
-        // Host capacity is immutable for the lifetime of a visible monitor/edge/DPI
-        // generation. A larger late descriptor waits for a future hidden/generation
-        // rebuild instead of resizing the live HWND under the user's pointer.
-        if (_edgeCapsuleHost?.IsVisible == true &&
+        // Live capacity may grow between compositor transactions. While a queue proxy retains this
+        // HWND as a live source, however, its native surface identity/size is part of the active
+        // translation contract; defer a larger request until that authority has been released.
+        if (_controller.IsEdgeCapsuleQueueProxyRetainingSource(this) &&
+            _edgeCapsuleHost?.IsVisible == true &&
             !CurrentEdgeCapsuleHostCapacityContains(size))
         {
             return false;
@@ -391,7 +395,7 @@ public sealed partial class PaperWindow
 
 #if DEBUG
         EdgeCapsulePerformanceDiagnostics.Trace(
-            $"preview.capacity phase=visible-growth-rejected " +
+            $"preview.capacity phase=active-proxy-growth-deferred " +
             $"paper={EdgeCapsulePerformanceDiagnostics.ShortId(_paper.Id)} " +
             $"requested={size.WidthDip:F1}x{size.HeightDip:F1} " +
             $"reserved={_edgeCapsuleHostCapacityWidthDip:F1}x" +
@@ -413,15 +417,21 @@ public sealed partial class PaperWindow
         var previewHeight = previewSize?.HeightDip ??
             PaperLayoutDefaults.CapsuleHeight;
 
-        _ = GrowEdgeCapsuleHostCapacity(
-            monitor,
-            edge,
-            Math.Max(
-                restingWidth + CapsuleCloseWidth,
-                previewWidth),
-            Math.Max(
-                PaperLayoutDefaults.CapsuleHeight,
-                previewHeight));
+        // Outside compositor ownership the live bounded HWND may resize to new title/plugin/mini
+        // requirements. During an active queue proxy transaction the proxy owns a live surface from
+        // this HWND, so keep that source capacity stable until the proxy releases it.
+        if (!_controller.IsEdgeCapsuleQueueProxyRetainingSource(this))
+        {
+            _ = GrowEdgeCapsuleHostCapacity(
+                monitor,
+                edge,
+                Math.Max(
+                    restingWidth + CapsuleCloseWidth,
+                    previewWidth),
+                Math.Max(
+                    PaperLayoutDefaults.CapsuleHeight,
+                    previewHeight));
+        }
 
         var restingOpacity =
             _controller.State.ExperimentalRestingCapsuleOpacity

--- a/src/PaperWindow.EdgeCapsulePreview.cs
+++ b/src/PaperWindow.EdgeCapsulePreview.cs
@@ -305,17 +305,13 @@ public sealed partial class PaperWindow
         return false;
     }
 
-    // Descriptor sizing is presentation capacity, not preview content. Resolve it while
-    // the capsule is being attached so the very first docked HWND owns a bounded useful capacity.
-    // Built-ins use their renderer envelope, Web uses declared/fallback bounds, and a loaded Native
-    // session reserves its current Preferred Size. A later Native growth is constrained to the
-    // current host generation and remembered for the next safe first-show generation.
+    // Descriptor sizing is presentation capacity, not preview content. Resolve an initial useful
+    // capacity while the capsule is being attached. Later title/plugin/mini growth may resize the
+    // live host; only an active queue-proxy transaction temporarily holds its source capacity stable.
     private void ReserveEdgeCapsulePreviewCapacityBeforeFirstShow()
     {
-        // This method owns only the immutable first-show capacity generation. Hot queue
-        // placement must not repeatedly Describe every visible paper just to rediscover that
-        // its already-bounded Host cannot grow. Preview open still validates the requested
-        // descriptor through PrepareEdgeCapsuleHostCapacity.
+        // This warmup avoids repeatedly describing every visible paper during hot queue placement.
+        // Preview open still validates the fresh descriptor and may grow the host when no proxy owns it.
         if (_edgeCapsuleHost?.IsVisible == true)
         {
             return;
@@ -330,6 +326,8 @@ public sealed partial class PaperWindow
         {
             return;
         }
+
+        ScheduleEdgeCapsuleCompositionPrewarm();
 
         var generation = _bodySessionGeneration;
         IEdgeCapsulePreviewProvider? provider = null;
@@ -419,8 +417,8 @@ public sealed partial class PaperWindow
         catch (Exception ex)
         {
             // Capacity warmup is opportunistic. Opening still performs a fresh descriptor read;
-            // an oversized late Native request degrades to current Host capacity instead of
-            // disabling preview and is remembered for a future safe Host generation.
+            // a larger request may resize the live host, or temporarily use the current capacity
+            // when a queue proxy is already retaining that HWND as its live source.
             EdgeCapsulePerformanceDiagnostics.Trace(
                 $"preview.capacity.reserve-fail paper={EdgeCapsulePerformanceDiagnostics.ShortId(_paper.Id)} " +
                 $"provider={provider?.GetType().Name ?? "<unresolved>"} " +
@@ -463,7 +461,7 @@ public sealed partial class PaperWindow
         {
             EdgeCapsulePerformanceDiagnostics.Trace(
                 $"preview.open.reject paper={EdgeCapsulePerformanceDiagnostics.ShortId(_paper.Id)} " +
-                "reason=visible-host-capacity-growth");
+                "reason=active-proxy-capacity-growth");
             return false;
         }
 
@@ -967,10 +965,33 @@ public sealed partial class PaperWindow
             !frame.InteractiveBounds.IsEmpty;
     }
 
+    private void ScheduleEdgeCapsuleCompositionPrewarm()
+    {
+        if (!_controller.State.ExperimentalEdgeCapsuleHoverPreview ||
+            _windowLifecycle != PaperWindowLifecycleState.Alive ||
+            IsClosed)
+        {
+            return;
+        }
+
+        _ = Dispatcher.BeginInvoke(
+            DispatcherPriority.ApplicationIdle,
+            (Action)(() =>
+            {
+                if (_controller.State.ExperimentalEdgeCapsuleHoverPreview &&
+                    _windowLifecycle == PaperWindowLifecycleState.Alive &&
+                    !IsClosed)
+                {
+                    EdgeCapsuleQueueCompositionProxy.PrewarmLightweight(Dispatcher);
+                }
+            }));
+    }
+
     internal void RefreshEdgeCapsuleHoverIntentSettings()
     {
         if (_controller.State.ExperimentalEdgeCapsuleHoverPreview)
         {
+            ScheduleEdgeCapsuleCompositionPrewarm();
             ScheduleMigratedPluginBodyPreviewWarmup();
         }
         else

--- a/src/PaperWindow.EdgeCapsuleRecovery.cs
+++ b/src/PaperWindow.EdgeCapsuleRecovery.cs
@@ -1,0 +1,139 @@
+using System.Diagnostics;
+using System.Windows.Threading;
+
+namespace PaperTodo;
+
+public sealed partial class PaperWindow
+{
+    // Presenter apply retry is intentionally bounded at 120 ms. Wait past that window before
+    // restoring the last presenter-confirmed frame so transient native/WPF failures still use the
+    // normal reconcile path and this remains a terminal safety net rather than a second scheduler.
+    private const int EdgeCapsuleApplyFailureRecoveryDelayMilliseconds = 160;
+
+    private DispatcherTimer? _edgeCapsuleApplyFailureRecoveryTimer;
+    private bool _edgeCapsuleApplyFailureRecoveryRunning;
+
+    private void ScheduleEdgeCapsuleApplyFailureRecovery()
+    {
+        if (_windowLifecycle != PaperWindowLifecycleState.Alive || IsClosed)
+        {
+            return;
+        }
+
+        if (_edgeCapsuleApplyFailureRecoveryTimer == null)
+        {
+            var dispatcher = _edgeCapsuleHost?.Dispatcher ?? Dispatcher;
+            _edgeCapsuleApplyFailureRecoveryTimer =
+                new DispatcherTimer(DispatcherPriority.Send, dispatcher)
+                {
+                    Interval = TimeSpan.FromMilliseconds(
+                        EdgeCapsuleApplyFailureRecoveryDelayMilliseconds)
+                };
+            _edgeCapsuleApplyFailureRecoveryTimer.Tick +=
+                OnEdgeCapsuleApplyFailureRecoveryTimerTick;
+        }
+
+        RestartEdgeCapsuleApplyFailureRecoveryTimer();
+    }
+
+    private void RestartEdgeCapsuleApplyFailureRecoveryTimer()
+    {
+        var timer = _edgeCapsuleApplyFailureRecoveryTimer;
+        if (timer == null)
+        {
+            return;
+        }
+
+        timer.Stop();
+        timer.Interval = TimeSpan.FromMilliseconds(
+            EdgeCapsuleApplyFailureRecoveryDelayMilliseconds);
+        timer.Start();
+    }
+
+    private void OnEdgeCapsuleApplyFailureRecoveryTimerTick(
+        object? sender,
+        EventArgs e)
+    {
+        _edgeCapsuleApplyFailureRecoveryTimer?.Stop();
+        if (_edgeCapsuleApplyFailureRecoveryRunning ||
+            _windowLifecycle != PaperWindowLifecycleState.Alive ||
+            IsClosed ||
+            _edgeCapsuleHost is not { } host)
+        {
+            return;
+        }
+
+        var authority = CurrentEdgeCapsuleVisualAuthority;
+        if (authority == EdgeCapsuleVisualAuthority.QueueTranslation)
+        {
+            // The compositor still covers this HWND. Let its bounded handoff finish before touching
+            // the real host; the source must keep the same capacity for the entire translation.
+            RestartEdgeCapsuleApplyFailureRecoveryTimer();
+            return;
+        }
+        if (authority != EdgeCapsuleVisualAuthority.RealDocked)
+        {
+            // Floating/docking overlap currently owns visible pixels. Its normal terminal handoff
+            // will either restore the docked host or schedule a fresh recovery on apply failure.
+            return;
+        }
+
+        // Hidden/retracted/suppressed surfaces have another visual authority by design. The safety
+        // net is only for a real docked capsule that should still be visible after apply retries.
+        var confirmed = _edgeCapsule.AppliedPresentation;
+        if (!confirmed.Visible ||
+            confirmed.Surface is not (
+                EdgeCapsuleSurfaceKind.DockedResting or
+                EdgeCapsuleSurfaceKind.DockedHovered or
+                EdgeCapsuleSurfaceKind.DockedActive or
+                EdgeCapsuleSurfaceKind.DockedPreview) ||
+            host.MatchesPresentation(confirmed))
+        {
+            return;
+        }
+
+        _edgeCapsuleApplyFailureRecoveryRunning = true;
+        try
+        {
+            if (host.Apply(confirmed))
+            {
+                // Re-arm the presenter's bounded retry budget for the next real invalidation. The
+                // restored frame is already the presenter's last committed frame, so no state is
+                // rewritten and no additional reconcile is required here.
+                _edgeCapsule.ForceApplyCurrentPresentation();
+#if DEBUG
+                EdgeCapsulePerformanceDiagnostics.Trace(
+                    $"host.recovery paper={EdgeCapsulePerformanceDiagnostics.ShortId(_paper.Id)} " +
+                    $"outcome=restored surface={confirmed.Surface}");
+#endif
+                return;
+            }
+        }
+        finally
+        {
+            _edgeCapsuleApplyFailureRecoveryRunning = false;
+        }
+
+        if (CurrentEdgeCapsuleVisualAuthority !=
+            EdgeCapsuleVisualAuthority.RealDocked)
+        {
+            // Host.Apply can synchronously dispatch native messages. If a new authority appeared
+            // while it was failing, do not tear that owner down from the recovery callback.
+            if (CurrentEdgeCapsuleVisualAuthority ==
+                EdgeCapsuleVisualAuthority.QueueTranslation)
+            {
+                RestartEdgeCapsuleApplyFailureRecoveryTimer();
+            }
+            return;
+        }
+
+        // The real docked HWND could not even restore the last presenter-confirmed frame. Prefer a
+        // visible expanded paper over leaving an opacity-zero capsule indefinitely.
+        Trace.TraceWarning(
+            "Edge capsule terminal apply recovery failed. Paper={0}; Surface={1}. " +
+            "Restoring the expanded paper surface.",
+            _paper.Id,
+            confirmed.Surface);
+        RestoreFromCapsuleAfterEligibilityLoss();
+    }
+}


### PR DESCRIPTION
## Summary
- allow bounded edge host capacity to grow when no queue proxy retains the live source
- add terminal recovery for exhausted docked-host apply failures without introducing a second geometry authority
- bound normal queue-proxy completion retries before entering the existing cover-loss/source-reveal path
- avoid DComp prewarm in MCP bridge mode

## Review
Reviewed against the repository architecture/decision constraints and the strict maintainability review bar. Recovery remains a terminal safety net over Presenter-confirmed frames; queue translation authority is respected and no duplicate edge geometry/state model is introduced.