### PR TITLE
Align Markdown parsing and UI culture usage

### DIFF
--- a/md-sample.md
+++ b/md-sample.md
@@ -7,7 +7,7 @@ This note covers the Markdown styles currently handled by PaperTodo's AvalonEdit
 ~~Strikethrough text~~.
 Nested styles: **_bold italic_**, _**italic bold**_, and ~~**bold strike**~~.
 A styled link label: [**PaperTodo**](https://github.com/testsnow0722/todoc).
-Escaped syntax stays literal: \*not italic\*, \**not bold**, and \[not a link](https://example.com).
+Escaped syntax stays literal: \*not italic\*, \*\*not bold\*\*, and \[not a link](https://example.com).
 `inline code` keeps a code background; \`not code\` stays literal.
 A link label is highlighted: [PaperTodo](https://github.com/testsnow0722/todoc).
 ---

--- a/src/AppController.Plugins.cs
+++ b/src/AppController.Plugins.cs
@@ -394,7 +394,7 @@ public sealed partial class AppController
         var editor = new TextBox
         {
             Text = current.TryGetDouble(out var number)
-                ? number.ToString("G", CultureInfo.CurrentCulture)
+                ? number.ToString("G", UiLanguages.EffectiveCulture)
                 : "0",
             Width = string.IsNullOrWhiteSpace(setting.Suffix) ? 112 : 86,
             MinHeight = 27,
@@ -417,7 +417,7 @@ public sealed partial class AppController
             if (!TryParsePluginNumber(editor.Text, out var parsed))
             {
                 var stored = _paperBodyPlugins.DataStore.GetSettingValue(descriptor, setting);
-                editor.Text = stored.GetDouble().ToString("G", CultureInfo.CurrentCulture);
+                editor.Text = stored.GetDouble().ToString("G", UiLanguages.EffectiveCulture);
                 return;
             }
 
@@ -425,7 +425,7 @@ public sealed partial class AppController
                 descriptor,
                 setting,
                 JsonSerializer.SerializeToElement(parsed));
-            editor.Text = normalized.GetDouble().ToString("G", CultureInfo.CurrentCulture);
+            editor.Text = normalized.GetDouble().ToString("G", UiLanguages.EffectiveCulture);
         };
         panel.Children.Add(editor);
         if (!string.IsNullOrWhiteSpace(setting.Suffix))
@@ -677,7 +677,7 @@ public sealed partial class AppController
         var parsed = double.TryParse(
                 text,
                 NumberStyles.Float,
-                CultureInfo.CurrentCulture,
+                UiLanguages.EffectiveCulture,
                 out value) ||
             double.TryParse(
                 text,

--- a/src/AppController.Shortcuts.cs
+++ b/src/AppController.Shortcuts.cs
@@ -856,7 +856,7 @@ public sealed partial class AppController
         {
             var formatted = new FormattedText(
                 text,
-                CultureInfo.CurrentUICulture,
+                UiLanguages.EffectiveUiCulture,
                 FlowDirection.LeftToRight,
                 new Typeface(AppTypography.UiFontFamily, FontStyles.Normal, weight, FontStretches.Normal),
                 fontSize,

--- a/src/AppTypography.cs
+++ b/src/AppTypography.cs
@@ -21,7 +21,7 @@ public static class AppTypography
     private static double _scale = 1.0;
 
     public static XmlLanguage Language =>
-        XmlLanguage.GetLanguage(CultureInfo.CurrentUICulture.IetfLanguageTag);
+        XmlLanguage.GetLanguage(UiLanguages.EffectiveUiCulture.IetfLanguageTag);
 
     public static FontFamily UiFontFamily => _customFontFace?.Family ?? ResolveUiFontFamily();
 
@@ -185,8 +185,8 @@ public static class AppTypography
 
     private static FontFamily DefaultBodyFontFamily()
     {
-        var cultureName = CultureInfo.CurrentUICulture.Name;
-        var language = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+        var cultureName = UiLanguages.EffectiveUiCulture.Name;
+        var language = UiLanguages.EffectiveUiCulture.TwoLetterISOLanguageName;
 
         return language switch
         {
@@ -268,7 +268,7 @@ public static class AppTypography
 
     private static string PreferredFamilyName(GlyphTypeface glyphTypeface)
     {
-        var culture = CultureInfo.CurrentUICulture;
+        var culture = UiLanguages.EffectiveUiCulture;
         if (glyphTypeface.Win32FamilyNames.TryGetValue(culture, out var localized))
         {
             return localized;

--- a/src/EdgeCapsulePreview.Markdown.cs
+++ b/src/EdgeCapsulePreview.Markdown.cs
@@ -148,12 +148,29 @@ internal static partial class MarkdownEdgeCapsulePreviewRenderer
 
     public static string MeasureText(string? markdown)
     {
-        return string.Join(
-            Environment.NewLine,
-            NormalizeLines(markdown)
-                .Where(line => !string.IsNullOrWhiteSpace(line.Text))
-                .Take(MaximumMeasuredLines)
-                .Select(line => CompactText(MarkdownInlineSyntax.Unescape(StripBlockPrefix(line.Text)))));
+        var measured = new List<string>();
+        var fencedCodeState = default(MarkdownFencedCodeState);
+        foreach (var previewLine in NormalizeLines(markdown).Take(MaximumMeasuredLines))
+        {
+            var original = previewLine.Text;
+            var wasInsideFence = fencedCodeState.IsInside;
+            var fenceKind = MarkdownFencedCodeScanner.ClassifyLine(
+                original,
+                fencedCodeState,
+                out fencedCodeState);
+            if (fenceKind is MarkdownFenceLineKind.Opening or MarkdownFenceLineKind.Closing ||
+                string.IsNullOrWhiteSpace(original))
+            {
+                continue;
+            }
+
+            var text = wasInsideFence
+                ? original.TrimEnd()
+                : PrepareInlineTextForMeasurement(StripBlockPrefix(original));
+            measured.Add(CompactText(text));
+        }
+
+        return string.Join(Environment.NewLine, measured);
     }
 
     public static int EstimateVisualLines(string? markdown, double widthDip)
@@ -182,14 +199,18 @@ internal static partial class MarkdownEdgeCapsulePreviewRenderer
             {
                 estimate += 1;
             }
-            else if (trimmed.Length == 0 || HorizontalRulePattern.IsMatch(trimmed))
+            else if (trimmed.Length == 0 ||
+                     (!wasInsideFence && HorizontalRulePattern.IsMatch(trimmed)))
             {
                 estimate += 1;
             }
             else
             {
+                var measurementText = wasInsideFence
+                    ? raw.TrimEnd()
+                    : PrepareInlineTextForMeasurement(StripBlockPrefix(trimmed));
                 var lines = EdgeCapsulePreviewMeasure.EstimateWrappedLines(
-                    MarkdownInlineSyntax.Unescape(StripBlockPrefix(trimmed)),
+                    measurementText,
                     widthDip);
                 estimate += wasInsideFence ? Math.Min(3, lines) : Math.Min(4, lines);
             }
@@ -655,6 +676,39 @@ internal static partial class MarkdownEdgeCapsulePreviewRenderer
         }
         target.Append(value);
         return truncated;
+    }
+
+    private static string PrepareInlineTextForMeasurement(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        var builder = new StringBuilder(text.Length);
+        var cursor = 0;
+        while (cursor < text.Length)
+        {
+            var start = MarkdownInlineSyntax.IndexOfUnescaped(text, '`', cursor);
+            if (start < 0)
+            {
+                builder.Append(MarkdownInlineSyntax.Unescape(text[cursor..]));
+                break;
+            }
+
+            var end = MarkdownInlineSyntax.IndexOfUnescaped(text, '`', start + 1);
+            if (end < 0)
+            {
+                builder.Append(MarkdownInlineSyntax.Unescape(text[cursor..]));
+                break;
+            }
+
+            builder.Append(MarkdownInlineSyntax.Unescape(text[cursor..start]));
+            builder.Append(text.AsSpan(start + 1, end - start - 1));
+            cursor = end + 1;
+        }
+
+        return builder.ToString();
     }
 
     private static string CompactText(string value) =>

--- a/src/MarkdownInlineSyntax.cs
+++ b/src/MarkdownInlineSyntax.cs
@@ -82,17 +82,7 @@ internal static class MarkdownInlineSyntax
             }
 
             chars ??= text.ToCharArray();
-            // Deliberately mask the whole delimiter run when its first punctuation is escaped.
-            // PaperTodo treats \**text** as literal Markdown markers rather than parsing the
-            // remaining asterisk as the start of emphasis.
-            var marker = text[i];
-            do
-            {
-                chars[i] = MaskedPunctuation;
-                i++;
-            }
-            while (i < text.Length && text[i] == marker);
-            i--;
+            chars[i] = MaskedPunctuation;
         }
         return chars == null ? text : new string(chars);
     }

--- a/src/MarkdownTextBox.cs
+++ b/src/MarkdownTextBox.cs
@@ -3807,7 +3807,7 @@ public sealed partial class MarkdownTextBox : TextEditor
 
         while (search < text.Length)
         {
-            var start = text.IndexOf("</", search, StringComparison.Ordinal);
+            var start = MarkdownInlineSyntax.IndexOfUnescaped(text, "</", search);
             if (start < 0)
             {
                 return false;
@@ -4163,7 +4163,7 @@ public sealed partial class MarkdownTextBox : TextEditor
                     {
                         var formatted = new FormattedText(
                             text.Substring(markerStart, markerLength),
-                            CultureInfo.CurrentUICulture,
+                            UiLanguages.EffectiveUiCulture,
                             FlowDirection.LeftToRight,
                             ListMarkerTypeface,
                             _owner.ScaledFontSize(NoteTypography.FontSize),

--- a/src/MasterCapsuleWindow.cs
+++ b/src/MasterCapsuleWindow.cs
@@ -450,7 +450,7 @@ public sealed class MasterCapsuleWindow : Window
     {
         _glyph.Text = _active ? "▸" : "▾";
         _label.Text = _active
-            ? string.Format(CultureInfo.CurrentUICulture, Strings.Get("CapsuleCollapseAllCountFormat"), _count)
+            ? string.Format(UiLanguages.EffectiveCulture, Strings.Get("CapsuleCollapseAllCountFormat"), _count)
             : Strings.Get("CapsuleCollapseAllLabel");
         _pill.ToolTip = _active
             ? Strings.Get("CapsuleCollapseAllCollapsedTip")
@@ -608,7 +608,7 @@ public sealed class MasterCapsuleWindow : Window
         {
             var formatted = new FormattedText(
                 text,
-                CultureInfo.CurrentUICulture,
+                UiLanguages.EffectiveUiCulture,
                 FlowDirection.LeftToRight,
                 new Typeface(fontFamily, FontStyles.Normal, weight, FontStretches.Normal),
                 fontSize,

--- a/src/PaperBodyPluginRegistry.cs
+++ b/src/PaperBodyPluginRegistry.cs
@@ -86,6 +86,8 @@ internal sealed partial class PaperBodyPluginRegistry : IDisposable
     internal const string SupportedPluginApiVersion = "1.8";
     internal const string MinimumPluginApiVersion = "1.8";
     private static readonly Regex PluginIdPattern = PluginIdRegex();
+    private static readonly StringComparer UiDisplayNameComparer =
+        StringComparer.Create(UiLanguages.EffectiveUiCulture, ignoreCase: true);
     private static readonly JsonSerializerOptions ManifestJsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
@@ -118,7 +120,7 @@ internal sealed partial class PaperBodyPluginRegistry : IDisposable
     public IReadOnlyList<PaperBodyPluginDescriptor> Descriptors =>
         _descriptors.Values
             .OrderBy(item => item.Kind)
-            .ThenBy(item => item.DisplayName, StringComparer.CurrentCultureIgnoreCase)
+            .ThenBy(item => item.DisplayName, UiDisplayNameComparer)
             .ToArray();
 
     public IReadOnlyList<PaperBodyPluginLoadIssue> Issues => _issues.ToArray();

--- a/src/PaperWindow.Reminders.cs
+++ b/src/PaperWindow.Reminders.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -306,7 +305,7 @@ public sealed partial class PaperWindow
                 "TodoReminderSetForFormat",
                 reminderAt.ToLocalTime().ToString(
                     "g",
-                    CultureInfo.CurrentCulture))
+                    UiLanguages.EffectiveCulture))
             : Strings.Get("TodoReminderSet");
     }
 
@@ -433,7 +432,7 @@ public sealed partial class PaperWindow
                     "TodoReminderPresetAtFormat",
                     evening.ToLocalTime().ToString(
                         "ddd HH:mm",
-                        CultureInfo.CurrentCulture)),
+                        UiLanguages.EffectiveCulture)),
                 (_, _) => QueueTodoReminderChange(itemId, evening)));
         }
 
@@ -448,7 +447,7 @@ public sealed partial class PaperWindow
                     "TodoReminderPresetAtFormat",
                     morning.ToLocalTime().ToString(
                         "ddd HH:mm",
-                        CultureInfo.CurrentCulture)),
+                        UiLanguages.EffectiveCulture)),
                 (_, _) => QueueTodoReminderChange(itemId, morning)));
         }
 

--- a/src/PaperWindow.cs
+++ b/src/PaperWindow.cs
@@ -3539,7 +3539,7 @@ public sealed partial class PaperWindow : Window
         {
             var formatted = new FormattedText(
                 text,
-                CultureInfo.CurrentUICulture,
+                UiLanguages.EffectiveUiCulture,
                 FlowDirection.LeftToRight,
                 new Typeface(fontFamily, FontStyles.Normal, weight, FontStretches.Normal),
                 fontSize,

--- a/src/StateJsonReadPolicy.cs
+++ b/src/StateJsonReadPolicy.cs
@@ -1,0 +1,15 @@
+using System.Text.Json;
+
+namespace PaperTodo;
+
+internal static class StateJsonReadPolicy
+{
+    public const JsonCommentHandling CommentHandling = JsonCommentHandling.Skip;
+    public const bool AllowTrailingCommas = true;
+
+    public static JsonDocumentOptions DocumentOptions => new()
+    {
+        CommentHandling = CommentHandling,
+        AllowTrailingCommas = AllowTrailingCommas
+    };
+}

--- a/src/StateStore.cs
+++ b/src/StateStore.cs
@@ -11,8 +11,8 @@ public sealed class StateStore
     {
         WriteIndented = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-        AllowTrailingCommas = true,
+        ReadCommentHandling = StateJsonReadPolicy.CommentHandling,
+        AllowTrailingCommas = StateJsonReadPolicy.AllowTrailingCommas,
         // Tolerate unknown properties so configs written by older / experimental builds (e.g.
         // retired deepCapsuleDock* fields) still load instead of crashing on startup. The Strict
         // preset otherwise sets Disallow, which makes any removed/renamed field fatal.

--- a/src/TodoReminderDialog.cs
+++ b/src/TodoReminderDialog.cs
@@ -320,7 +320,7 @@ internal static class TodoReminderDialog
                     out value) ||
                 DateTime.TryParse(
                     dateInput.Text.Trim(),
-                    CultureInfo.CurrentCulture,
+                    UiLanguages.EffectiveCulture,
                     DateTimeStyles.AllowWhiteSpaces,
                     out value);
         }

--- a/src/UiLanguages.cs
+++ b/src/UiLanguages.cs
@@ -26,6 +26,8 @@ public static class UiLanguages
     private static readonly string StartupPreference = LoadPersistedPreferenceCore();
 
     // Intentionally fixed for the process lifetime; a settings change takes effect after restart.
+    // EffectiveCulture owns user-visible number/date formatting and parsing; EffectiveUiCulture
+    // owns resource lookup plus WPF language/shaping. Persistence and protocols choose explicitly.
     public static CultureInfo EffectiveCulture { get; } =
         ResolveCulture(StartupPreference, SystemCulture);
 
@@ -53,7 +55,9 @@ public static class UiLanguages
 
             try
             {
-                using var document = JsonDocument.Parse(File.ReadAllText(path));
+                using var document = JsonDocument.Parse(
+                    File.ReadAllText(path),
+                    StateJsonReadPolicy.DocumentOptions);
                 if (document.RootElement.TryGetProperty("uiLanguage", out var value) &&
                     value.ValueKind == JsonValueKind.String)
                 {

--- a/src/VectorIconElements.cs
+++ b/src/VectorIconElements.cs
@@ -504,7 +504,7 @@ internal sealed class VectorGlyphElement : FrameworkElement
     {
         return new FormattedText(
             _text,
-            CultureInfo.CurrentUICulture,
+            UiLanguages.EffectiveUiCulture,
             FlowDirection.LeftToRight,
             new Typeface(
                 _fontFamily,


### PR DESCRIPTION
## Summary
- keep UI/resource/typography behavior pinned to the configured startup culture instead of ambient Dispatcher/ExecutionContext culture
- share tolerant state JSON read options with startup language preference loading
- align Edge Markdown preview escaping with standard single-character backslash escapes
- keep fenced-code measurement/rendering isolated from ordinary Markdown block/inline parsing

## Review
Reviewed against current `main` after PR #111. The Markdown escape change is intentional standard-syntax behavior rather than preserving the earlier PaperTodo delimiter-run special case. Culture changes distinguish effective formatting culture from effective UI/resource culture and keep protocol/persistence parsing explicit.