### PR TITLE
fix: harden plugin protocol post-merge edges

### DIFF
--- a/src/AppController.PluginTopBar.cs
+++ b/src/AppController.PluginTopBar.cs
@@ -17,6 +17,7 @@ internal sealed record PluginTopBarRenderState(
 public sealed partial class AppController
 {
     private const int MaximumPaperTopBarActions = 4;
+    private const int MaximumGlobalTopBarActions = 256;
     private const int MaximumTopBarActionIdLength = 64;
     private const int MaximumTopBarToolTipLength = 160;
     private const int MaximumTopBarCharacterLength = 8;
@@ -112,12 +113,11 @@ public sealed partial class AppController
         // The app-runtime manager validates protocol 2.0 before creating this capability. Once a
         // runtime is alive, it owns its process-lifetime lease even if the user rescans plugin
         // manifests; ordinary plugin Reload does not silently replace a running app runtime.
-        // Global action count is intentionally unbounded at the protocol layer. The window gives
-        // current-paper actions first claim on plugin space, then considers Global actions by
-        // Priority and shows only the prefix that still fits without displacing host controls.
+        // The protocol accepts a broad descriptor set, while the window still materializes only
+        // the fitting prefix after current-paper actions have taken first claim on plugin space.
         var normalized = NormalizePluginTopBarActions(
             actions,
-            maximumCount: null,
+            MaximumGlobalTopBarActions,
             "global");
 
         if (_pluginGlobalTopBars.TryGetValue(providerId, out var current) &&

--- a/src/GlobalHotkeys.cs
+++ b/src/GlobalHotkeys.cs
@@ -632,7 +632,11 @@ internal static class GlobalHotkeyBroker
         public HashSet<string> ReservedCommandIds { get; set; } = new(StringComparer.Ordinal);
     }
 
-    private sealed record NativeBinding(Guid OwnerId, string CommandId, int NativeId);
+    private sealed record NativeBinding(
+        Guid OwnerId,
+        string CommandId,
+        int NativeId,
+        ShortcutGesture Gesture);
 
     private static readonly HwndSource Source;
     private static readonly Dictionary<Guid, OwnerState> Owners = new();
@@ -681,7 +685,8 @@ internal static class GlobalHotkeyBroker
             if (owner.Bindings.TryGetValue(commandId, out var binding) &&
                 NativeByGesture.Values.Any(item =>
                     item.OwnerId == ownerId &&
-                    string.Equals(item.CommandId, commandId, StringComparison.Ordinal)))
+                    string.Equals(item.CommandId, commandId, StringComparison.Ordinal) &&
+                    IsCommittedNativeBinding(owner, item)))
             {
                 active[commandId] = binding;
             }
@@ -754,7 +759,11 @@ internal static class GlobalHotkeyBroker
                 return false;
             }
 
-            var native = new NativeBinding(pair.Value.OwnerId, pair.Value.CommandId, nativeId);
+            var native = new NativeBinding(
+                pair.Value.OwnerId,
+                pair.Value.CommandId,
+                nativeId,
+                pair.Key);
             NativeByGesture[pair.Key] = native;
             NativeById[nativeId] = native;
             newlyRegistered.Add(pair.Key);
@@ -805,7 +814,8 @@ internal static class GlobalHotkeyBroker
             var updated = new NativeBinding(
                 pair.Value.OwnerId,
                 pair.Value.CommandId,
-                current.NativeId);
+                current.NativeId,
+                pair.Key);
             NativeByGesture[pair.Key] = updated;
             NativeById[current.NativeId] = updated;
         }
@@ -860,6 +870,9 @@ internal static class GlobalHotkeyBroker
     {
         foreach (var gesture in gestures.Reverse())
         {
+            // A failed release can leave a native registration in the maps, but dispatch validates
+            // every WM_HOTKEY against the owner's last committed plan. Rollback residue is therefore
+            // inert immediately and a later apply retries the native cleanup.
             _ = TryUnregisterGesture(gesture);
         }
     }
@@ -884,8 +897,9 @@ internal static class GlobalHotkeyBroker
             return false;
         }
 
-        NativeByGesture[gesture] = binding;
-        NativeById[binding.NativeId] = binding;
+        var restored = binding with { Gesture = gesture };
+        NativeByGesture[gesture] = restored;
+        NativeById[restored.NativeId] = restored;
         return true;
     }
 
@@ -983,6 +997,26 @@ internal static class GlobalHotkeyBroker
         return gesture.RegistrationGestures(includeDigitAlias);
     }
 
+    private static bool IsCommittedNativeBinding(
+        OwnerState owner,
+        NativeBinding native)
+    {
+        if (!owner.ActiveCommandIds.Contains(native.CommandId) ||
+            !owner.Bindings.TryGetValue(native.CommandId, out var text) ||
+            string.IsNullOrWhiteSpace(text) ||
+            !ShortcutGesture.TryParse(text, out var gesture) ||
+            gesture.Key == Key.None)
+        {
+            return false;
+        }
+
+        return RegistrationGesturesFor(
+                native.CommandId,
+                gesture,
+                _distinguishNumpadDigits)
+            .Contains(native.Gesture);
+    }
+
     private static bool TryRegisterGesture(
         ShortcutGesture gesture,
         out int nativeId,
@@ -1031,7 +1065,8 @@ internal static class GlobalHotkeyBroker
     {
         if (msg == WmHotkey && NativeById.TryGetValue(wParam.ToInt32(), out var native))
         {
-            if (Owners.TryGetValue(native.OwnerId, out var owner))
+            if (Owners.TryGetValue(native.OwnerId, out var owner) &&
+                IsCommittedNativeBinding(owner, native))
             {
                 owner.Dispatch(native.CommandId);
             }

--- a/src/WebPaperBodySession.cs
+++ b/src/WebPaperBodySession.cs
@@ -309,10 +309,17 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
               let stateProvider = null;
               let markHostReady;
               const hostReady = new Promise(resolve => { markHostReady = resolve; });
-              const post = (type, payload = null) => {
+              const rawPost = (type, payload = null) => {
                 window.chrome.webview.postMessage({ type, payload });
               };
-              const saveState = state => post('saveState', state ?? {});
+              const post = (type, payload = null) => {
+                if (type === 'saveState') {
+                  rawPost(type, payload);
+                  return;
+                }
+                void hostReady.then(() => rawPost(type, payload));
+              };
+              const saveState = state => rawPost('saveState', state ?? {});
               const flushState = () => {
                 if (typeof stateProvider !== 'function') return;
                 try { saveState(stateProvider()); } catch { }

--- a/src/WebPaperBodySession.cs
+++ b/src/WebPaperBodySession.cs
@@ -11,8 +11,9 @@ using PaperTodo.Plugin;
 
 namespace PaperTodo;
 
-// Web plugins are trusted. WebView2 keeps its normal navigation, frame, popup and permission
-// behavior; only PaperTodo's host bridge remains restricted to the plugin's local top-level origin.
+// Web plugins are trusted. Top-level body navigation stays on the plugin's local origin; normal
+// http/https/mailto external navigation is handed to the system shell. Frames, popups and permission
+// behavior remain WebView2-owned, and PaperTodo's host bridge is restricted to the local top-level origin.
 internal sealed partial class WebPaperBodySession : IPaperBodySession
 {
     private static readonly object EnvironmentGate = new();
@@ -428,10 +429,22 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
             })();
             """;
     }
+
     private void OnNavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs e)
     {
         if (!ReferenceEquals(sender, _webView.CoreWebView2))
         {
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(_expectedOrigin) &&
+            !IsAllowedDocumentUri(e.Uri))
+        {
+            e.Cancel = true;
+            if (Uri.TryCreate(e.Uri, UriKind.Absolute, out var external))
+            {
+                TryOpenExternalNavigation(external);
+            }
             return;
         }
 
@@ -481,17 +494,9 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
             return;
         }
 
-        try
+        if (TryOpenExternalNavigation(uri))
         {
-            Process.Start(new ProcessStartInfo(uri.AbsoluteUri)
-            {
-                UseShellExecute = true
-            });
             e.Cancel = true;
-        }
-        catch
-        {
-            // If the default browser could not be launched, keep WebView2's normal download.
         }
     }
 
@@ -499,6 +504,27 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
     {
         return Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
             string.Equals(uri.GetLeftPart(UriPartial.Authority), _expectedOrigin, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryOpenExternalNavigation(Uri uri)
+    {
+        if (uri.Scheme is not ("http" or "https" or "mailto"))
+        {
+            return false;
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo(uri.AbsoluteUri)
+            {
+                UseShellExecute = true
+            });
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private void ShowWebView()
@@ -696,6 +722,14 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
             }
 
             var type = typeElement.GetString() ?? "";
+            if (!CanAcceptDocumentMessage(
+                    type,
+                    _documentReady,
+                    _pluginDocumentReady))
+            {
+                return;
+            }
+
             var payload = root.TryGetProperty("payload", out var payloadElement)
                 ? payloadElement
                 : default;
@@ -743,6 +777,13 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
             // A malformed plugin message is isolated to the plugin body.
         }
     }
+
+    private static bool CanAcceptDocumentMessage(
+        string type,
+        bool documentReady,
+        bool pluginDocumentReady) =>
+        string.Equals(type, "saveState", StringComparison.Ordinal) ||
+        (documentReady && pluginDocumentReady);
 
     private void HandleHostRequest(JsonElement payload)
     {

--- a/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
+++ b/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
@@ -51,6 +51,14 @@ internal static class Program
         Assert(
             brokerType.GetMethod("TryRestoreGesture", BindingFlags.Static | BindingFlags.NonPublic) != null,
             "The broker must be able to restore registrations during rollback.");
+        Assert(
+            brokerType.GetMethod("IsCommittedNativeBinding", BindingFlags.Static | BindingFlags.NonPublic) != null,
+            "Native hotkey dispatch must validate rollback residue against the committed owner plan.");
+        var nativeBinding = brokerType.GetNestedType("NativeBinding", BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("GlobalHotkeyBroker.NativeBinding was not found.");
+        Assert(
+            nativeBinding.GetProperty("Gesture") != null,
+            "Native hotkey bindings must retain their exact gesture so stale rollback residue can be rejected.");
 
         var tryApply = managerType
             .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
@@ -274,6 +282,21 @@ internal static class Program
         Assert(
             body.GetField("_hasDocumentNavigation", BindingFlags.Instance | BindingFlags.NonPublic)?.FieldType == typeof(bool),
             "Web body must track whether a current navigation identity exists.");
+
+        var canAccept = body.GetMethod(
+            "CanAcceptDocumentMessage",
+            BindingFlags.Static | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Web body document-message guard was not found.");
+        Assert((bool)(canAccept.Invoke(null, ["saveState", false, false]) ?? false),
+            "A departing Web document must still be allowed to flush its final state.");
+        Assert(!(bool)(canAccept.Invoke(null, ["hostRequest", false, false]) ?? true),
+            "A stale or navigating Web document must not keep Workspace mutation authority.");
+        Assert((bool)(canAccept.Invoke(null, ["hostRequest", true, true]) ?? false),
+            "The current ready plugin document must retain normal host-request authority.");
+
+        Assert(
+            body.GetMethod("TryOpenExternalNavigation", BindingFlags.Static | BindingFlags.NonPublic) != null,
+            "Web body must have an explicit system-shell path for external top-level navigation.");
     }
 
     private static void CheckManifestRuntimeAndMiniContracts(Assembly host)
@@ -299,9 +322,14 @@ internal static class Program
             "PaperTopBarAction.Priority was not found.");
 
         var controller = RequireType(host, "PaperTodo.AppController");
+        var maximumGlobal = controller.GetField(
+            "MaximumGlobalTopBarActions",
+            BindingFlags.Static | BindingFlags.NonPublic);
         Assert(
-            controller.GetField("MaximumGlobalTopBarActions", BindingFlags.Static | BindingFlags.NonPublic) == null,
-            "Global Top Bar still has a hard action-count limit.");
+            maximumGlobal?.IsLiteral == true &&
+            maximumGlobal.GetRawConstantValue() is int limit &&
+            limit == 256,
+            "Global Top Bar must keep a broad but finite 256-action descriptor cap.");
 
         var window = RequireType(host, "PaperTodo.PaperWindow");
         Assert(


### PR DESCRIPTION
Post-merge hardening for plugin protocol 2.0:

- keep failed hotkey rollback residue inert at dispatch time
- reject stale Web body messages after navigation except final saveState flushes
- hand external top-level Web body navigation to the system shell
- cap Global Top Bar descriptors at 256 per provider runtime
- extend protocol policy checks for these guards