### PR TITLE
refactor(plugin): harden protocol 2.0 ownership

### DIFF
--- a/.github/workflows/plugin-samples.yml
+++ b/.github/workflows/plugin-samples.yml
@@ -6,6 +6,15 @@ on:
       - "PaperTodo.Plugin.Abstractions/**"
       - "plugin-samples/**"
       - "plugins/**"
+      - "tests/PaperTodo.ProtocolPolicyChecks/**"
+      - "PaperTodo.csproj"
+      - "src/AppController.Plugin*.cs"
+      - "src/AppController.Shortcuts.cs"
+      - "src/GlobalHotkeys.cs"
+      - "src/PaperBodyPlugin*.cs"
+      - "src/PaperWindow.Plugin*.cs"
+      - "src/WebPaperBodySession*.cs"
+      - "src/WebPlugin*.cs"
       - ".github/workflows/plugin-samples.yml"
   push:
     branches:
@@ -14,6 +23,15 @@ on:
       - "PaperTodo.Plugin.Abstractions/**"
       - "plugin-samples/**"
       - "plugins/**"
+      - "tests/PaperTodo.ProtocolPolicyChecks/**"
+      - "PaperTodo.csproj"
+      - "src/AppController.Plugin*.cs"
+      - "src/AppController.Shortcuts.cs"
+      - "src/GlobalHotkeys.cs"
+      - "src/PaperBodyPlugin*.cs"
+      - "src/PaperWindow.Plugin*.cs"
+      - "src/WebPaperBodySession*.cs"
+      - "src/WebPlugin*.cs"
       - ".github/workflows/plugin-samples.yml"
 
 permissions:
@@ -30,6 +48,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+
+      - name: Build PaperTodo plugin host
+        shell: pwsh
+        run: dotnet build .\PaperTodo.csproj -c Release
+
+      - name: Run protocol policy checks
+        shell: pwsh
+        run: dotnet run --project .\tests\PaperTodo.ProtocolPolicyChecks\PaperTodo.ProtocolPolicyChecks.csproj -c Release
 
       - name: Validate plugin manifests
         shell: pwsh

--- a/.github/workflows/plugin-samples.yml
+++ b/.github/workflows/plugin-samples.yml
@@ -43,6 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           submodules: recursive
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/plugin-samples.yml
+++ b/.github/workflows/plugin-samples.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "10.0.x"

--- a/PaperTodo.Plugin.Abstractions/PaperAppRuntimeContracts.cs
+++ b/PaperTodo.Plugin.Abstractions/PaperAppRuntimeContracts.cs
@@ -35,6 +35,13 @@ public interface IPaperGlobalShortcutApi
 /// Context for one provider-level runtime. The runtime exists while PaperTodo has at least one real
 /// Note paper whose BodyProviderId is this plugin. It does not depend on that paper being visible,
 /// expanded, or having a live body session.
+///
+/// Native app runtimes may call Workspace / GlobalTopBar / GlobalShortcuts from worker threads;
+/// PaperTodo marshals those host operations to its UI dispatcher when required. Those calls are
+/// synchronous from the plugin's point of view. A runtime therefore must not block its Dispose
+/// implementation waiting for a worker that can itself be blocked inside one of these host calls,
+/// otherwise the UI thread and worker can deadlock during shutdown. Keep host calls short and make
+/// worker shutdown cancellation-based rather than UI-thread join-based.
 /// </summary>
 public sealed class PaperAppRuntimeContext
 {
@@ -59,7 +66,9 @@ public interface IPaperAppRuntimeProvider
 
 /// <summary>
 /// One provider-level plugin runtime. It is not a hidden paper session and owns no Paper/Body/Mini
-/// presentation. Dispose ends the runtime and revokes its provider-level contributions.
+/// presentation. Dispose ends the runtime and revokes its provider-level contributions. Native
+/// implementations are disposed from PaperTodo's UI-owned runtime lifecycle; Dispose must return
+/// promptly and must not synchronously join workers that may call back into PaperTodo host APIs.
 /// </summary>
 public interface IPaperAppRuntime : IDisposable
 {

--- a/PaperTodo.csproj
+++ b/PaperTodo.csproj
@@ -27,7 +27,7 @@
     <PaperTodoLmdbLibrary>$(MSBuildProjectDirectory)\native\lmdb\bin\win-x64\papertodo_lmdb.dll</PaperTodoLmdbLibrary>
     <OutputPath>$(MSBuildProjectDirectory)\输出\PaperTodo-v$(Version)\</OutputPath>
     <SatelliteResourceLanguages>en;ja;ko</SatelliteResourceLanguages>
-    <DefaultItemExcludes>$(DefaultItemExcludes);对比_StickyMD\**;输出\**;PaperTodo_v*\**;.codex_decompile_debug\**;PaperTodo.Plugin.Abstractions\**;plugin-samples\**;plugins\**\.runtime\**;plugins\data\**;vendor\**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);对比_StickyMD\**;输出\**;PaperTodo_v*\**;.codex_decompile_debug\**;PaperTodo.Plugin.Abstractions\**;plugin-samples\**;plugins\**\.runtime\**;plugins\data\**;tests\**;vendor\**</DefaultItemExcludes>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(PaperTodoDefaultEnglish)' == 'true'">

--- a/src/AppController.PluginAppRuntime.cs
+++ b/src/AppController.PluginAppRuntime.cs
@@ -15,6 +15,16 @@ public sealed partial class AppController
         TimeSpan.FromSeconds(10)
     ];
 
+    private enum PluginAppRuntimeState
+    {
+        Stopped,
+        Starting,
+        Running,
+        Backoff,
+        Failed,
+        Disposing
+    }
+
     private sealed class PluginAppRuntimeLifetime
     {
         public bool Active { get; set; } = true;
@@ -22,6 +32,18 @@ public sealed partial class AppController
 
     private sealed class PluginAppRuntimeOwnershipCanceledException(string message)
         : Exception(message);
+
+    private sealed class PluginAppRuntimeSlot
+    {
+        public required string ProviderId { get; init; }
+        public PaperBodyPluginDescriptor? Descriptor { get; set; }
+        public PluginAppRuntimeState State { get; set; }
+        public Guid RuntimeId { get; set; }
+        public PluginAppRuntimeLease? Lease { get; set; }
+        public int FailureCount { get; set; }
+        public int RetryGeneration { get; set; }
+        public bool RestartRequested { get; set; }
+    }
 
     private sealed class PluginAppRuntimeLease : IDisposable
     {
@@ -40,6 +62,7 @@ public sealed partial class AppController
             {
                 return;
             }
+
             Lifetime.Active = false;
             try { Runtime?.Dispose(); } catch { }
             try { GlobalShortcuts.Dispose(); } catch { }
@@ -52,27 +75,17 @@ public sealed partial class AppController
         }
     }
 
-    private readonly Dictionary<string, PluginAppRuntimeLease> _pluginAppRuntimes =
+    // One provider, one authoritative lifecycle record. Starting/running/backoff/failure/restart
+    // state must never be inferred by combining several parallel dictionaries or hash sets.
+    private readonly Dictionary<string, PluginAppRuntimeSlot> _pluginAppRuntimeSlots =
         new(StringComparer.Ordinal);
-    private readonly HashSet<string> _pluginAppRuntimeStarts =
-        new(StringComparer.Ordinal);
-    private readonly HashSet<string> _pluginAppRuntimeStartFailures =
-        new(StringComparer.Ordinal);
-    private readonly Dictionary<string, int> _pluginAppRuntimeStartFailureCounts =
-        new(StringComparer.Ordinal);
-    private readonly Dictionary<string, int> _pluginAppRuntimeRetryTokens =
-        new(StringComparer.Ordinal);
-    private readonly Dictionary<string, Guid> _pluginAppRuntimeRestartRequests =
-        new(StringComparer.Ordinal);
-    private int _pluginAppRuntimeNextRetryToken;
     private bool _pluginAppRuntimeReconciliationEnabled;
     private bool _pluginAppRuntimeDisposing;
 
     /// <summary>
-    /// Enables process-level plugin runtimes only after startupPaper handling has settled. From this
-    /// point on, the final State.Papers provider set is the authority: 0 -> 1 entity paper starts the
-    /// provider runtime and 1 -> 0 stops it. Paper visibility/presentation/body-session state is not
-    /// part of this lifetime decision.
+    /// Enables provider-level runtimes only after startupPaper handling has settled. From this point
+    /// the final entity-paper set is the authority: provider 0 -> 1 starts a runtime and 1 -> 0 ends
+    /// it. Visibility, folding and live body-session state do not own this lifetime.
     /// </summary>
     internal void EnablePluginAppRuntimeReconciliation()
     {
@@ -81,11 +94,10 @@ public sealed partial class AppController
             return;
         }
 
-        // Host-owned paper.* shortcuts do not require a live appRuntime. Register them when plugin
-        // startup ownership becomes authoritative; custom actions are activated later by their
-        // provider runtime's GlobalShortcuts handler.
-        RefreshPluginShortcuts();
         _pluginAppRuntimeReconciliationEnabled = true;
+        // paper.* shortcuts depend on entity-paper ownership but not on appRuntime. Rebuild the
+        // unified shortcut plan as soon as entity ownership becomes authoritative.
+        RefreshPluginShortcuts();
         ReconcilePluginAppRuntimes();
     }
 
@@ -102,42 +114,42 @@ public sealed partial class AppController
             .Where(DeclaresPluginAppRuntime)
             .Where(descriptor => HasEntityPluginPaper(descriptor.Id))
             .ToDictionary(descriptor => descriptor.Id, StringComparer.Ordinal);
-        var runtimeSetChanged = false;
+        var statusChanged = false;
 
-        foreach (var providerId in _pluginAppRuntimes.Keys
+        foreach (var providerId in _pluginAppRuntimeSlots.Keys
                      .Where(providerId => !desired.ContainsKey(providerId))
                      .ToArray())
         {
-            var lease = _pluginAppRuntimes[providerId];
-            _pluginAppRuntimes.Remove(providerId);
-            lease.Dispose();
-            ClearPluginAppRuntimeFailureState(providerId);
-            _pluginAppRuntimeRestartRequests.Remove(providerId);
-            runtimeSetChanged = true;
-        }
-
-        foreach (var providerId in _pluginAppRuntimeStartFailures
-                     .Where(providerId => !desired.ContainsKey(providerId))
-                     .ToArray())
-        {
-            ClearPluginAppRuntimeFailureState(providerId);
-            _pluginAppRuntimeRestartRequests.Remove(providerId);
-            runtimeSetChanged = true;
+            RemovePluginAppRuntimeSlot(providerId);
+            statusChanged = true;
         }
 
         foreach (var descriptor in desired.Values)
         {
-            if (_pluginAppRuntimes.ContainsKey(descriptor.Id) ||
-                _pluginAppRuntimeStarts.Contains(descriptor.Id) ||
-                _pluginAppRuntimeStartFailures.Contains(descriptor.Id))
+            if (!_pluginAppRuntimeSlots.TryGetValue(descriptor.Id, out var slot))
             {
-                continue;
+                slot = new PluginAppRuntimeSlot
+                {
+                    ProviderId = descriptor.Id,
+                    Descriptor = descriptor,
+                    State = PluginAppRuntimeState.Stopped
+                };
+                _pluginAppRuntimeSlots.Add(descriptor.Id, slot);
+                statusChanged = true;
             }
-            _pluginAppRuntimeStarts.Add(descriptor.Id);
-            _ = StartPluginAppRuntimeSafelyAsync(descriptor);
+            else
+            {
+                slot.Descriptor = descriptor;
+            }
+
+            if (slot.State == PluginAppRuntimeState.Stopped)
+            {
+                StartPluginAppRuntimeSlot(slot, descriptor);
+                statusChanged = true;
+            }
         }
 
-        if (runtimeSetChanged)
+        if (statusChanged)
         {
             QueuePluginStatusUiRefresh();
         }
@@ -151,119 +163,110 @@ public sealed partial class AppController
                 providerId,
                 StringComparison.Ordinal));
 
-    private async Task StartPluginAppRuntimeSafelyAsync(
+    private bool IsPluginAppRuntimeRunning(string providerId) =>
+        _pluginAppRuntimeSlots.TryGetValue(providerId, out var slot) &&
+        slot.State == PluginAppRuntimeState.Running &&
+        slot.Lease != null;
+
+    private bool HasPluginAppRuntimeFailure(string providerId) =>
+        _pluginAppRuntimeSlots.TryGetValue(providerId, out var slot) &&
+        slot.State is PluginAppRuntimeState.Backoff or PluginAppRuntimeState.Failed;
+
+    private void StartPluginAppRuntimeSlot(
+        PluginAppRuntimeSlot slot,
         PaperBodyPluginDescriptor descriptor)
     {
+        if (slot.State != PluginAppRuntimeState.Stopped ||
+            !IsPluginAppRuntimeDesired(descriptor.Id))
+        {
+            return;
+        }
+
+        slot.State = PluginAppRuntimeState.Starting;
+        slot.Descriptor = descriptor;
+        slot.RuntimeId = Guid.NewGuid();
+        slot.RestartRequested = false;
+        var runtimeId = slot.RuntimeId;
+        _ = StartPluginAppRuntimeSlotAsync(slot, descriptor, runtimeId);
+    }
+
+    private async Task StartPluginAppRuntimeSlotAsync(
+        PluginAppRuntimeSlot slot,
+        PaperBodyPluginDescriptor descriptor,
+        Guid runtimeId)
+    {
+        PluginAppRuntimeLease? lease = null;
         try
         {
-            await StartPluginAppRuntimeAsync(descriptor);
-            ClearPluginAppRuntimeFailureState(descriptor.Id);
+            lease = await CreatePluginAppRuntimeLeaseAsync(
+                slot,
+                descriptor,
+                runtimeId);
+
+            if (!IsCurrentPluginAppRuntimeSlot(slot, runtimeId) ||
+                !IsPluginAppRuntimeDesired(descriptor.Id))
+            {
+                lease.Dispose();
+                lease = null;
+                if (IsCurrentPluginAppRuntimeSlot(slot, runtimeId))
+                {
+                    slot.State = PluginAppRuntimeState.Stopped;
+                    ReconcilePluginAppRuntimes();
+                }
+                return;
+            }
+
+            if (slot.RestartRequested)
+            {
+                lease.Dispose();
+                lease = null;
+                slot.RestartRequested = false;
+                slot.State = PluginAppRuntimeState.Stopped;
+                slot.FailureCount = 0;
+                QueuePluginStatusUiRefresh();
+                ReconcilePluginAppRuntimes();
+                return;
+            }
+
+            slot.Lease = lease;
+            lease = null;
+            slot.State = PluginAppRuntimeState.Running;
+            slot.FailureCount = 0;
+            slot.RetryGeneration++;
             QueuePluginStatusUiRefresh();
         }
         catch (PluginAppRuntimeOwnershipCanceledException)
         {
-            // The last entity paper disappeared, a failed WebView requested a clean replacement,
-            // or PaperTodo began shutting down while startup was in flight. None is a plugin fault.
+            lease?.Dispose();
+            if (!IsCurrentPluginAppRuntimeSlot(slot, runtimeId))
+            {
+                return;
+            }
+
+            slot.RestartRequested = false;
+            slot.State = PluginAppRuntimeState.Stopped;
+            QueuePluginStatusUiRefresh();
+            ReconcilePluginAppRuntimes();
         }
         catch (Exception ex)
         {
-            var failureCount =
-                _pluginAppRuntimeStartFailureCounts.GetValueOrDefault(descriptor.Id) + 1;
-            _pluginAppRuntimeStartFailureCounts[descriptor.Id] = failureCount;
-            _pluginAppRuntimeStartFailures.Add(descriptor.Id);
-            SchedulePluginAppRuntimeRetry(descriptor.Id, failureCount);
-            QueuePluginStatusUiRefresh();
-            Trace.TraceWarning(
-                "Plugin app runtime failed to start. Provider={0}; Attempt={1}; Exception={2}",
-                descriptor.Id,
-                failureCount,
-                ex.GetBaseException());
-        }
-        finally
-        {
-            _pluginAppRuntimeStarts.Remove(descriptor.Id);
-            // 0 -> 1 can occur while an earlier async start is cancelling. Re-evaluate after the
-            // in-flight marker is gone so the new entity paper cannot be stranded without runtime.
-            ReconcilePluginAppRuntimes();
-        }
-    }
-
-    private void SchedulePluginAppRuntimeRetry(string providerId, int failureCount)
-    {
-        var retryIndex = failureCount - 1;
-        if (retryIndex < 0 ||
-            retryIndex >= PluginAppRuntimeRetryDelays.Length ||
-            _pluginAppRuntimeRetryTokens.ContainsKey(providerId) ||
-            !_pluginAppRuntimeReconciliationEnabled ||
-            _pluginAppRuntimeDisposing ||
-            IsExiting ||
-            !HasEntityPluginPaper(providerId))
-        {
-            return;
-        }
-
-        var token = ++_pluginAppRuntimeNextRetryToken;
-        _pluginAppRuntimeRetryTokens[providerId] = token;
-        _ = RetryPluginAppRuntimeAfterDelayAsync(
-            providerId,
-            token,
-            PluginAppRuntimeRetryDelays[retryIndex]);
-    }
-
-    private async Task RetryPluginAppRuntimeAfterDelayAsync(
-        string providerId,
-        int token,
-        TimeSpan delay)
-    {
-        await Task.Delay(delay).ConfigureAwait(false);
-        var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher == null || dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
-        {
-            return;
-        }
-
-        _ = dispatcher.BeginInvoke(
-            (Action)(() =>
+            lease?.Dispose();
+            if (!IsCurrentPluginAppRuntimeSlot(slot, runtimeId))
             {
-                if (!_pluginAppRuntimeRetryTokens.TryGetValue(providerId, out var currentToken) ||
-                    currentToken != token)
-                {
-                    return;
-                }
-                _pluginAppRuntimeRetryTokens.Remove(providerId);
+                return;
+            }
 
-                if (_pluginAppRuntimeDisposing ||
-                    IsExiting ||
-                    !_pluginAppRuntimeReconciliationEnabled ||
-                    !HasEntityPluginPaper(providerId))
-                {
-                    ClearPluginAppRuntimeFailureState(providerId);
-                    return;
-                }
-
-                // Release the failure gate only when its backoff has elapsed. A new failure records
-                // the next attempt and schedules the next bounded delay.
-                _pluginAppRuntimeStartFailures.Remove(providerId);
-                ReconcilePluginAppRuntimes();
-            }),
-            DispatcherPriority.Background);
+            HandlePluginAppRuntimeStartFailure(slot, descriptor, ex);
+        }
     }
 
-    private void ClearPluginAppRuntimeFailureState(string providerId)
+    private async Task<PluginAppRuntimeLease> CreatePluginAppRuntimeLeaseAsync(
+        PluginAppRuntimeSlot slot,
+        PaperBodyPluginDescriptor descriptor,
+        Guid runtimeId)
     {
-        _pluginAppRuntimeStartFailures.Remove(providerId);
-        _pluginAppRuntimeStartFailureCounts.Remove(providerId);
-        // Removing the token also invalidates a delayed retry callback that has not dispatched yet.
-        _pluginAppRuntimeRetryTokens.Remove(providerId);
-    }
-
-    private async Task StartPluginAppRuntimeAsync(PaperBodyPluginDescriptor descriptor)
-    {
-        if (_pluginAppRuntimes.ContainsKey(descriptor.Id) ||
-            !_pluginAppRuntimeReconciliationEnabled ||
-            _pluginAppRuntimeDisposing ||
-            IsExiting ||
-            !HasEntityPluginPaper(descriptor.Id))
+        if (!IsCurrentPluginAppRuntimeSlot(slot, runtimeId) ||
+            !IsPluginAppRuntimeDesired(descriptor.Id))
         {
             throw new PluginAppRuntimeOwnershipCanceledException(
                 "The plugin app runtime no longer has an entity-paper owner.");
@@ -273,10 +276,10 @@ public sealed partial class AppController
         bool IsActive() =>
             lifetime.Active &&
             IsRunning &&
-            _pluginAppRuntimeReconciliationEnabled &&
-            !_pluginAppRuntimeDisposing &&
-            HasEntityPluginPaper(descriptor.Id);
-        var runtimeId = Guid.NewGuid();
+            IsCurrentPluginAppRuntimeSlot(slot, runtimeId) &&
+            slot.State is PluginAppRuntimeState.Starting or PluginAppRuntimeState.Running &&
+            IsPluginAppRuntimeDesired(descriptor.Id);
+
         var workspace = new PaperAppRuntimeWorkspaceApi(
             this,
             descriptor.Id,
@@ -306,6 +309,7 @@ public sealed partial class AppController
                     throw new InvalidOperationException(
                         $"Native plugin '{descriptor.Id}' declares appRuntime but does not implement IPaperAppRuntimeProvider.");
                 }
+
                 runtime = provider.CreateAppRuntime(new PaperAppRuntimeContext
                 {
                     ProviderId = descriptor.Id,
@@ -338,22 +342,10 @@ public sealed partial class AppController
             if (!IsActive())
             {
                 throw new PluginAppRuntimeOwnershipCanceledException(
-                    "The plugin app runtime lost its last entity paper while starting.");
+                    "The plugin app runtime lost its entity-paper owner while starting.");
             }
 
-            if (_pluginAppRuntimeRestartRequests.TryGetValue(
-                    descriptor.Id,
-                    out var requestedRuntimeId))
-            {
-                _pluginAppRuntimeRestartRequests.Remove(descriptor.Id);
-                if (requestedRuntimeId == runtimeId)
-                {
-                    throw new PluginAppRuntimeOwnershipCanceledException(
-                        "The plugin app runtime requested replacement while starting.");
-                }
-            }
-
-            _pluginAppRuntimes.Add(descriptor.Id, new PluginAppRuntimeLease
+            return new PluginAppRuntimeLease
             {
                 RuntimeId = runtimeId,
                 ProviderId = descriptor.Id,
@@ -363,7 +355,7 @@ public sealed partial class AppController
                 GlobalShortcuts = globalShortcuts,
                 Runtime = runtime,
                 NativeFactory = nativeFactory
-            });
+            };
         }
         catch
         {
@@ -380,6 +372,107 @@ public sealed partial class AppController
         }
     }
 
+    private void HandlePluginAppRuntimeStartFailure(
+        PluginAppRuntimeSlot slot,
+        PaperBodyPluginDescriptor descriptor,
+        Exception exception)
+    {
+        slot.Lease = null;
+        slot.RestartRequested = false;
+        slot.FailureCount++;
+        var attempt = slot.FailureCount;
+
+        Trace.TraceWarning(
+            "Plugin app runtime failed to start. Provider={0}; Attempt={1}; Exception={2}",
+            descriptor.Id,
+            attempt,
+            exception.GetBaseException());
+
+        if (attempt <= PluginAppRuntimeRetryDelays.Length &&
+            IsPluginAppRuntimeDesired(descriptor.Id))
+        {
+            slot.State = PluginAppRuntimeState.Backoff;
+            SchedulePluginAppRuntimeRetry(
+                slot,
+                PluginAppRuntimeRetryDelays[attempt - 1]);
+        }
+        else
+        {
+            slot.State = PluginAppRuntimeState.Failed;
+        }
+
+        QueuePluginStatusUiRefresh();
+    }
+
+    private void SchedulePluginAppRuntimeRetry(
+        PluginAppRuntimeSlot slot,
+        TimeSpan delay)
+    {
+        var generation = ++slot.RetryGeneration;
+        _ = RetryPluginAppRuntimeAfterDelayAsync(
+            slot.ProviderId,
+            slot,
+            generation,
+            delay);
+    }
+
+    private async Task RetryPluginAppRuntimeAfterDelayAsync(
+        string providerId,
+        PluginAppRuntimeSlot slot,
+        int generation,
+        TimeSpan delay)
+    {
+        await Task.Delay(delay).ConfigureAwait(false);
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
+        {
+            return;
+        }
+
+        _ = dispatcher.BeginInvoke(
+            (Action)(() =>
+            {
+                if (_pluginAppRuntimeDisposing ||
+                    IsExiting ||
+                    !_pluginAppRuntimeReconciliationEnabled ||
+                    !_pluginAppRuntimeSlots.TryGetValue(providerId, out var current) ||
+                    !ReferenceEquals(current, slot) ||
+                    slot.RetryGeneration != generation ||
+                    slot.State != PluginAppRuntimeState.Backoff)
+                {
+                    return;
+                }
+
+                if (!IsPluginAppRuntimeDesired(providerId))
+                {
+                    ReconcilePluginAppRuntimes();
+                    return;
+                }
+
+                slot.State = PluginAppRuntimeState.Stopped;
+                ReconcilePluginAppRuntimes();
+            }),
+            DispatcherPriority.Background);
+    }
+
+    private bool IsCurrentPluginAppRuntimeSlot(
+        PluginAppRuntimeSlot slot,
+        Guid runtimeId) =>
+        !_pluginAppRuntimeDisposing &&
+        _pluginAppRuntimeReconciliationEnabled &&
+        _pluginAppRuntimeSlots.TryGetValue(slot.ProviderId, out var current) &&
+        ReferenceEquals(current, slot) &&
+        slot.RuntimeId == runtimeId &&
+        slot.State != PluginAppRuntimeState.Disposing;
+
+    private bool IsPluginAppRuntimeDesired(string providerId) =>
+        _pluginAppRuntimeReconciliationEnabled &&
+        !_pluginAppRuntimeDisposing &&
+        !IsExiting &&
+        HasEntityPluginPaper(providerId) &&
+        PaperBodyPlugins.TryGet(providerId, out var descriptor) &&
+        DeclaresPluginAppRuntime(descriptor);
+
     private void RequestPluginAppRuntimeRestart(Guid runtimeId, string providerId)
     {
         if (_pluginAppRuntimeDisposing || IsExiting)
@@ -393,57 +486,73 @@ public sealed partial class AppController
             return;
         }
 
-        // ProcessFailed is raised by WebView2. Defer disposal out of that callback so we never tear
-        // down the control while WebView2 is still unwinding its own failure notification.
+        // WebView2 raises ProcessFailed from inside its own callback. Queue teardown so disposal is
+        // never re-entrant into WebView2. RuntimeId prevents a stale callback from replacing a newer
+        // provider runtime.
         _ = dispatcher.BeginInvoke(
             (Action)(() =>
             {
-                if (_pluginAppRuntimeDisposing || IsExiting)
+                if (_pluginAppRuntimeDisposing ||
+                    IsExiting ||
+                    !_pluginAppRuntimeSlots.TryGetValue(providerId, out var slot) ||
+                    slot.RuntimeId != runtimeId)
                 {
                     return;
                 }
 
-                if (_pluginAppRuntimes.TryGetValue(providerId, out var lease) &&
-                    lease.RuntimeId == runtimeId)
+                if (slot.State == PluginAppRuntimeState.Starting)
                 {
-                    _pluginAppRuntimes.Remove(providerId);
-                    ClearPluginAppRuntimeFailureState(providerId);
-                    _pluginAppRuntimeRestartRequests.Remove(providerId);
-                    lease.Dispose();
-                    QueuePluginStatusUiRefresh();
-                    ReconcilePluginAppRuntimes();
+                    slot.RestartRequested = true;
                     return;
                 }
 
-                if (_pluginAppRuntimeStarts.Contains(providerId))
+                if (slot.State != PluginAppRuntimeState.Running ||
+                    slot.Lease?.RuntimeId != runtimeId)
                 {
-                    // StartAsync returns before the first document necessarily settles. Remember
-                    // the exact runtime id so a stale crash callback can never cancel a newer start.
-                    _pluginAppRuntimeRestartRequests[providerId] = runtimeId;
+                    return;
                 }
+
+                var lease = slot.Lease;
+                slot.Lease = null;
+                slot.RetryGeneration++;
+                slot.RestartRequested = false;
+                slot.FailureCount = 0;
+                slot.State = PluginAppRuntimeState.Stopped;
+                lease.Dispose();
+                QueuePluginStatusUiRefresh();
+                ReconcilePluginAppRuntimes();
             }),
             DispatcherPriority.Background);
     }
 
+    private void RemovePluginAppRuntimeSlot(string providerId)
+    {
+        if (!_pluginAppRuntimeSlots.Remove(providerId, out var slot))
+        {
+            return;
+        }
+
+        slot.RetryGeneration++;
+        slot.RestartRequested = false;
+        slot.State = PluginAppRuntimeState.Disposing;
+        var lease = slot.Lease;
+        slot.Lease = null;
+        lease?.Dispose();
+    }
+
     private static bool DeclaresPluginAppRuntime(PaperBodyPluginDescriptor descriptor) =>
-        descriptor.Manifest?.Capabilities?.Any(value =>
-            string.Equals(
-                value?.Trim(),
-                PluginAppRuntimeCapability,
-                StringComparison.Ordinal)) == true;
+        descriptor.Manifest?.Capabilities?.Contains(
+            PluginAppRuntimeCapability,
+            StringComparer.Ordinal) == true;
 
     private void DisposePluginAppRuntimes()
     {
         _pluginAppRuntimeDisposing = true;
         _pluginAppRuntimeReconciliationEnabled = false;
-        foreach (var lease in _pluginAppRuntimes.Values.ToArray())
+        foreach (var providerId in _pluginAppRuntimeSlots.Keys.ToArray())
         {
-            lease.Dispose();
+            RemovePluginAppRuntimeSlot(providerId);
         }
-        _pluginAppRuntimes.Clear();
-        _pluginAppRuntimeStartFailures.Clear();
-        _pluginAppRuntimeStartFailureCounts.Clear();
-        _pluginAppRuntimeRetryTokens.Clear();
-        _pluginAppRuntimeRestartRequests.Clear();
+        _pluginAppRuntimeSlots.Clear();
     }
 }

--- a/src/AppController.PluginShortcutLifecycle.cs
+++ b/src/AppController.PluginShortcutLifecycle.cs
@@ -4,13 +4,10 @@ public sealed partial class AppController
 {
     private void SuspendPluginShortcutRegistrations()
     {
-        if (_pluginHotkeys == null)
-        {
-            return;
-        }
-
-        _pluginHotkeys.Invoked -= OnPluginHotkeyInvoked;
-        _pluginHotkeys.Dispose();
-        _pluginHotkeys = null;
+        // Keep configured reservations inside the process-global broker while releasing only this
+        // owner's active RegisterHotKey entries. That prevents a built-in shortcut transaction from
+        // stealing a plugin key merely because the plugin is temporarily suspended for recording or
+        // numpad-mode reconciliation.
+        _pluginHotkeys?.Suspend();
     }
 }

--- a/src/AppController.PluginShortcuts.cs
+++ b/src/AppController.PluginShortcuts.cs
@@ -22,6 +22,8 @@ public sealed partial class AppController
         Func<bool> IsActive,
         Action<PaperShortcutActionInvocation> Dispatch);
 
+    // Logical plugin owner only. All native RegisterHotKey ownership is centralized in the
+    // process-global GlobalHotkeyBroker shared with PaperTodo's built-in shortcut manager.
     private GlobalHotkeyManager? _pluginHotkeys;
     private readonly Dictionary<string, PluginShortcutRegistration> _pluginShortcutRegistrations =
         new(StringComparer.Ordinal);
@@ -64,9 +66,9 @@ public sealed partial class AppController
 
     private void RefreshPluginShortcutsAfterRuntimeChange()
     {
-        // Recording intentionally releases all WM_HOTKEY owners. Runtime navigation/startup may
-        // race that UI state, so defer rebuilding registrations until recording ends.
-        if (_pluginShortcutRecordingCommandId == null)
+        // Recording temporarily releases active native registrations. Runtime navigation/startup may
+        // race either recorder, so leave the current capture stable and rebuild when recording ends.
+        if (_pluginShortcutRecordingCommandId == null && _shortcutRecordingCommandId == null)
         {
             RefreshPluginShortcuts();
         }
@@ -85,8 +87,10 @@ public sealed partial class AppController
         _pluginShortcutStatuses.Clear();
 
         var desiredBindings = new Dictionary<string, string>(StringComparer.Ordinal);
+        var reservedCommandIds = new HashSet<string>(StringComparer.Ordinal);
         var activeCommandIds = new HashSet<string>(StringComparer.Ordinal);
         var registrationsByCommand = new Dictionary<string, ShortcutGesture[]>(StringComparer.Ordinal);
+
         foreach (var descriptor in _paperBodyPlugins.Descriptors)
         {
             if (descriptor.Kind == PaperBodyPluginKind.BuiltIn || descriptor.Manifest == null)
@@ -97,11 +101,12 @@ public sealed partial class AppController
             foreach (var setting in descriptor.Manifest.Settings.Where(item => item.Type == "shortcut"))
             {
                 var commandId = PluginShortcutCommandId(descriptor.Id, setting.Id);
-                _pluginShortcutRegistrations[commandId] = new PluginShortcutRegistration(
+                var registration = new PluginShortcutRegistration(
                     commandId,
                     descriptor.Id,
                     setting.Id,
                     setting.ShortcutAction);
+                _pluginShortcutRegistrations[commandId] = registration;
 
                 var binding = bindingOverrides != null &&
                               bindingOverrides.TryGetValue(commandId, out var overridden)
@@ -122,21 +127,28 @@ public sealed partial class AppController
                     continue;
                 }
 
-                // Host-owned paper.* actions are always executable. Plugin-defined actions only
-                // claim a Windows hotkey while their appRuntime has a live handler; otherwise a
-                // failed/refreshing runtime would steal a key that can only no-op.
-                if (PluginShortcutActions.IsCustomAction(setting.ShortcutAction) &&
-                    !HasActivePluginShortcutRuntime(descriptor.Id))
-                {
-                    _pluginShortcutStatuses[commandId] = ShortcutUiStatus.RegistrationFailed;
-                    continue;
-                }
-
+                // Configuration ownership and runtime activation are intentionally separate:
+                // configured gestures always reserve their PaperTodo-internal slot, while only a
+                // command that can execute right now is actually registered with Windows.
+                reservedCommandIds.Add(commandId);
                 registrationsByCommand[commandId] = RegistrationGesturesForPlugin(gesture).ToArray();
-                activeCommandIds.Add(commandId);
+
+                var canExecute = PluginShortcutActions.IsCustomAction(setting.ShortcutAction)
+                    ? HasActivePluginShortcutRuntime(descriptor.Id)
+                    : HasEntityPluginPaper(descriptor.Id);
+                if (canExecute)
+                {
+                    activeCommandIds.Add(commandId);
+                }
+                else
+                {
+                    _pluginShortcutStatuses[commandId] = ShortcutUiStatus.Disabled;
+                }
             }
         }
 
+        // Existing PaperTodo commands have priority over plugin reservations. A plugin configuration
+        // remains stored/reserved but is marked duplicate and cannot claim the native registration.
         var builtInGestures = ConfiguredBuiltInRegistrationGestures();
         foreach (var pair in registrationsByCommand)
         {
@@ -147,6 +159,9 @@ public sealed partial class AppController
             }
         }
 
+        // Plugin-to-plugin conflicts are checked against configured reservations, not just commands
+        // that happen to be executable today. This prevents A from going idle, B stealing its key,
+        // and A becoming conflicting the next time a paper/runtime appears.
         var commandsByGesture = new Dictionary<ShortcutGesture, HashSet<string>>();
         foreach (var pair in registrationsByCommand)
         {
@@ -175,6 +190,7 @@ public sealed partial class AppController
             if (manager.TryApply(
                     desiredBindings,
                     activeCommandIds,
+                    reservedCommandIds,
                     State.DistinguishNumpadShortcutDigits,
                     out var failedCommandId,
                     out var failure))
@@ -182,6 +198,8 @@ public sealed partial class AppController
                 break;
             }
 
+            // System occupancy affects only commands that were about to become active. Preserve the
+            // configured reservation and keep the rest of the plugin/built-in native plan alive.
             if (string.IsNullOrEmpty(failedCommandId) ||
                 !activeCommandIds.Remove(failedCommandId))
             {
@@ -195,6 +213,7 @@ public sealed partial class AppController
                 _ = manager.TryApply(
                     desiredBindings,
                     activeCommandIds,
+                    reservedCommandIds,
                     State.DistinguishNumpadShortcutDigits,
                     out _,
                     out _);
@@ -219,7 +238,7 @@ public sealed partial class AppController
                 ? ShortcutUiStatus.Unassigned
                 : manager.ActiveBindings.ContainsKey(registration.CommandId)
                     ? ShortcutUiStatus.Registered
-                    : ShortcutUiStatus.RegistrationFailed;
+                    : ShortcutUiStatus.Disabled;
         }
     }
 
@@ -516,7 +535,12 @@ public sealed partial class AppController
                 [commandId] = normalized
             });
         status = PluginShortcutStatusFor(commandId);
-        if (status is not (ShortcutUiStatus.Registered or ShortcutUiStatus.Unassigned))
+        // Disabled means configured/reserved but currently not executable (no entity paper or no
+        // live appRuntime handler). Configuration is still valid and must be persisted.
+        if (status is not (
+                ShortcutUiStatus.Registered or
+                ShortcutUiStatus.Unassigned or
+                ShortcutUiStatus.Disabled))
         {
             RefreshPluginShortcuts();
             return false;
@@ -585,8 +609,9 @@ public sealed partial class AppController
         }
 
         _shortcutRecordingCommandId = null;
-        // The plugin currently owns this exact RegisterHotKey slot. Release it before applying the
-        // host draft, then rebuild plugin registrations against the newly authoritative host set.
+        // Release only the plugin's active native registration. Its configured reservation stays in
+        // the broker, so ApplyShortcutDraft correctly rejects a host command that tries to steal the
+        // same configured plugin gesture.
         SuspendPluginShortcutRegistrations();
         try
         {

--- a/src/AppController.PluginShortcuts.cs
+++ b/src/AppController.PluginShortcuts.cs
@@ -147,8 +147,9 @@ public sealed partial class AppController
             }
         }
 
-        // Existing PaperTodo commands have priority over plugin reservations. A plugin configuration
-        // remains stored/reserved but is marked duplicate and cannot claim the native registration.
+        // Existing PaperTodo commands have priority over plugin reservations. A conflicting legacy
+        // plugin value stays persisted and visible as Duplicate, but cannot become an effective
+        // reservation that would invalidate the rest of the broker plan.
         var builtInGestures = ConfiguredBuiltInRegistrationGestures();
         foreach (var pair in registrationsByCommand)
         {
@@ -156,12 +157,13 @@ public sealed partial class AppController
             {
                 _pluginShortcutStatuses[pair.Key] = ShortcutUiStatus.Duplicate;
                 activeCommandIds.Remove(pair.Key);
+                reservedCommandIds.Remove(pair.Key);
             }
         }
 
-        // Plugin-to-plugin conflicts are checked against configured reservations, not just commands
-        // that happen to be executable today. This prevents A from going idle, B stealing its key,
-        // and A becoming conflicting the next time a paper/runtime appears.
+        // Plugin-to-plugin conflicts are checked against configured values, not just commands that
+        // happen to be executable today. Conflicting legacy values are reported but neither side is
+        // allowed to poison the effective reservation plan.
         var commandsByGesture = new Dictionary<ShortcutGesture, HashSet<string>>();
         foreach (var pair in registrationsByCommand)
         {
@@ -181,6 +183,7 @@ public sealed partial class AppController
             {
                 _pluginShortcutStatuses[commandId] = ShortcutUiStatus.Duplicate;
                 activeCommandIds.Remove(commandId);
+                reservedCommandIds.Remove(commandId);
             }
         }
 

--- a/src/AppController.PluginStatus.cs
+++ b/src/AppController.PluginStatus.cs
@@ -24,7 +24,7 @@ public sealed partial class AppController
         bool hasDataIssue)
     {
         if (hasDataIssue ||
-            _pluginAppRuntimeStartFailures.Contains(descriptor.Id) ||
+            HasPluginAppRuntimeFailure(descriptor.Id) ||
             (descriptor.Kind != PaperBodyPluginKind.BuiltIn &&
              _paperBodyPlugins.Issues.Any(issue =>
                  PluginIssueMatchesDescriptor(issue, descriptor))) ||
@@ -34,7 +34,7 @@ public sealed partial class AppController
             return PluginPageStatus.Issue;
         }
 
-        return _pluginAppRuntimes.ContainsKey(descriptor.Id) ||
+        return IsPluginAppRuntimeRunning(descriptor.Id) ||
                _windows.Values.Any(window =>
                    window.HasRunningPluginBody(descriptor.Id))
             ? PluginPageStatus.Running

--- a/src/GlobalHotkeys.cs
+++ b/src/GlobalHotkeys.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows.Input;
 using System.Windows.Interop;
@@ -536,7 +535,90 @@ internal enum GlobalShortcutRegistrationFailure
     RegistrationFailed
 }
 
+/// <summary>
+/// One logical shortcut owner. All instances share <see cref="GlobalHotkeyBroker"/>, which is the
+/// only process-level RegisterHotKey authority. A manager can reserve configured gestures without
+/// activating them, allowing an unavailable plugin command to keep its PaperTodo-internal ownership
+/// while releasing the actual Windows hotkey until it becomes executable again.
+/// </summary>
 internal sealed class GlobalHotkeyManager : IDisposable
+{
+    private readonly Guid _ownerId = Guid.NewGuid();
+    private bool _disposed;
+
+    public GlobalHotkeyManager()
+    {
+        GlobalHotkeyBroker.AddOwner(_ownerId, commandId => Invoked?.Invoke(commandId));
+    }
+
+    public event Action<string>? Invoked;
+
+    public IReadOnlyDictionary<string, string> ActiveBindings =>
+        GlobalHotkeyBroker.ActiveBindings(_ownerId);
+
+    public bool TryApply(
+        IReadOnlyDictionary<string, string> desiredBindings,
+        IReadOnlyCollection<string> activeCommandIds,
+        bool distinguishNumpadDigits,
+        out string? failedCommandId,
+        out GlobalShortcutRegistrationFailure failure) =>
+        TryApply(
+            desiredBindings,
+            activeCommandIds,
+            activeCommandIds,
+            distinguishNumpadDigits,
+            out failedCommandId,
+            out failure);
+
+    public bool TryApply(
+        IReadOnlyDictionary<string, string> desiredBindings,
+        IReadOnlyCollection<string> activeCommandIds,
+        IReadOnlyCollection<string> reservedCommandIds,
+        bool distinguishNumpadDigits,
+        out string? failedCommandId,
+        out GlobalShortcutRegistrationFailure failure)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return GlobalHotkeyBroker.TryApply(
+            _ownerId,
+            desiredBindings,
+            activeCommandIds,
+            reservedCommandIds,
+            distinguishNumpadDigits,
+            out failedCommandId,
+            out failure);
+    }
+
+    /// <summary>
+    /// Releases this owner's native registrations but keeps its configured reservations in the
+    /// broker. Used while another shortcut recorder/transaction needs the key events themselves.
+    /// </summary>
+    public void Suspend()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        GlobalHotkeyBroker.SuspendOwner(_ownerId);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        GlobalHotkeyBroker.RemoveOwner(_ownerId);
+    }
+}
+
+/// <summary>
+/// Process-global native hotkey authority. Owner states are combined transactionally before any
+/// RegisterHotKey mutation, so host and plugin shortcuts cannot temporarily steal each other's
+/// configured gestures. One global numpad mode is applied to every owner during each transaction.
+/// </summary>
+internal static class GlobalHotkeyBroker
 {
     private const int WmHotkey = 0x0312;
     private const uint ModAlt = 0x0001;
@@ -546,114 +628,291 @@ internal sealed class GlobalHotkeyManager : IDisposable
     private const uint ModNoRepeat = 0x4000;
     private const int ErrorHotkeyAlreadyRegistered = 1409;
 
-    private readonly HwndSource _source;
-    private readonly Dictionary<int, string> _commandByNativeId = new();
-    private readonly Dictionary<ShortcutGesture, int> _nativeIdByGesture = new();
-    private Dictionary<string, string> _activeBindings = new(StringComparer.Ordinal);
-    private int _nextNativeId = 1;
-
-    public GlobalHotkeyManager()
+    private sealed class OwnerState
     {
-        var parameters = new HwndSourceParameters("PaperTodo.GlobalHotkeys")
+        public required Action<string> Dispatch { get; init; }
+        public Dictionary<string, string> Bindings { get; set; } = new(StringComparer.Ordinal);
+        public HashSet<string> ActiveCommandIds { get; set; } = new(StringComparer.Ordinal);
+        public HashSet<string> ReservedCommandIds { get; set; } = new(StringComparer.Ordinal);
+    }
+
+    private sealed record NativeBinding(Guid OwnerId, string CommandId, int NativeId);
+
+    private static readonly HwndSource Source;
+    private static readonly Dictionary<Guid, OwnerState> Owners = new();
+    private static readonly Dictionary<ShortcutGesture, NativeBinding> NativeByGesture = new();
+    private static readonly Dictionary<int, NativeBinding> NativeById = new();
+    private static int _nextNativeId = 1;
+    private static bool _distinguishNumpadDigits;
+
+    static GlobalHotkeyBroker()
+    {
+        var parameters = new HwndSourceParameters("PaperTodo.GlobalHotkeyBroker")
         {
             Width = 0,
             Height = 0,
             WindowStyle = 0,
             ExtendedWindowStyle = 0x00000080
         };
-        _source = new HwndSource(parameters);
-        _source.AddHook(WindowHook);
+        Source = new HwndSource(parameters);
+        Source.AddHook(WindowHook);
     }
 
-    public event Action<string>? Invoked;
+    public static void AddOwner(Guid ownerId, Action<string> dispatch)
+    {
+        ArgumentNullException.ThrowIfNull(dispatch);
+        if (!Owners.TryAdd(ownerId, new OwnerState { Dispatch = dispatch }))
+        {
+            throw new InvalidOperationException("A global hotkey owner with the same id already exists.");
+        }
+    }
 
-    public IReadOnlyDictionary<string, string> ActiveBindings => _activeBindings;
+    public static IReadOnlyDictionary<string, string> ActiveBindings(Guid ownerId)
+    {
+        if (!Owners.TryGetValue(ownerId, out var owner))
+        {
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
 
-    public bool TryApply(
+        var active = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var commandId in owner.ActiveCommandIds)
+        {
+            if (owner.Bindings.TryGetValue(commandId, out var binding) &&
+                NativeByGesture.Values.Any(item =>
+                    item.OwnerId == ownerId &&
+                    string.Equals(item.CommandId, commandId, StringComparison.Ordinal)))
+            {
+                active[commandId] = binding;
+            }
+        }
+        return active;
+    }
+
+    public static bool TryApply(
+        Guid ownerId,
         IReadOnlyDictionary<string, string> desiredBindings,
         IReadOnlyCollection<string> activeCommandIds,
+        IReadOnlyCollection<string> reservedCommandIds,
         bool distinguishNumpadDigits,
         out string? failedCommandId,
         out GlobalShortcutRegistrationFailure failure)
     {
         failedCommandId = null;
         failure = GlobalShortcutRegistrationFailure.None;
-        var activeIds = activeCommandIds.ToHashSet(StringComparer.Ordinal);
-        var desiredCommands = new List<(string CommandId, string Text, ShortcutGesture Gesture)>();
-        var desiredRegistrations = new List<(string CommandId, ShortcutGesture Gesture)>();
-        var commandByGesture = new Dictionary<ShortcutGesture, string>();
-        foreach (var pair in desiredBindings)
+        if (!Owners.ContainsKey(ownerId))
         {
-            if (!activeIds.Contains(pair.Key) ||
-                string.IsNullOrWhiteSpace(pair.Value) ||
-                !ShortcutGesture.TryParse(pair.Value, out var gesture) ||
-                gesture.Key == Key.None)
-            {
-                continue;
-            }
+            failure = GlobalShortcutRegistrationFailure.RegistrationFailed;
+            return false;
+        }
 
-            var definition = GlobalShortcutCatalog.Find(pair.Key);
-            var includeDigitAlias =
-                !distinguishNumpadDigits &&
-                definition?.IsEdgeCapsule != true &&
-                gesture.IsDigitKey;
-            foreach (var registrationGesture in gesture.RegistrationGestures(includeDigitAlias))
-            {
-                if (!commandByGesture.TryAdd(registrationGesture, pair.Key))
-                {
-                    failedCommandId = pair.Key;
-                    failure = GlobalShortcutRegistrationFailure.RegistrationFailed;
-                    return false;
-                }
-                desiredRegistrations.Add((pair.Key, registrationGesture));
-            }
+        var candidateBindings = new Dictionary<string, string>(desiredBindings, StringComparer.Ordinal);
+        var candidateActive = activeCommandIds.ToHashSet(StringComparer.Ordinal);
+        var candidateReserved = reservedCommandIds.ToHashSet(StringComparer.Ordinal);
+        candidateReserved.UnionWith(candidateActive);
 
-            desiredCommands.Add((pair.Key, pair.Value, gesture));
+        if (!TryBuildCombinedPlan(
+                ownerId,
+                candidateBindings,
+                candidateActive,
+                candidateReserved,
+                distinguishNumpadDigits,
+                out var desiredNative,
+                out failedCommandId))
+        {
+            failure = GlobalShortcutRegistrationFailure.RegistrationFailed;
+            return false;
         }
 
         var newlyRegistered = new List<ShortcutGesture>();
-        foreach (var binding in desiredRegistrations)
+        foreach (var pair in desiredNative)
         {
-            if (_nativeIdByGesture.ContainsKey(binding.Gesture))
+            if (NativeByGesture.ContainsKey(pair.Key))
             {
                 continue;
             }
 
-            if (!TryRegisterGesture(binding.Gesture, out var nativeId, out failure))
+            if (!TryRegisterGesture(pair.Key, out var nativeId, out failure))
             {
-                failedCommandId = binding.CommandId;
-                foreach (var registeredGesture in newlyRegistered)
+                failedCommandId = pair.Value.CommandId;
+                foreach (var gesture in newlyRegistered)
                 {
-                    TryUnregisterGesture(registeredGesture);
+                    TryUnregisterGesture(gesture);
                 }
                 return false;
             }
 
-            _nativeIdByGesture[binding.Gesture] = nativeId;
-            _commandByNativeId[nativeId] = "";
-            newlyRegistered.Add(binding.Gesture);
+            var native = new NativeBinding(pair.Value.OwnerId, pair.Value.CommandId, nativeId);
+            NativeByGesture[pair.Key] = native;
+            NativeById[nativeId] = native;
+            newlyRegistered.Add(pair.Key);
         }
 
-        var activeByGesture = desiredRegistrations
-            .ToDictionary(binding => binding.Gesture, binding => binding.CommandId);
-
-        foreach (var pair in _nativeIdByGesture.ToArray())
+        foreach (var pair in NativeByGesture.ToArray())
         {
-            if (activeByGesture.TryGetValue(pair.Key, out var commandId))
+            if (!desiredNative.ContainsKey(pair.Key))
             {
-                _commandByNativeId[pair.Value] = commandId;
+                TryUnregisterGesture(pair.Key);
+            }
+        }
+
+        foreach (var pair in desiredNative)
+        {
+            if (!NativeByGesture.TryGetValue(pair.Key, out var current))
+            {
+                continue;
+            }
+            if (current.OwnerId == pair.Value.OwnerId &&
+                string.Equals(current.CommandId, pair.Value.CommandId, StringComparison.Ordinal))
+            {
                 continue;
             }
 
-            TryUnregisterGesture(pair.Key);
+            var updated = new NativeBinding(
+                pair.Value.OwnerId,
+                pair.Value.CommandId,
+                current.NativeId);
+            NativeByGesture[pair.Key] = updated;
+            NativeById[current.NativeId] = updated;
         }
 
-        _activeBindings = desiredCommands
-            .ToDictionary(binding => binding.CommandId, binding => binding.Text, StringComparer.Ordinal);
+        var owner = Owners[ownerId];
+        owner.Bindings = candidateBindings;
+        owner.ActiveCommandIds = candidateActive;
+        owner.ReservedCommandIds = candidateReserved;
+        _distinguishNumpadDigits = distinguishNumpadDigits;
         return true;
     }
 
-    private bool TryRegisterGesture(
+    public static void SuspendOwner(Guid ownerId)
+    {
+        if (!Owners.TryGetValue(ownerId, out var owner))
+        {
+            return;
+        }
+
+        _ = TryApply(
+            ownerId,
+            owner.Bindings,
+            Array.Empty<string>(),
+            owner.ReservedCommandIds,
+            _distinguishNumpadDigits,
+            out _,
+            out _);
+    }
+
+    public static void RemoveOwner(Guid ownerId)
+    {
+        if (!Owners.TryGetValue(ownerId, out var owner))
+        {
+            return;
+        }
+
+        _ = TryApply(
+            ownerId,
+            owner.Bindings,
+            Array.Empty<string>(),
+            Array.Empty<string>(),
+            _distinguishNumpadDigits,
+            out _,
+            out _);
+        Owners.Remove(ownerId);
+    }
+
+    private static bool TryBuildCombinedPlan(
+        Guid candidateOwnerId,
+        IReadOnlyDictionary<string, string> candidateBindings,
+        IReadOnlySet<string> candidateActive,
+        IReadOnlySet<string> candidateReserved,
+        bool distinguishNumpadDigits,
+        out Dictionary<ShortcutGesture, (Guid OwnerId, string CommandId)> desiredNative,
+        out string? failedCommandId)
+    {
+        desiredNative = new Dictionary<ShortcutGesture, (Guid OwnerId, string CommandId)>();
+        failedCommandId = null;
+        var reservations = new Dictionary<ShortcutGesture, (Guid OwnerId, string CommandId)>();
+
+        foreach (var ownerPair in Owners)
+        {
+            var ownerId = ownerPair.Key;
+            var owner = ownerPair.Value;
+            var bindings = ownerId == candidateOwnerId ? candidateBindings : owner.Bindings;
+            var reserved = ownerId == candidateOwnerId ? candidateReserved : owner.ReservedCommandIds;
+
+            foreach (var commandId in reserved)
+            {
+                if (!bindings.TryGetValue(commandId, out var text) ||
+                    string.IsNullOrWhiteSpace(text) ||
+                    !ShortcutGesture.TryParse(text, out var gesture) ||
+                    gesture.Key == Key.None)
+                {
+                    continue;
+                }
+
+                foreach (var registrationGesture in RegistrationGesturesFor(
+                             commandId,
+                             gesture,
+                             distinguishNumpadDigits))
+                {
+                    if (reservations.TryGetValue(registrationGesture, out var existing))
+                    {
+                        if (ownerId == candidateOwnerId)
+                        {
+                            failedCommandId = commandId;
+                        }
+                        else if (existing.OwnerId == candidateOwnerId)
+                        {
+                            failedCommandId = existing.CommandId;
+                        }
+                        return false;
+                    }
+                    reservations[registrationGesture] = (ownerId, commandId);
+                }
+            }
+        }
+
+        foreach (var ownerPair in Owners)
+        {
+            var ownerId = ownerPair.Key;
+            var owner = ownerPair.Value;
+            var bindings = ownerId == candidateOwnerId ? candidateBindings : owner.Bindings;
+            var active = ownerId == candidateOwnerId ? candidateActive : owner.ActiveCommandIds;
+            foreach (var commandId in active)
+            {
+                if (!bindings.TryGetValue(commandId, out var text) ||
+                    string.IsNullOrWhiteSpace(text) ||
+                    !ShortcutGesture.TryParse(text, out var gesture) ||
+                    gesture.Key == Key.None)
+                {
+                    continue;
+                }
+
+                foreach (var registrationGesture in RegistrationGesturesFor(
+                             commandId,
+                             gesture,
+                             distinguishNumpadDigits))
+                {
+                    desiredNative[registrationGesture] = (ownerId, commandId);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static IEnumerable<ShortcutGesture> RegistrationGesturesFor(
+        string commandId,
+        ShortcutGesture gesture,
+        bool distinguishNumpadDigits)
+    {
+        var definition = GlobalShortcutCatalog.Find(commandId);
+        var includeDigitAlias =
+            !distinguishNumpadDigits &&
+            definition?.IsEdgeCapsule != true &&
+            gesture.IsDigitKey;
+        return gesture.RegistrationGestures(includeDigitAlias);
+    }
+
+    private static bool TryRegisterGesture(
         ShortcutGesture gesture,
         out int nativeId,
         out GlobalShortcutRegistrationFailure failure)
@@ -661,7 +920,7 @@ internal sealed class GlobalHotkeyManager : IDisposable
         nativeId = _nextNativeId++;
         failure = GlobalShortcutRegistrationFailure.None;
         if (RegisterHotKey(
-                _source.Handle,
+                Source.Handle,
                 nativeId,
                 NativeModifiers(gesture.Modifiers) | ModNoRepeat,
                 (uint)KeyInterop.VirtualKeyFromKey(gesture.Key)))
@@ -675,38 +934,35 @@ internal sealed class GlobalHotkeyManager : IDisposable
         return false;
     }
 
-    private bool TryUnregisterGesture(ShortcutGesture gesture)
+    private static bool TryUnregisterGesture(ShortcutGesture gesture)
     {
-        if (!_nativeIdByGesture.TryGetValue(gesture, out var nativeId))
+        if (!NativeByGesture.TryGetValue(gesture, out var native))
         {
             return true;
         }
 
-        _commandByNativeId[nativeId] = "";
-        if (!UnregisterHotKey(_source.Handle, nativeId))
+        if (!UnregisterHotKey(Source.Handle, native.NativeId))
         {
             return false;
         }
 
-        _nativeIdByGesture.Remove(gesture);
-        _commandByNativeId.Remove(nativeId);
+        NativeByGesture.Remove(gesture);
+        NativeById.Remove(native.NativeId);
         return true;
     }
 
-    private void UnregisterAll()
+    private static IntPtr WindowHook(
+        IntPtr hwnd,
+        int msg,
+        IntPtr wParam,
+        IntPtr lParam,
+        ref bool handled)
     {
-        foreach (var gesture in _nativeIdByGesture.Keys.ToArray())
+        if (msg == WmHotkey && NativeById.TryGetValue(wParam.ToInt32(), out var native))
         {
-            TryUnregisterGesture(gesture);
-        }
-    }
-    private IntPtr WindowHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
-    {
-        if (msg == WmHotkey && _commandByNativeId.TryGetValue(wParam.ToInt32(), out var commandId))
-        {
-            if (!string.IsNullOrEmpty(commandId))
+            if (Owners.TryGetValue(native.OwnerId, out var owner))
             {
-                Invoked?.Invoke(commandId);
+                owner.Dispatch(native.CommandId);
             }
             handled = true;
         }
@@ -722,13 +978,6 @@ internal sealed class GlobalHotkeyManager : IDisposable
         if (modifiers.HasFlag(ModifierKeys.Shift)) result |= ModShift;
         if (modifiers.HasFlag(ModifierKeys.Windows)) result |= ModWin;
         return result;
-    }
-
-    public void Dispose()
-    {
-        UnregisterAll();
-        _source.RemoveHook(WindowHook);
-        _source.Dispose();
     }
 
     [DllImport("user32.dll", SetLastError = true)]

--- a/src/PaperBodyPluginHostApi.Presentation.cs
+++ b/src/PaperBodyPluginHostApi.Presentation.cs
@@ -44,6 +44,7 @@ internal sealed partial class PaperBodyPluginHostApi
     private string RequireHostPaperId()
     {
         EnsureUsable();
+        EnsurePresentationProtocol();
         if (string.IsNullOrEmpty(_hostPaperId))
         {
             throw Error(
@@ -51,6 +52,22 @@ internal sealed partial class PaperBodyPluginHostApi
                 "This plugin context is not attached to a paper.");
         }
         return _hostPaperId;
+    }
+
+    private void EnsurePresentationProtocol()
+    {
+        if (_controller.PaperBodyPlugins.TryGet(_providerId, out var descriptor) &&
+            string.Equals(
+                descriptor.ApiVersion,
+                PaperBodyPluginRegistry.SupportedPluginApiVersion,
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        throw Error(
+            "presentation_requires_api_2_0",
+            "Own-paper presentation controls require plugin apiVersion 2.0.");
     }
 
     private void QueuePresentation(Func<string, bool> action)

--- a/src/PaperBodyPluginRegistry.Permissions.cs
+++ b/src/PaperBodyPluginRegistry.Permissions.cs
@@ -28,17 +28,51 @@ internal sealed partial class PaperBodyPluginRegistry
         return result.ToFrozenSet(StringComparer.Ordinal);
     }
 
+    /// <summary>
+    /// Canonicalizes manifest capability names exactly once before any feature-specific validator
+    /// consumes them. Unknown values are rejected instead of being silently ignored, so a typo
+    /// cannot produce a plugin that loads successfully with a missing feature.
+    /// </summary>
+    private static void NormalizeProtocolFeatures(PaperBodyPluginManifest manifest)
+    {
+        manifest.Capabilities ??= [];
+        var normalized = new List<string>(manifest.Capabilities.Length);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var raw in manifest.Capabilities)
+        {
+            var value = raw?.Trim() ?? "";
+            if (value.Length == 0)
+            {
+                continue;
+            }
+
+            var canonical = value.ToLowerInvariant() switch
+            {
+                "textzoom" => "textZoom",
+                "notelinks" => "noteLinks",
+                "appruntime" => "appRuntime",
+                _ => throw new InvalidDataException(
+                    $"Unknown plugin capability '{value}'.")
+            };
+            if (seen.Add(canonical))
+            {
+                normalized.Add(canonical);
+            }
+        }
+
+        manifest.Capabilities = normalized.ToArray();
+    }
+
     private static void ValidateProtocolFeatures(PaperBodyPluginManifest manifest)
     {
         manifest.Permissions ??= [];
-        manifest.Capabilities ??= [];
+        NormalizeProtocolFeatures(manifest);
         if (manifest.Permissions.Length > 0 && !ApiAtLeast(manifest.ApiVersion, 1, 3))
         {
             throw new InvalidDataException(
                 "Plugin permissions require apiVersion 1.3 or newer.");
         }
-        if (manifest.Capabilities.Any(value =>
-                string.Equals(value?.Trim(), "appRuntime", StringComparison.Ordinal)) &&
+        if (manifest.Capabilities.Contains("appRuntime", StringComparer.Ordinal) &&
             !ApiAtLeast(manifest.ApiVersion, 2, 0))
         {
             throw new InvalidDataException(

--- a/src/PaperBodyPluginRegistry.Settings.cs
+++ b/src/PaperBodyPluginRegistry.Settings.cs
@@ -19,9 +19,11 @@ internal sealed partial class PaperBodyPluginRegistry
     private static void ValidateSettings(PaperBodyPluginManifest manifest)
     {
         manifest.Settings ??= [];
-        manifest.Capabilities ??= [];
-        var hasAppRuntime = manifest.Capabilities.Any(value =>
-            string.Equals(value?.Trim(), "appRuntime", StringComparison.Ordinal));
+        // Settings may depend on provider-level capabilities (for example custom shortcut actions
+        // require appRuntime). Normalize and validate the capability list before reading it here so
+        // every feature consumes one canonical manifest representation.
+        NormalizeProtocolFeatures(manifest);
+        var hasAppRuntime = manifest.Capabilities.Contains("appRuntime", StringComparer.Ordinal);
         var ids = new HashSet<string>(StringComparer.Ordinal);
         var quickCount = 0;
         foreach (var setting in manifest.Settings)

--- a/src/WebPaperBodySession.SharedRuntime.cs
+++ b/src/WebPaperBodySession.SharedRuntime.cs
@@ -1,8 +1,13 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.Wpf;
 
 namespace PaperTodo;
 
+// These narrow accessors keep the large body-session implementation private while allowing the
+// shared Web runtime infrastructure below to reuse the same environment pool/background host.
 internal sealed partial class WebPaperBodySession
 {
     internal static Task<CoreWebView2Environment> SharedPluginEnvironmentAsync(
@@ -19,4 +24,79 @@ internal sealed partial class WebPaperBodySession
     internal static void DetachSharedBackgroundWebView(
         WebView2CompositionControl webView) =>
         BackgroundWebViewHost.Detach(webView);
+}
+
+/// <summary>
+/// Common non-surface-specific Web plugin runtime services. Body, mini and provider app-runtime
+/// code should not each invent origin/URI/serialization/environment rules. The body session still
+/// owns its visual lifecycle; this class owns only the shared transport/runtime policy.
+/// </summary>
+internal static class WebPluginRuntimeInfrastructure
+{
+    public static JsonSerializerOptions JsonOptions { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    public static Task<CoreWebView2Environment> EnvironmentAsync(string pluginDirectory) =>
+        WebPaperBodySession.SharedPluginEnvironmentAsync(pluginDirectory);
+
+    public static bool AttachBackground(WebView2CompositionControl webView) =>
+        WebPaperBodySession.AttachSharedBackgroundWebView(webView);
+
+    public static void DetachBackground(WebView2CompositionControl webView) =>
+        WebPaperBodySession.DetachSharedBackgroundWebView(webView);
+
+    public static string Origin(string pluginId) =>
+        $"https://{WebPaperBodySession.SharedWebHostName(pluginId)}";
+
+    public static string HostName(string pluginId) =>
+        WebPaperBodySession.SharedWebHostName(pluginId);
+
+    public static Uri LocalEntryUri(
+        string expectedOrigin,
+        string webRoot,
+        string entryPath)
+    {
+        var relative = Path.GetRelativePath(webRoot, entryPath).Replace('\\', '/');
+        return new Uri(
+            $"{expectedOrigin}/{Uri.EscapeDataString(relative).Replace("%2F", "/", StringComparison.OrdinalIgnoreCase)}");
+    }
+
+    public static bool IsSameOrigin(string? value, string expectedOrigin) =>
+        Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
+        string.Equals(
+            uri.GetLeftPart(UriPartial.Authority),
+            expectedOrigin,
+            StringComparison.OrdinalIgnoreCase);
+
+    public static void ConfigureBackgroundCore(CoreWebView2 core)
+    {
+        core.Settings.AreDefaultContextMenusEnabled = false;
+        core.Settings.AreDevToolsEnabled = false;
+        core.Settings.IsStatusBarEnabled = false;
+        core.Settings.AreBrowserAcceleratorKeysEnabled = false;
+    }
+
+    public static string RequiredString(JsonElement payload, string name)
+    {
+        if (payload.ValueKind != JsonValueKind.Object ||
+            !payload.TryGetProperty(name, out var value) ||
+            value.ValueKind != JsonValueKind.String ||
+            string.IsNullOrWhiteSpace(value.GetString()))
+        {
+            throw new PaperTodo.Plugin.PaperTodoPluginException(
+                "invalid_params",
+                $"{name} is required.");
+        }
+        return value.GetString()!;
+    }
+
+    public static JsonElement ParametersOrEmpty(JsonElement payload) =>
+        payload.ValueKind == JsonValueKind.Object &&
+        payload.TryGetProperty("params", out var paramsValue)
+            ? paramsValue
+            : JsonSerializer.SerializeToElement(new { });
 }

--- a/src/WebPluginAppRuntime.cs
+++ b/src/WebPluginAppRuntime.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Windows;
 using System.Windows.Threading;
 using Microsoft.Web.WebView2.Core;
@@ -11,13 +10,6 @@ namespace PaperTodo;
 
 internal sealed class WebPluginAppRuntime : IDisposable
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true,
-        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
-    };
-
     private readonly PaperBodyPluginDescriptor _descriptor;
     private readonly IPaperTodoHostApi _workspace;
     private readonly PaperAppRuntimeGlobalTopBarApi _globalTopBar;
@@ -57,7 +49,7 @@ internal sealed class WebPluginAppRuntime : IDisposable
             IsHitTestVisible = false
         };
         _webView.SetValue(UIElement.OpacityProperty, 0.0);
-        if (!WebPaperBodySession.AttachSharedBackgroundWebView(_webView))
+        if (!WebPluginRuntimeInfrastructure.AttachBackground(_webView))
         {
             throw new InvalidOperationException(
                 "PaperTodo could not attach the Web plugin app runtime to its background host.");
@@ -79,7 +71,7 @@ internal sealed class WebPluginAppRuntime : IDisposable
                 runtimePath);
         }
 
-        var environment = await WebPaperBodySession.SharedPluginEnvironmentAsync(
+        var environment = await WebPluginRuntimeInfrastructure.EnvironmentAsync(
             manifest.DirectoryPath);
         _lifetime.Token.ThrowIfCancellationRequested();
         ThrowIfInactive();
@@ -90,17 +82,14 @@ internal sealed class WebPluginAppRuntime : IDisposable
         var core = _webView.CoreWebView2
             ?? throw new InvalidOperationException(
                 "WebView2 initialization returned no CoreWebView2 instance.");
-        core.Settings.AreDefaultContextMenusEnabled = false;
-        core.Settings.AreDevToolsEnabled = false;
-        core.Settings.IsStatusBarEnabled = false;
-        core.Settings.AreBrowserAcceleratorKeysEnabled = false;
+        WebPluginRuntimeInfrastructure.ConfigureBackgroundCore(core);
 
-        var hostName = WebPaperBodySession.SharedWebHostName(_descriptor.Id);
-        _expectedOrigin = $"https://{hostName}";
-        var relativeRuntime = Path.GetRelativePath(webRoot, runtimePath)
-            .Replace('\\', '/');
-        var runtimeUri = new Uri(
-            $"{_expectedOrigin}/{Uri.EscapeDataString(relativeRuntime).Replace("%2F", "/", StringComparison.OrdinalIgnoreCase)}");
+        var hostName = WebPluginRuntimeInfrastructure.HostName(_descriptor.Id);
+        _expectedOrigin = WebPluginRuntimeInfrastructure.Origin(_descriptor.Id);
+        var runtimeUri = WebPluginRuntimeInfrastructure.LocalEntryUri(
+            _expectedOrigin,
+            webRoot,
+            runtimePath);
 
         core.WebMessageReceived += OnWebMessageReceived;
         core.NavigationStarting += OnNavigationStarting;
@@ -368,14 +357,11 @@ internal sealed class WebPluginAppRuntime : IDisposable
 
     private void HandleHostRequest(JsonElement payload)
     {
-        var requestId = RequiredString(payload, "requestId");
+        var requestId = WebPluginRuntimeInfrastructure.RequiredString(payload, "requestId");
         try
         {
-            var method = RequiredString(payload, "method");
-            var parameters = payload.ValueKind == JsonValueKind.Object &&
-                             payload.TryGetProperty("params", out var paramsValue)
-                ? paramsValue
-                : JsonSerializer.SerializeToElement(new { });
+            var method = WebPluginRuntimeInfrastructure.RequiredString(payload, "method");
+            var parameters = WebPluginRuntimeInfrastructure.ParametersOrEmpty(payload);
             object? result;
             if (string.Equals(method, "topbar.global.set", StringComparison.Ordinal))
             {
@@ -424,7 +410,8 @@ internal sealed class WebPluginAppRuntime : IDisposable
             actions = parameters.ValueKind == JsonValueKind.Object &&
                       parameters.TryGetProperty("actions", out var actionsValue) &&
                       actionsValue.ValueKind != JsonValueKind.Null
-                ? actionsValue.Deserialize<PaperTopBarAction[]>(JsonOptions) ?? []
+                ? actionsValue.Deserialize<PaperTopBarAction[]>(
+                    WebPluginRuntimeInfrastructure.JsonOptions) ?? []
                 : [];
         }
         catch (Exception ex) when (ex is JsonException or NotSupportedException)
@@ -451,24 +438,8 @@ internal sealed class WebPluginAppRuntime : IDisposable
             }));
     }
 
-    private static string RequiredString(JsonElement payload, string name)
-    {
-        if (payload.ValueKind != JsonValueKind.Object ||
-            !payload.TryGetProperty(name, out var value) ||
-            value.ValueKind != JsonValueKind.String ||
-            string.IsNullOrWhiteSpace(value.GetString()))
-        {
-            throw new PaperTodoPluginException("invalid_params", $"{name} is required.");
-        }
-        return value.GetString()!;
-    }
-
     private bool IsAllowedSource(string? value) =>
-        Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
-        string.Equals(
-            uri.GetLeftPart(UriPartial.Authority),
-            _expectedOrigin,
-            StringComparison.OrdinalIgnoreCase);
+        WebPluginRuntimeInfrastructure.IsSameOrigin(value, _expectedOrigin);
 
     private void Send(object value)
     {
@@ -479,7 +450,9 @@ internal sealed class WebPluginAppRuntime : IDisposable
         try
         {
             _webView.CoreWebView2.PostWebMessageAsJson(
-                JsonSerializer.Serialize(value, JsonOptions));
+                JsonSerializer.Serialize(
+                    value,
+                    WebPluginRuntimeInfrastructure.JsonOptions));
         }
         catch
         {
@@ -522,7 +495,7 @@ internal sealed class WebPluginAppRuntime : IDisposable
             core.NavigationCompleted -= OnNavigationCompleted;
             core.ProcessFailed -= OnProcessFailed;
         }
-        WebPaperBodySession.DetachSharedBackgroundWebView(_webView);
+        WebPluginRuntimeInfrastructure.DetachBackground(_webView);
         try { _webView.Dispose(); } catch { }
         _lifetime.Dispose();
     }

--- a/tests/PaperTodo.ProtocolPolicyChecks/PaperTodo.ProtocolPolicyChecks.csproj
+++ b/tests/PaperTodo.ProtocolPolicyChecks/PaperTodo.ProtocolPolicyChecks.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\PaperTodo.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
+++ b/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Reflection;
 
 internal static class Program

--- a/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
+++ b/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
@@ -1,0 +1,200 @@
+using System.Reflection;
+
+internal static class Program
+{
+    [STAThread]
+    private static int Main()
+    {
+        try
+        {
+            var host = Assembly.Load("PaperTodo");
+            CheckSingleHotkeyAuthority(host);
+            CheckRuntimeSlotAuthority(host);
+            CheckCapabilityNormalization(host);
+            CheckProtocolBoundaries(host);
+            CheckSharedWebInfrastructure(host);
+            Console.WriteLine("PaperTodo protocol policy checks passed.");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex);
+            return 1;
+        }
+    }
+
+    private static void CheckSingleHotkeyAuthority(Assembly host)
+    {
+        var managerType = RequireType(host, "PaperTodo.GlobalHotkeyManager");
+        var brokerType = RequireType(host, "PaperTodo.GlobalHotkeyBroker");
+        Assert(
+            managerType.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic)
+                .All(field => field.FieldType.FullName != "System.Windows.Interop.HwndSource"),
+            "GlobalHotkeyManager must not own a native HwndSource; the broker is the single authority.");
+        Assert(
+            brokerType.GetFields(BindingFlags.Static | BindingFlags.NonPublic)
+                .Any(field => field.FieldType.FullName == "System.Windows.Interop.HwndSource"),
+            "GlobalHotkeyBroker must own the process-level native hotkey window.");
+
+        var tryApply = managerType
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Single(method =>
+                method.Name == "TryApply" &&
+                method.GetParameters().Length == 6);
+        var suspend = managerType.GetMethod(
+            "Suspend",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("GlobalHotkeyManager.Suspend was not found.");
+
+        var ownerA = Activator.CreateInstance(managerType, nonPublic: true)
+            ?? throw new InvalidOperationException("Could not create hotkey owner A.");
+        var ownerB = Activator.CreateInstance(managerType, nonPublic: true)
+            ?? throw new InvalidOperationException("Could not create hotkey owner B.");
+
+        try
+        {
+            const string gesture = "Ctrl+Alt+Shift+U";
+            Assert(
+                ApplyReservation(tryApply, ownerA, "a", gesture),
+                "An inactive configured command must be reservable without RegisterHotKey.");
+
+            suspend.Invoke(ownerA, null);
+            Assert(
+                !ApplyReservation(tryApply, ownerB, "b", gesture),
+                "Suspending an owner must release native registration only, not its configured reservation.");
+
+            ((IDisposable)ownerA).Dispose();
+            Assert(
+                ApplyReservation(tryApply, ownerB, "b", gesture),
+                "Removing an owner must release its configured reservation.");
+        }
+        finally
+        {
+            try { ((IDisposable)ownerA).Dispose(); } catch { }
+            try { ((IDisposable)ownerB).Dispose(); } catch { }
+        }
+    }
+
+    private static bool ApplyReservation(
+        MethodInfo tryApply,
+        object manager,
+        string commandId,
+        string gesture)
+    {
+        var bindings = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [commandId] = gesture
+        };
+        var failureType = tryApply.GetParameters()[5].ParameterType.GetElementType()
+            ?? throw new InvalidOperationException("Could not resolve hotkey failure enum.");
+        object?[] args =
+        [
+            bindings,
+            Array.Empty<string>(),
+            new[] { commandId },
+            false,
+            null,
+            Activator.CreateInstance(failureType)
+        ];
+        return (bool)(tryApply.Invoke(manager, args) ?? false);
+    }
+
+    private static void CheckRuntimeSlotAuthority(Assembly host)
+    {
+        var controller = RequireType(host, "PaperTodo.AppController");
+        Assert(
+            controller.GetNestedType("PluginAppRuntimeSlot", BindingFlags.NonPublic) != null,
+            "Plugin app runtime must use one provider slot state object.");
+        Assert(
+            controller.GetField("_pluginAppRuntimeSlots", BindingFlags.Instance | BindingFlags.NonPublic) != null,
+            "Plugin app runtime slot dictionary was not found.");
+
+        var obsoleteParallelState = new[]
+        {
+            "_pluginAppRuntimes",
+            "_pluginAppRuntimeStarts",
+            "_pluginAppRuntimeStartFailures",
+            "_pluginAppRuntimeStartFailureCounts",
+            "_pluginAppRuntimeRetryTokens",
+            "_pluginAppRuntimeRestartRequests"
+        };
+        foreach (var fieldName in obsoleteParallelState)
+        {
+            Assert(
+                controller.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic) == null,
+                $"Obsolete parallel app-runtime state remains: {fieldName}");
+        }
+    }
+
+    private static void CheckCapabilityNormalization(Assembly host)
+    {
+        var registry = RequireType(host, "PaperTodo.PaperBodyPluginRegistry");
+        var manifestType = RequireType(host, "PaperTodo.PaperBodyPluginManifest");
+        var normalize = registry.GetMethod(
+            "NormalizeProtocolFeatures",
+            BindingFlags.Static | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("NormalizeProtocolFeatures was not found.");
+        var capabilities = manifestType.GetProperty("Capabilities")
+            ?? throw new InvalidOperationException("Manifest Capabilities property was not found.");
+
+        var typoManifest = Activator.CreateInstance(manifestType, nonPublic: true)
+            ?? throw new InvalidOperationException("Could not create plugin manifest.");
+        capabilities.SetValue(typoManifest, new[] { "appRunime" });
+        try
+        {
+            normalize.Invoke(null, new[] { typoManifest });
+            throw new InvalidOperationException("Unknown capability typo was silently accepted.");
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is InvalidDataException)
+        {
+        }
+
+        var canonicalManifest = Activator.CreateInstance(manifestType, nonPublic: true)
+            ?? throw new InvalidOperationException("Could not create canonical plugin manifest.");
+        capabilities.SetValue(
+            canonicalManifest,
+            new[] { " APPRUNTIME ", "textzoom", "noteLinks", "appRuntime" });
+        normalize.Invoke(null, new[] { canonicalManifest });
+        var values = (string[]?)capabilities.GetValue(canonicalManifest) ?? [];
+        Assert(values.SequenceEqual(new[] { "appRuntime", "textZoom", "noteLinks" }),
+            "Capability normalization did not produce one canonical representation.");
+    }
+
+    private static void CheckProtocolBoundaries(Assembly host)
+    {
+        var hostApi = RequireType(host, "PaperTodo.PaperBodyPluginHostApi");
+        Assert(
+            hostApi.GetMethod(
+                "EnsurePresentationProtocol",
+                BindingFlags.Instance | BindingFlags.NonPublic) != null,
+            "Own-paper presentation lacks an explicit protocol-version gate.");
+    }
+
+    private static void CheckSharedWebInfrastructure(Assembly host)
+    {
+        var infrastructure = RequireType(host, "PaperTodo.WebPluginRuntimeInfrastructure");
+        var appRuntime = RequireType(host, "PaperTodo.WebPluginAppRuntime");
+        Assert(
+            infrastructure.GetProperty(
+                "JsonOptions",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic) != null,
+            "Shared Web runtime serialization policy was not found.");
+        Assert(
+            appRuntime.GetField(
+                "JsonOptions",
+                BindingFlags.Static | BindingFlags.NonPublic) == null,
+            "WebPluginAppRuntime still owns a duplicate JSON bridge policy.");
+    }
+
+    private static Type RequireType(Assembly assembly, string name) =>
+        assembly.GetType(name, throwOnError: true)
+        ?? throw new InvalidOperationException($"Type was not found: {name}");
+
+    private static void Assert(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+}


### PR DESCRIPTION
Temporary hardening/validation PR for protocol 2.0. Scope: protocol-version gating, configured-vs-active shortcut reservation, one process-level hotkey broker, single-slot appRuntime lifecycle, shared Web runtime policy, capability typo rejection, thread-contract docs, and protocol policy checks. This PR is intentionally draft until Windows CI and review pass.