### PR TITLE
fix(plugin): harden protocol 2.0 before freeze

### DIFF
--- a/PaperTodo.Plugin.Abstractions/PaperAppRuntimeContracts.cs
+++ b/PaperTodo.Plugin.Abstractions/PaperAppRuntimeContracts.cs
@@ -70,6 +70,10 @@ public sealed class PaperAppRuntimeContext
 /// "appRuntime" must implement this interface. After startupPaper handling, PaperTodo starts one
 /// provider runtime when at least one real paper uses the provider; a later 0 -> 1 transition starts
 /// it as well, and deleting/repurposing the last such paper ends it.
+///
+/// CreateAppRuntime is invoked on PaperTodo's UI-owned runtime lifecycle and must return promptly.
+/// Do not perform slow I/O or long initialization inline; start plugin-owned background work from the
+/// returned runtime and stop it with cancellation during Dispose.
 /// </summary>
 public interface IPaperAppRuntimeProvider
 {

--- a/PaperTodo.Plugin.Abstractions/PaperPresentationContracts.cs
+++ b/PaperTodo.Plugin.Abstractions/PaperPresentationContracts.cs
@@ -4,6 +4,11 @@ namespace PaperTodo.Plugin;
 /// Presentation controls for the paper that owns the current plugin body session. PaperTodo keeps
 /// ownership of window lifetime, geometry, animation, capsule layout, focus and activation rules;
 /// plugins can only request state changes for their own host paper.
+///
+/// These methods are request APIs, not visual-completion APIs. A Native call returning, or the
+/// equivalent Web Promise resolving, means PaperTodo accepted/processed the request; it does not
+/// mean a window animation or final visual state has completed. Later host or lifecycle changes may
+/// supersede a previously accepted request.
 /// </summary>
 public interface IPaperPresentationApi
 {

--- a/plugin-samples/PROTOCOL-2.0-SHORTCUTS.md
+++ b/plugin-samples/PROTOCOL-2.0-SHORTCUTS.md
@@ -37,7 +37,7 @@ PaperTodo 负责：
 - 主键盘数字 / 小键盘数字别名规则；
 - 设置保存、恢复默认和插件卸载 / 退出清理。
 
-插件不要自己调用 Windows `RegisterHotKey` 来绕过这套管理。
+插件不要自己调用 Windows `RegisterHotKey` 来绕过这套管理。无法映射到真实 Windows 虚拟键的键名会在解析阶段直接拒绝，例如未定义的数值型 `Key`，不会拖到 `RegisterHotKey` 时才失败。
 
 ### 1.1 宿主自带的 paper action
 
@@ -60,7 +60,15 @@ paper.toggle
 
 这些动作由 PaperTodo 直接执行，不要求 body session 当前展开，也不需要插件 app runtime 接收回调。
 
-宿主会优先定位同 provider 的 `startupPaper` 所有者纸片；没有时回退到同 provider 的可见纸片，再回退到第一张同 provider 纸片。当前不会在完全没有该 provider 纸片时凭空猜一个多实例目标。
+同一个 provider 有多张纸片时，宿主按这个顺序找目标：
+
+1. 当前激活的同 provider 纸片；
+2. 最近激活过的同 provider 纸片；
+3. 当前可见的同 provider 纸片；
+4. 同 provider 的 `startupPaper` 所有者纸片；
+5. 第一张同 provider 纸片。
+
+完全没有该 provider 纸片时，不会凭空猜一个多实例目标。
 
 ## 2. 插件自己的快捷键 action
 
@@ -87,6 +95,8 @@ paper.toggle
 - 插件声明 `appRuntime`；
 - action id 为 1～80 个 ASCII 字母、数字、`.`、`_`、`-`；
 - app runtime 注册快捷键 action handler。
+
+自定义 action 是 **provider/appRuntime 全局动作**。宿主不会替它选择某张纸片，也不会在回调中偷偷附加“当前纸片”语义；如果插件业务需要目标纸片，应通过 Workspace 数据自行决定。
 
 ### Native app runtime
 
@@ -167,6 +177,8 @@ public interface IPaperPresentationApi
 
 调用会排队回到 PaperTodo UI Dispatcher，再进入已有 `ShowPaper`、`HidePaper`、`SetPaperCollapsedRuntime`、`ArrangeDeepCapsules`、`BringPaperToFront` 等宿主流程，不绕过已有状态机。
 
+**Presentation 是请求接口，不是动画完成接口。** Native 方法返回只表示请求已经交给宿主；不表示窗口动画已经结束，也不保证之后不会被新的宿主状态或生命周期变化覆盖。
+
 ## 4. Web：控制承载自己的纸片
 
 body 页面直接使用：
@@ -192,7 +204,7 @@ await papertodo.paper.expand({ activate: false });
 await papertodo.paper.toggleCollapsed({ activate: false });
 ```
 
-这些方法仍通过 PaperTodo host request，不直接操作 WebView2 外层窗口。
+这些方法仍通过 PaperTodo host request，不直接操作 WebView2 外层窗口。Promise resolve 表示宿主已经接受/处理这次请求，**不代表视觉动画已经完成**。
 
 ## 5. 快捷键录制期间的处理
 

--- a/src/AppController.PluginAppRuntime.cs
+++ b/src/AppController.PluginAppRuntime.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Threading;
 using System.Windows;
 using System.Windows.Threading;
 using PaperTodo.Plugin;
@@ -14,6 +15,8 @@ public sealed partial class AppController
         TimeSpan.FromSeconds(3),
         TimeSpan.FromSeconds(10)
     ];
+    private static readonly TimeSpan PluginAppRuntimeStableFailureResetAfter =
+        TimeSpan.FromSeconds(30);
 
     private enum PluginAppRuntimeState
     {
@@ -58,7 +61,12 @@ public sealed partial class AppController
 
     private sealed class PluginAppRuntimeLifetime
     {
-        public bool Active { get; set; } = true;
+        private int _active = 1;
+
+        public bool IsActive => Volatile.Read(ref _active) != 0;
+
+        public bool TryDeactivate() =>
+            Interlocked.Exchange(ref _active, 0) != 0;
     }
 
     private sealed class PluginAppRuntimeOwnershipCanceledException(string message)
@@ -70,14 +78,18 @@ public sealed partial class AppController
         public PaperBodyPluginDescriptor? Descriptor { get; set; }
         public PluginAppRuntimeState State { get; set; }
         public Guid RuntimeId { get; set; }
+        public PluginAppRuntimeLifetime? Lifetime { get; set; }
         public PluginAppRuntimeLease? Lease { get; set; }
         public int FailureCount { get; set; }
         public int RetryGeneration { get; set; }
         public bool RestartRequested { get; set; }
+        public DateTimeOffset RunningSinceUtc { get; set; }
     }
 
     private sealed class PluginAppRuntimeLease : IDisposable
     {
+        private int _disposed;
+
         public required Guid RuntimeId { get; init; }
         public required string ProviderId { get; init; }
         public required PluginAppRuntimeLifetime Lifetime { get; init; }
@@ -89,17 +101,18 @@ public sealed partial class AppController
 
         public void Dispose()
         {
-            if (!Lifetime.Active)
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
             {
                 return;
             }
 
-            Lifetime.Active = false;
+            Lifetime.TryDeactivate();
             try { Runtime?.Dispose(); } catch { }
             try { GlobalShortcuts.Dispose(); } catch { }
             try { GlobalTopBar.Dispose(); } catch { }
             try { Workspace.Dispose(); } catch { }
-            if (NativeFactory is IDisposable disposable)
+            if (NativeFactory is IDisposable disposable &&
+                !ReferenceEquals(Runtime, NativeFactory))
             {
                 try { disposable.Dispose(); } catch { }
             }
@@ -221,23 +234,36 @@ public sealed partial class AppController
         slot.Descriptor = descriptor;
         slot.RuntimeId = Guid.NewGuid();
         slot.RestartRequested = false;
+        slot.RunningSinceUtc = default;
         var runtimeId = slot.RuntimeId;
-        _ = StartPluginAppRuntimeSlotAsync(slot, descriptor, runtimeId);
+        var lifetime = new PluginAppRuntimeLifetime();
+        slot.Lifetime = lifetime;
+        _ = StartPluginAppRuntimeSlotAsync(
+            slot,
+            descriptor,
+            runtimeId,
+            lifetime);
     }
 
     private async Task StartPluginAppRuntimeSlotAsync(
         PluginAppRuntimeSlot slot,
         PaperBodyPluginDescriptor descriptor,
-        Guid runtimeId)
+        Guid runtimeId,
+        PluginAppRuntimeLifetime lifetime)
     {
         PluginAppRuntimeLease? lease = null;
         try
         {
-            lease = await CreatePluginAppRuntimeLeaseAsync(slot, descriptor, runtimeId);
+            lease = await CreatePluginAppRuntimeLeaseAsync(
+                slot,
+                descriptor,
+                runtimeId,
+                lifetime);
 
             if (!IsCurrentPluginAppRuntimeSlot(slot, runtimeId) ||
                 !IsPluginAppRuntimeDesired(descriptor.Id))
             {
+                ClearPluginAppRuntimeLifetime(slot, lifetime);
                 lease.Dispose();
                 lease = null;
                 if (IsCurrentPluginAppRuntimeSlot(slot, runtimeId))
@@ -250,25 +276,30 @@ public sealed partial class AppController
 
             if (slot.RestartRequested)
             {
+                ClearPluginAppRuntimeLifetime(slot, lifetime);
                 lease.Dispose();
                 lease = null;
                 slot.RestartRequested = false;
-                slot.State = PluginAppRuntimeState.Stopped;
-                slot.FailureCount = 0;
-                QueuePluginStatusUiRefresh();
-                ReconcilePluginAppRuntimes();
+                HandlePluginAppRuntimeFailure(
+                    slot,
+                    descriptor,
+                    new InvalidOperationException(
+                        "The Web plugin app runtime failed while completing startup."),
+                    "startup-ready");
                 return;
             }
 
             slot.Lease = lease;
             lease = null;
             slot.State = PluginAppRuntimeTransitions.StartSucceeded(slot.State);
-            slot.FailureCount = 0;
+            slot.RunningSinceUtc = DateTimeOffset.UtcNow;
             slot.RetryGeneration++;
             QueuePluginStatusUiRefresh();
         }
         catch (PluginAppRuntimeOwnershipCanceledException)
         {
+            ClearPluginAppRuntimeLifetime(slot, lifetime);
+            lifetime.TryDeactivate();
             lease?.Dispose();
             if (!IsCurrentPluginAppRuntimeSlot(slot, runtimeId))
             {
@@ -282,35 +313,33 @@ public sealed partial class AppController
         }
         catch (Exception ex)
         {
+            ClearPluginAppRuntimeLifetime(slot, lifetime);
+            lifetime.TryDeactivate();
             lease?.Dispose();
             if (!IsCurrentPluginAppRuntimeSlot(slot, runtimeId))
             {
                 return;
             }
 
-            HandlePluginAppRuntimeStartFailure(slot, descriptor, ex);
+            HandlePluginAppRuntimeFailure(slot, descriptor, ex, "start");
         }
     }
 
     private async Task<PluginAppRuntimeLease> CreatePluginAppRuntimeLeaseAsync(
         PluginAppRuntimeSlot slot,
         PaperBodyPluginDescriptor descriptor,
-        Guid runtimeId)
+        Guid runtimeId,
+        PluginAppRuntimeLifetime lifetime)
     {
         if (!IsCurrentPluginAppRuntimeSlot(slot, runtimeId) ||
-            !IsPluginAppRuntimeDesired(descriptor.Id))
+            !IsPluginAppRuntimeDesired(descriptor.Id) ||
+            !lifetime.IsActive)
         {
             throw new PluginAppRuntimeOwnershipCanceledException(
                 "The plugin app runtime no longer has an entity-paper owner.");
         }
 
-        var lifetime = new PluginAppRuntimeLifetime();
-        bool IsActive() =>
-            lifetime.Active &&
-            IsRunning &&
-            IsCurrentPluginAppRuntimeSlot(slot, runtimeId) &&
-            slot.State is PluginAppRuntimeState.Starting or PluginAppRuntimeState.Running &&
-            IsPluginAppRuntimeDesired(descriptor.Id);
+        bool IsActive() => lifetime.IsActive;
 
         var workspace = new PaperAppRuntimeWorkspaceApi(
             this,
@@ -377,7 +406,7 @@ public sealed partial class AppController
                     "Built-in body providers cannot declare plugin appRuntime.");
             }
 
-            if (!IsActive())
+            if (!lifetime.IsActive)
             {
                 throw new PluginAppRuntimeOwnershipCanceledException(
                     "The plugin app runtime lost its entity-paper owner while starting.");
@@ -397,12 +426,13 @@ public sealed partial class AppController
         }
         catch
         {
-            lifetime.Active = false;
+            lifetime.TryDeactivate();
             try { runtime?.Dispose(); } catch { }
             try { globalShortcuts.Dispose(); } catch { }
             try { globalTopBar.Dispose(); } catch { }
             try { workspace.Dispose(); } catch { }
-            if (nativeFactory is IDisposable disposable)
+            if (nativeFactory is IDisposable disposable &&
+                !ReferenceEquals(runtime, nativeFactory))
             {
                 try { disposable.Dispose(); } catch { }
             }
@@ -410,19 +440,24 @@ public sealed partial class AppController
         }
     }
 
-    private void HandlePluginAppRuntimeStartFailure(
+    private void HandlePluginAppRuntimeFailure(
         PluginAppRuntimeSlot slot,
         PaperBodyPluginDescriptor descriptor,
-        Exception exception)
+        Exception exception,
+        string phase)
     {
         slot.Lease = null;
+        slot.Lifetime?.TryDeactivate();
+        slot.Lifetime = null;
         slot.RestartRequested = false;
+        slot.RunningSinceUtc = default;
         slot.FailureCount++;
         var attempt = slot.FailureCount;
 
         Trace.TraceWarning(
-            "Plugin app runtime failed to start. Provider={0}; Attempt={1}; Exception={2}",
+            "Plugin app runtime failure. Provider={0}; Phase={1}; Attempt={2}; Exception={3}",
             descriptor.Id,
+            phase,
             attempt,
             exception.GetBaseException());
 
@@ -545,22 +580,64 @@ public sealed partial class AppController
                 }
 
                 if (slot.State != PluginAppRuntimeState.Running ||
-                    slot.Lease?.RuntimeId != runtimeId)
+                    slot.Lease?.RuntimeId != runtimeId ||
+                    slot.Descriptor == null)
                 {
                     return;
                 }
 
+                if (slot.RunningSinceUtc != default &&
+                    DateTimeOffset.UtcNow - slot.RunningSinceUtc >=
+                    PluginAppRuntimeStableFailureResetAfter)
+                {
+                    slot.FailureCount = 0;
+                }
+
+                var descriptor = slot.Descriptor;
                 var lease = slot.Lease;
                 slot.Lease = null;
+                slot.Lifetime?.TryDeactivate();
+                slot.Lifetime = null;
                 slot.RetryGeneration++;
                 slot.RestartRequested = false;
-                slot.FailureCount = 0;
-                slot.State = PluginAppRuntimeState.Stopped;
                 lease.Dispose();
-                QueuePluginStatusUiRefresh();
-                ReconcilePluginAppRuntimes();
+                HandlePluginAppRuntimeFailure(
+                    slot,
+                    descriptor,
+                    new InvalidOperationException(
+                        "The Web plugin app runtime requested restart after a fatal navigation or browser-process failure."),
+                    "running");
             }),
             DispatcherPriority.Background);
+    }
+
+    private void RetryFailedPluginAppRuntimeAfterSettingsChanged(string providerId)
+    {
+        if (_pluginAppRuntimeDisposing ||
+            IsExiting ||
+            !_pluginAppRuntimeSlots.TryGetValue(providerId, out var slot) ||
+            slot.State is not (PluginAppRuntimeState.Backoff or PluginAppRuntimeState.Failed))
+        {
+            return;
+        }
+
+        slot.RetryGeneration++;
+        slot.RestartRequested = false;
+        slot.FailureCount = 0;
+        slot.RunningSinceUtc = default;
+        slot.State = PluginAppRuntimeState.Stopped;
+        QueuePluginStatusUiRefresh();
+        ReconcilePluginAppRuntimes();
+    }
+
+    private static void ClearPluginAppRuntimeLifetime(
+        PluginAppRuntimeSlot slot,
+        PluginAppRuntimeLifetime lifetime)
+    {
+        if (ReferenceEquals(slot.Lifetime, lifetime))
+        {
+            slot.Lifetime = null;
+        }
     }
 
     private void RemovePluginAppRuntimeSlot(string providerId)
@@ -573,6 +650,8 @@ public sealed partial class AppController
         slot.RetryGeneration++;
         slot.RestartRequested = false;
         slot.State = PluginAppRuntimeState.Disposing;
+        slot.Lifetime?.TryDeactivate();
+        slot.Lifetime = null;
         var lease = slot.Lease;
         slot.Lease = null;
         lease?.Dispose();

--- a/src/AppController.PluginShortcuts.cs
+++ b/src/AppController.PluginShortcuts.cs
@@ -29,6 +29,10 @@ public sealed partial class AppController
         new(StringComparer.Ordinal);
     private readonly Dictionary<string, PluginGlobalShortcutRuntime> _pluginShortcutRuntimes =
         new(StringComparer.Ordinal);
+    private readonly HashSet<PaperWindow> _pluginShortcutTrackedWindows = [];
+    private readonly Dictionary<string, long> _pluginShortcutPaperRecency =
+        new(StringComparer.Ordinal);
+    private long _pluginShortcutPaperRecencySequence;
     private string? _pluginShortcutRecordingCommandId;
 
     internal void SetPluginGlobalShortcutRuntime(
@@ -79,6 +83,7 @@ public sealed partial class AppController
             return;
         }
 
+        EnsurePluginShortcutWindowTracking();
         _pluginShortcutRegistrations.Clear();
         _pluginShortcutStatuses.Clear();
 
@@ -549,6 +554,7 @@ public sealed partial class AppController
     private void NotifyPluginSettingsChanged(PaperBodyPluginDescriptor descriptor)
     {
         var settingsJson = _paperBodyPlugins.DataStore.GetSettingsJson(descriptor);
+        RetryFailedPluginAppRuntimeAfterSettingsChanged(descriptor.Id);
         foreach (var window in _windows.Values.ToList())
         {
             window.NotifyPaperBodyPluginSettingsChanged(descriptor.Id, settingsJson);
@@ -687,8 +693,45 @@ public sealed partial class AppController
         }
     }
 
+    private void EnsurePluginShortcutWindowTracking()
+    {
+        foreach (var pair in _windows.ToArray())
+        {
+            var paperId = pair.Key;
+            var window = pair.Value;
+            if (window.IsClosed || !_pluginShortcutTrackedWindows.Add(window))
+            {
+                continue;
+            }
+
+            window.Activated += (_, _) =>
+            {
+                if (!IsExiting && !window.IsClosed)
+                {
+                    RecordPluginShortcutPaperActivation(paperId);
+                }
+            };
+            window.Closed += (_, _) =>
+            {
+                _pluginShortcutTrackedWindows.Remove(window);
+                _pluginShortcutPaperRecency.Remove(paperId);
+            };
+
+            if (window.IsActive)
+            {
+                RecordPluginShortcutPaperActivation(paperId);
+            }
+        }
+    }
+
+    private void RecordPluginShortcutPaperActivation(string paperId)
+    {
+        _pluginShortcutPaperRecency[paperId] = ++_pluginShortcutPaperRecencySequence;
+    }
+
     private PaperData? ResolvePluginShortcutPaper(string providerId)
     {
+        EnsurePluginShortcutWindowTracking();
         var candidates = State.Papers
             .Where(paper =>
                 paper.Type == PaperTypes.Note &&
@@ -697,12 +740,28 @@ public sealed partial class AppController
                     providerId,
                     StringComparison.Ordinal))
             .ToArray();
-        return candidates.FirstOrDefault(paper =>
+
+        var active = candidates.FirstOrDefault(paper =>
+            _windows.TryGetValue(paper.Id, out var window) &&
+            !window.IsClosed &&
+            window.IsActive);
+        if (active != null)
+        {
+            RecordPluginShortcutPaperActivation(active.Id);
+            return active;
+        }
+
+        var recent = candidates
+            .Where(paper => _pluginShortcutPaperRecency.ContainsKey(paper.Id))
+            .OrderByDescending(paper => _pluginShortcutPaperRecency[paper.Id])
+            .FirstOrDefault();
+        return recent
+               ?? candidates.FirstOrDefault(paper => paper.IsVisible)
+               ?? candidates.FirstOrDefault(paper =>
                    string.Equals(
                        paper.StartupOwnerPluginId,
                        providerId,
                        StringComparison.Ordinal))
-               ?? candidates.FirstOrDefault(paper => paper.IsVisible)
                ?? candidates.FirstOrDefault();
     }
 
@@ -718,5 +777,7 @@ public sealed partial class AppController
         _pluginShortcutRegistrations.Clear();
         _pluginShortcutStatuses.Clear();
         _pluginShortcutRuntimes.Clear();
+        _pluginShortcutTrackedWindows.Clear();
+        _pluginShortcutPaperRecency.Clear();
     }
 }

--- a/src/AppController.PluginTopBar.cs
+++ b/src/AppController.PluginTopBar.cs
@@ -112,8 +112,9 @@ public sealed partial class AppController
         // The app-runtime manager validates protocol 2.0 before creating this capability. Once a
         // runtime is alive, it owns its process-lifetime lease even if the user rescans plugin
         // manifests; ordinary plugin Reload does not silently replace a running app runtime.
-        // Global action count is intentionally unbounded at the protocol layer; host layout remains
-        // authoritative and plugin Priority only orders plugin actions, never host actions.
+        // Global action count is intentionally unbounded at the protocol layer. The window gives
+        // current-paper actions first claim on plugin space, then considers Global actions by
+        // Priority and shows only the prefix that still fits without displacing host controls.
         var normalized = NormalizePluginTopBarActions(
             actions,
             maximumCount: null,
@@ -198,6 +199,18 @@ public sealed partial class AppController
                 IsActive(item.IsActive));
 
         var actions = new List<PluginTopBarActionBinding>();
+        if (paperRegistration != null)
+        {
+            foreach (var action in paperRegistration.Actions)
+            {
+                actions.Add(new PluginTopBarActionBinding(
+                    paperRegistration.SessionId,
+                    paperRegistration.ProviderId,
+                    PaperTopBarActionScope.Paper,
+                    action));
+            }
+        }
+
         var globalActions = _pluginGlobalTopBars.Values
             .Where(item => IsActive(item.IsActive))
             .SelectMany(registration =>
@@ -217,18 +230,6 @@ public sealed partial class AppController
                 item.Registration.ProviderId,
                 PaperTopBarActionScope.Global,
                 item.Action));
-        }
-
-        if (paperRegistration != null)
-        {
-            foreach (var action in paperRegistration.Actions)
-            {
-                actions.Add(new PluginTopBarActionBinding(
-                    paperRegistration.SessionId,
-                    paperRegistration.ProviderId,
-                    PaperTopBarActionScope.Paper,
-                    action));
-            }
         }
 
         return new PluginTopBarRenderState(

--- a/src/AppController.Plugins.cs
+++ b/src/AppController.Plugins.cs
@@ -684,6 +684,7 @@ public sealed partial class AppController
             setting,
             value);
         var settingsJson = _paperBodyPlugins.DataStore.GetSettingsJson(descriptor);
+        RetryFailedPluginAppRuntimeAfterSettingsChanged(descriptor.Id);
         foreach (var window in _windows.Values.ToList())
         {
             window.NotifyPaperBodyPluginSettingsChanged(descriptor.Id, settingsJson);

--- a/src/GlobalHotkeys.cs
+++ b/src/GlobalHotkeys.cs
@@ -478,7 +478,14 @@ internal readonly record struct ShortcutGesture(Key Key, ModifierKeys Modifiers)
             return true;
         }
 
-        return Enum.TryParse(text, ignoreCase: true, out key);
+        if (!Enum.TryParse(text, ignoreCase: true, out key) ||
+            !Enum.IsDefined(key) ||
+            KeyInterop.VirtualKeyFromKey(key) == 0)
+        {
+            key = Key.None;
+            return false;
+        }
+        return true;
     }
 
     private static string StorageKeyName(Key key)

--- a/src/PaperBodyPluginRegistry.cs
+++ b/src/PaperBodyPluginRegistry.cs
@@ -81,8 +81,9 @@ internal sealed class PaperBodyPluginMiniSizeManifest
 
 /// <summary>
 /// Discovers one fully trusted, unsandboxed native or local Web plugin from each self-contained
-/// plugins/&lt;plugin-id&gt;/plugin.json folder. Native code is not hot-replaced: changed native
-/// folders remain on the loaded version until restart, while Web folders reload immediately.
+/// plugins/&lt;plugin-id&gt;/plugin.json folder. Protocol 2.0 has no plugin hot-reload contract: code,
+/// manifest and Web file changes are discovered on the next app start. Loaded native assemblies
+/// remain loaded for the process lifetime.
 /// </summary>
 internal sealed partial class PaperBodyPluginRegistry : IDisposable
 {
@@ -564,6 +565,20 @@ internal sealed partial class PaperBodyPluginRegistry : IDisposable
             {
                 throw new InvalidDataException(
                     $"Native plugin runtime requirements {plugin.RuntimeRequirements} must match manifest requirements {manifestRuntimeRequirements}.");
+            }
+            const PaperBodyCapabilities supportedCapabilities =
+                PaperBodyCapabilities.TextZoom |
+                PaperBodyCapabilities.NoteLinks;
+            if ((plugin.Capabilities & ~supportedCapabilities) != PaperBodyCapabilities.None)
+            {
+                throw new InvalidDataException(
+                    $"Native plugin capabilities {plugin.Capabilities} contain unsupported flags.");
+            }
+            var manifestCapabilities = ParseCapabilities(manifest.Capabilities);
+            if (plugin.Capabilities != manifestCapabilities)
+            {
+                throw new InvalidDataException(
+                    $"Native plugin capabilities {plugin.Capabilities} must match manifest body capabilities {manifestCapabilities}.");
             }
             if (plugin.StateVersion < 1 ||
                 plugin.StateVersion != manifest.StateVersion)

--- a/src/PaperWindow.PluginTopBar.cs
+++ b/src/PaperWindow.PluginTopBar.cs
@@ -11,6 +11,8 @@ public sealed partial class PaperWindow
 {
     private static bool _pluginTopBarLoadedHandlerRegistered;
     private StackPanel? _pluginTopBarButtonsHost;
+    private readonly List<(FrameworkElement Element, PaperTopBarActionScope Scope)>
+        _pluginTopBarActionElements = [];
     private PaperHostTopBarActions _pluginHiddenHostTopBarActions;
     private bool _pluginHostActionVisibilityHooksInstalled;
     private bool _pluginTopBarCapacityHookInstalled;
@@ -51,6 +53,7 @@ public sealed partial class PaperWindow
         }
 
         _pluginTopBarButtonsHost.Children.Clear();
+        _pluginTopBarActionElements.Clear();
         foreach (var binding in state.Actions)
         {
             if (!binding.Action.Visible)
@@ -80,15 +83,10 @@ public sealed partial class PaperWindow
                         ? NormalizeBodyProviderId(_paper.BodyProviderId)
                         : string.Empty);
             _pluginTopBarButtonsHost.Children.Add(button);
+            _pluginTopBarActionElements.Add((button, binding.Scope));
         }
 
-        // The host responsive algorithm can run while the entire right action group is Collapsed,
-        // when a child's ActualWidth is no longer useful. Keep this aggregate width explicit so the
-        // same TopBarOuterWidth calculation stays truthful in both visible and collapsed states.
-        _pluginTopBarButtonsHost.Width = _pluginTopBarButtonsHost.Children
-            .OfType<FrameworkElement>()
-            .Sum(TopBarOuterWidth);
-
+        UpdatePluginTopBarHostWidth();
         _pluginHiddenHostTopBarActions = state.HiddenHostActions;
         ReconcilePluginHiddenHostTopBarActions();
         ReconcilePluginTopBarCapacity();
@@ -139,32 +137,85 @@ public sealed partial class PaperWindow
         _reconcilingPluginTopBarCapacity = true;
         try
         {
-            // Host actions have absolute precedence over plugin priority. First ask the existing
-            // responsive policy whether the host-only right group fits. Only if it does, try adding
-            // the plugin group. If that would collapse the whole host action group, the plugin group
-            // yields and the host-only decision is applied again. This keeps Global action count
-            // unbounded without letting a plugin push PaperTodo's own controls out first.
-            _pluginTopBarButtonsHost.Visibility = Visibility.Collapsed;
+            // Host actions always win. Paper-scoped plugin actions are a small bounded group and
+            // keep their existing all-or-nothing behavior. Global actions are unbounded at the API
+            // layer, so after host + Paper fit, expose them one at a time in Priority order. The
+            // first Global button that no longer fits is hidden and ends the pass; no controls are
+            // compressed, reordered or removed to make room for it.
+            foreach (var (element, _) in _pluginTopBarActionElements)
+            {
+                element.Visibility = Visibility.Collapsed;
+            }
+            UpdatePluginTopBarHostWidth();
             UpdateTopBarResponsiveLayout();
 
-            if (_pluginTopBarButtonsHost.Children.Count == 0 ||
+            if (_pluginTopBarActionElements.Count == 0 ||
                 _topBarActionButtonsHost.Visibility != Visibility.Visible)
             {
                 return;
             }
 
-            _pluginTopBarButtonsHost.Visibility = Visibility.Visible;
+            foreach (var (element, scope) in _pluginTopBarActionElements)
+            {
+                if (scope == PaperTopBarActionScope.Paper)
+                {
+                    element.Visibility = Visibility.Visible;
+                }
+            }
+            UpdatePluginTopBarHostWidth();
             UpdateTopBarResponsiveLayout();
             if (_topBarActionButtonsHost.Visibility != Visibility.Visible)
             {
-                _pluginTopBarButtonsHost.Visibility = Visibility.Collapsed;
+                foreach (var (element, _) in _pluginTopBarActionElements)
+                {
+                    element.Visibility = Visibility.Collapsed;
+                }
+                UpdatePluginTopBarHostWidth();
                 UpdateTopBarResponsiveLayout();
+                return;
+            }
+
+            foreach (var (element, scope) in _pluginTopBarActionElements)
+            {
+                if (scope != PaperTopBarActionScope.Global)
+                {
+                    continue;
+                }
+
+                element.Visibility = Visibility.Visible;
+                UpdatePluginTopBarHostWidth();
+                UpdateTopBarResponsiveLayout();
+                if (_topBarActionButtonsHost.Visibility == Visibility.Visible)
+                {
+                    continue;
+                }
+
+                element.Visibility = Visibility.Collapsed;
+                UpdatePluginTopBarHostWidth();
+                UpdateTopBarResponsiveLayout();
+                break;
             }
         }
         finally
         {
             _reconcilingPluginTopBarCapacity = false;
         }
+    }
+
+    private void UpdatePluginTopBarHostWidth()
+    {
+        if (_pluginTopBarButtonsHost == null)
+        {
+            return;
+        }
+
+        var width = _pluginTopBarActionElements
+            .Where(item => item.Element.Visibility == Visibility.Visible)
+            .Sum(item => TopBarOuterWidth(item.Element));
+        _pluginTopBarButtonsHost.Width = width;
+        _pluginTopBarButtonsHost.Visibility = width > 0
+            ? Visibility.Visible
+            : Visibility.Collapsed;
     }
 
     private void EnsurePluginHostActionVisibilityHooks()

--- a/src/WebPaperBodySession.cs
+++ b/src/WebPaperBodySession.cs
@@ -133,6 +133,8 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
     private bool _initialized;
     private bool _documentReady;
     private bool _pluginDocumentReady;
+    private ulong _documentNavigationId;
+    private bool _hasDocumentNavigation;
     private bool _disposed;
     private bool _runtimeVisible;
     private bool _presentationVisible;
@@ -429,6 +431,8 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
             return;
         }
 
+        _documentNavigationId = e.NavigationId;
+        _hasDocumentNavigation = true;
         _documentGeneration++;
         ClearHostSubscriptions();
         _documentReady = false;
@@ -437,11 +441,14 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
 
     private void OnNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs e)
     {
-        if (!ReferenceEquals(sender, _webView.CoreWebView2))
+        if (!ReferenceEquals(sender, _webView.CoreWebView2) ||
+            !_hasDocumentNavigation ||
+            e.NavigationId != _documentNavigationId)
         {
             return;
         }
 
+        _hasDocumentNavigation = false;
         if (!e.IsSuccess)
         {
             ShowFailure(
@@ -548,6 +555,7 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
 
         var previous = _webView;
         _webViewGeneration++;
+        _hasDocumentNavigation = false;
         BackgroundWebViewHost.Detach(previous);
         DisposeWebView(previous);
         _context.SetInputClaims(PaperBodyInputClaims.None);
@@ -621,6 +629,7 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
     {
         if (ReferenceEquals(webView, _webView))
         {
+            _hasDocumentNavigation = false;
             _documentGeneration++;
             ClearHostSubscriptions();
         }
@@ -989,6 +998,7 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
             return;
         }
 
+        _hasDocumentNavigation = false;
         _documentGeneration++;
         ClearHostSubscriptions();
         ShowFailure(Strings.Format("PluginsWebProcessFailedFormat", e.ProcessFailedKind));
@@ -1077,6 +1087,7 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
             return;
         }
 
+        _hasDocumentNavigation = false;
         _documentGeneration++;
         ClearHostSubscriptions();
         _documentReady = false;
@@ -1283,6 +1294,7 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
         _disposed = true;
         _miniViewHost?.Dispose();
         _miniViewHost = null;
+        _hasDocumentNavigation = false;
         _documentGeneration++;
         ClearHostSubscriptions();
         _lifetime.Cancel();

--- a/src/WebPluginAppRuntime.cs
+++ b/src/WebPluginAppRuntime.cs
@@ -19,12 +19,15 @@ internal sealed class WebPluginAppRuntime : IDisposable
     private readonly Action _requestRestart;
     private readonly WebView2CompositionControl _webView;
     private readonly CancellationTokenSource _lifetime = new();
+    private readonly TaskCompletionSource<bool> _startupReady =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
     private string _expectedOrigin = string.Empty;
     private bool _documentReady;
     private ulong _documentNavigationId;
     private bool _hasDocumentNavigation;
     private bool _reloadRecoveryPending;
     private bool _restartRequested;
+    private bool _startupCompleted;
     private bool _disposed;
 
     public WebPluginAppRuntime(
@@ -99,11 +102,20 @@ internal sealed class WebPluginAppRuntime : IDisposable
         core.ProcessFailed += OnProcessFailed;
         await core.AddScriptToExecuteOnDocumentCreatedAsync(
             BuildBridgeScript(_expectedOrigin));
+        _lifetime.Token.ThrowIfCancellationRequested();
+        ThrowIfInactive();
         core.SetVirtualHostNameToFolderMapping(
             hostName,
             webRoot,
             CoreWebView2HostResourceAccessKind.DenyCors);
         _webView.Source = runtimeUri;
+
+        // A runtime is not Running merely because Source was assigned. Wait until the matching
+        // local document has completed and the host has sent initialize, so bridge requests cannot
+        // disappear into the pre-navigation gap.
+        await _startupReady.Task.WaitAsync(_lifetime.Token);
+        _startupCompleted = true;
+        ThrowIfInactive();
     }
 
     private static string BuildBridgeScript(string expectedOrigin)
@@ -115,13 +127,19 @@ internal sealed class WebPluginAppRuntime : IDisposable
               if (window !== window.top || location.origin !== expectedOrigin || window.papertodo) return;
               const listeners = new Set();
               const pending = new Map();
+              const queuedRequests = [];
               let sequence = 0;
+              let hostReady = false;
               const post = (type, payload = null) => window.chrome.webview.postMessage({ type, payload });
+              const postRequest = payload => {
+                if (hostReady) post('hostRequest', payload);
+                else queuedRequests.push(payload);
+              };
               const request = (method, params = {}) => {
                 const requestId = `a${++sequence}`;
                 return new Promise((resolve, reject) => {
                   pending.set(requestId, { resolve, reject });
-                  post('hostRequest', { requestId, method: String(method ?? ''), params: params ?? {} });
+                  postRequest({ requestId, method: String(method ?? ''), params: params ?? {} });
                 });
               };
               const workspace = Object.freeze({ request });
@@ -149,6 +167,12 @@ internal sealed class WebPluginAppRuntime : IDisposable
               });
               window.chrome.webview.addEventListener('message', event => {
                 const message = event.data;
+                if (message?.type === 'initialize' && !hostReady) {
+                  hostReady = true;
+                  for (const payload of queuedRequests.splice(0)) {
+                    post('hostRequest', payload);
+                  }
+                }
                 if (message?.type === 'hostResponse') {
                   const waiter = pending.get(message.requestId);
                   if (waiter) {
@@ -216,7 +240,8 @@ internal sealed class WebPluginAppRuntime : IDisposable
             _documentReady = false;
             TryClearGlobalTopBar();
             TryClearGlobalShortcuts();
-            RequestRestart();
+            FailStartupOrRestart(
+                $"Web app runtime navigation failed ({e.WebErrorStatus}).");
             return;
         }
 
@@ -232,6 +257,7 @@ internal sealed class WebPluginAppRuntime : IDisposable
             permissions = _workspace.GrantedPermissions.OrderBy(value => value).ToArray(),
             settings = ReadSettings()
         });
+        _startupReady.TrySetResult(true);
     }
 
     private void OnProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
@@ -246,7 +272,7 @@ internal sealed class WebPluginAppRuntime : IDisposable
             case CoreWebView2ProcessFailedKind.BrowserProcessExited:
                 // The control is closed after a browser-process exit and cannot be recovered with
                 // Reload. Let the app-runtime owner dispose this instance and create a fresh view.
-                RequestRestart();
+                FailStartupOrRestart("The WebView2 browser process exited.");
                 return;
 
             case CoreWebView2ProcessFailedKind.RenderProcessExited:
@@ -276,7 +302,7 @@ internal sealed class WebPluginAppRuntime : IDisposable
         var dispatcher = _webView.Dispatcher;
         if (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
         {
-            RequestRestart();
+            FailStartupOrRestart("The Web app runtime dispatcher is shutting down.");
             return;
         }
 
@@ -294,17 +320,35 @@ internal sealed class WebPluginAppRuntime : IDisposable
                     var core = _webView.CoreWebView2;
                     if (core == null)
                     {
-                        RequestRestart();
+                        FailStartupOrRestart("The Web app runtime renderer could not be reloaded.");
                         return;
                     }
                     core.Reload();
                 }
-                catch
+                catch (Exception ex)
                 {
-                    RequestRestart();
+                    FailStartupOrRestart(
+                        $"The Web app runtime renderer reload failed: {ex.GetBaseException().Message}");
                 }
             }),
             DispatcherPriority.Background);
+    }
+
+    private void FailStartupOrRestart(string message)
+    {
+        _hasDocumentNavigation = false;
+        _reloadRecoveryPending = false;
+        _documentReady = false;
+        TryClearGlobalTopBar();
+        TryClearGlobalShortcuts();
+
+        if (!_startupCompleted &&
+            _startupReady.TrySetException(new InvalidOperationException(message)))
+        {
+            return;
+        }
+
+        RequestRestart();
     }
 
     private void RequestRestart()
@@ -504,6 +548,7 @@ internal sealed class WebPluginAppRuntime : IDisposable
         TryClearGlobalTopBar();
         TryClearGlobalShortcuts();
         _disposed = true;
+        _startupReady.TrySetCanceled();
         _lifetime.Cancel();
         if (_webView.CoreWebView2 is { } core)
         {

--- a/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
+++ b/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
@@ -11,14 +11,16 @@ internal static class Program
             var host = Assembly.Load("PaperTodo");
             var abstractions = Assembly.Load("PaperTodo.Plugin.Abstractions");
             CheckSingleHotkeyAuthority(host);
+            CheckShortcutValidation(host);
             CheckRuntimeSlotAuthority(host);
             CheckRuntimeTransitions(host);
             CheckCapabilityNormalization(host);
             CheckProtocolBoundaries(host);
             CheckSharedWebInfrastructure(host);
+            CheckWebBodyNavigationIdentity(host);
             CheckManifestRuntimeAndMiniContracts(host);
             CheckGlobalTopBarPriority(host, abstractions);
-            CheckAppRuntimeSettings(abstractions);
+            CheckAppRuntimeSettings(host, abstractions);
             Console.WriteLine("PaperTodo protocol policy checks passed.");
             return 0;
         }
@@ -112,6 +114,23 @@ internal static class Program
         return (applied, args[5]?.ToString() ?? "");
     }
 
+    private static void CheckShortcutValidation(Assembly host)
+    {
+        var gestureType = RequireType(host, "PaperTodo.ShortcutGesture");
+        var tryParse = gestureType.GetMethod(
+            "TryParse",
+            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("ShortcutGesture.TryParse was not found.");
+
+        object?[] invalid = ["Ctrl+999", Activator.CreateInstance(gestureType)];
+        Assert(!(bool)(tryParse.Invoke(null, invalid) ?? false),
+            "Undefined numeric Key enum values must not parse as shortcuts.");
+
+        object?[] valid = ["Ctrl+Alt+A", Activator.CreateInstance(gestureType)];
+        Assert((bool)(tryParse.Invoke(null, valid) ?? false),
+            "A normal defined shortcut stopped parsing.");
+    }
+
     private static void CheckRuntimeSlotAuthority(Assembly host)
     {
         var controller = RequireType(host, "PaperTodo.AppController");
@@ -121,6 +140,13 @@ internal static class Program
         Assert(
             controller.GetField("_pluginAppRuntimeSlots", BindingFlags.Instance | BindingFlags.NonPublic) != null,
             "Plugin app runtime slot dictionary was not found.");
+
+        var lifetime = controller.GetNestedType("PluginAppRuntimeLifetime", BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("PluginAppRuntimeLifetime was not found.");
+        Assert(lifetime.GetField("_active", BindingFlags.Instance | BindingFlags.NonPublic)?.FieldType == typeof(int),
+            "App runtime lifetime must expose one atomic integer active token to worker-side APIs.");
+        Assert(lifetime.GetMethod("TryDeactivate", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) != null,
+            "App runtime lifetime must support atomic revocation before teardown.");
 
         var obsoleteParallelState = new[]
         {
@@ -159,7 +185,7 @@ internal static class Program
         Assert(InvokeState("StartSucceeded", State("Starting")) == "Running",
             "Starting must enter Running after successful creation.");
         Assert(InvokeState("StartFailed", 1, 3) == "Backoff",
-            "The first start failure must enter Backoff.");
+            "The first runtime failure must enter Backoff.");
         Assert(InvokeState("StartFailed", 3, 3) == "Backoff",
             "The third bounded retry failure must still enter Backoff.");
         Assert(InvokeState("StartFailed", 4, 3) == "Failed",
@@ -234,6 +260,20 @@ internal static class Program
         Assert(
             appRuntime.GetField("JsonOptions", BindingFlags.Static | BindingFlags.NonPublic) == null,
             "WebPluginAppRuntime still owns a duplicate JSON bridge policy.");
+        Assert(
+            appRuntime.GetField("_startupReady", BindingFlags.Instance | BindingFlags.NonPublic) != null,
+            "Web app runtime must wait for document readiness before it enters Running.");
+    }
+
+    private static void CheckWebBodyNavigationIdentity(Assembly host)
+    {
+        var body = RequireType(host, "PaperTodo.WebPaperBodySession");
+        Assert(
+            body.GetField("_documentNavigationId", BindingFlags.Instance | BindingFlags.NonPublic)?.FieldType == typeof(ulong),
+            "Web body navigation completion must be tied to the current NavigationId.");
+        Assert(
+            body.GetField("_hasDocumentNavigation", BindingFlags.Instance | BindingFlags.NonPublic)?.FieldType == typeof(bool),
+            "Web body must track whether a current navigation identity exists.");
     }
 
     private static void CheckManifestRuntimeAndMiniContracts(Assembly host)
@@ -262,9 +302,14 @@ internal static class Program
         Assert(
             controller.GetField("MaximumGlobalTopBarActions", BindingFlags.Static | BindingFlags.NonPublic) == null,
             "Global Top Bar still has a hard action-count limit.");
+
+        var window = RequireType(host, "PaperTodo.PaperWindow");
+        Assert(
+            window.GetField("_pluginTopBarActionElements", BindingFlags.Instance | BindingFlags.NonPublic) != null,
+            "Top Bar must retain action scope per button so Global actions can be fitted individually.");
     }
 
-    private static void CheckAppRuntimeSettings(Assembly abstractions)
+    private static void CheckAppRuntimeSettings(Assembly host, Assembly abstractions)
     {
         var settings = RequireType(abstractions, "PaperTodo.Plugin.IPaperAppRuntimeSettings");
         Assert(settings.GetProperty("Json")?.PropertyType == typeof(string),
@@ -273,6 +318,13 @@ internal static class Program
         var context = RequireType(abstractions, "PaperTodo.Plugin.PaperAppRuntimeContext");
         Assert(context.GetProperty("Settings")?.PropertyType == settings,
             "PaperAppRuntimeContext.Settings was not found.");
+
+        var controller = RequireType(host, "PaperTodo.AppController");
+        Assert(
+            controller.GetMethod(
+                "RetryFailedPluginAppRuntimeAfterSettingsChanged",
+                BindingFlags.Instance | BindingFlags.NonPublic) != null,
+            "A Failed/Backoff app runtime must have a settings-change recovery path.");
     }
 
     private static Type RequireType(Assembly assembly, string name) =>


### PR DESCRIPTION
收口 Protocol 2.0 审查项，不重构整体架构：

- appRuntime 使用原子 lifetime token，补齐 worker Settings 线程安全合同，并避免重复 Dispose
- Web appRuntime 等待当前 document ready 后才进入 Running；启动前 bridge 请求排队；运行期致命故障复用 1s/3s/10s backoff
- Web body 用 NavigationId 拒绝过期 NavigationCompleted
- Global Top Bar：Paper action 优先，Global 按 Priority 逐个占用剩余空间；当前 Global 放不下即隐藏并停止，不挤宿主/纸片按钮，不限制注册数量
- paper.* 快捷键目标：当前激活 → MRU → 可见 → startupPaper → 第一张；自定义 action 保持 provider/appRuntime 全局语义
- 拒绝未定义数值 Key；Native body capability 与 manifest 对齐验证
- Failed/Backoff runtime 在插件设置变化后允许重试
- 明确 Presentation 为 request 语义，并补 Native runtime 构造/Dispose 文档与策略检查

目标分支：`agent/plugin-protocol-2.0`。先保持 Draft，用于跑 Windows Plugin samples / protocol policy checks。