### PR TITLE
fix: harden web plugin document navigation

### DIFF
--- a/plugin-samples/README.md
+++ b/plugin-samples/README.md
@@ -915,7 +915,7 @@ https://<plugin-id>.papertodo.local/
 
 只有该插件的本地 **top-level document** 获得 `window.papertodo`。远程页面、iframe 或其他 origin 不获得宿主 bridge。
 
-PaperTodo 把 Web 插件视为可信内容；WebView2 保持正常导航、frame、popup 和 permission 行为。普通 HTTP/HTTPS 下载优先交给系统默认浏览器；`blob:`、`data:` 等 session-local download 保留 WebView2 默认行为。
+PaperTodo 把 Web 插件视为可信内容；同源 frame/popup 和 permission 保持 WebView2 默认行为，外部顶层导航及外部新窗口请求交给系统默认程序。普通 HTTP/HTTPS 下载优先交给系统默认浏览器；`blob:`、`data:` 等 session-local download 保留 WebView2 默认行为。
 
 ### 10.2 Body bridge
 

--- a/plugin-samples/README.md
+++ b/plugin-samples/README.md
@@ -330,7 +330,7 @@ Native 最终目录只保留运行所需内容。不要分发无必要的 PDB/XM
 - 隐藏、折叠、没有展开正文、没有 live body session 都不影响 runtime；只有实体 paper 是否存在/仍使用这个 provider 才影响它；
 - 未声明 `appRuntime` 的 Native 插件仍保持 manifest-only discovery，不会因为仅安装就加载 DLL；
 - Native 声明后必须实现 `IPaperAppRuntimeProvider`；
-- Web 声明后可以用 manifest `runtime` 指定入口；省略时默认使用 `entry` 同目录的 `runtime.html`；显式路径必须仍位于 Web `entry` 静态目录内并在插件发现阶段通过存在性检查；
+- Web 声明后可以用 manifest `runtime` 指定入口；省略时默认使用 `entry` 同目录 `runtime.html`；显式路径必须仍位于 Web `entry` 静态目录内并在插件发现阶段通过存在性检查；
 - PaperTodo 不等待第三方 runtime 完成才继续主程序自身启动；不同 provider 的 runtime 也独立启动；
 - 插件文件没有热重载入口；修改 `plugin.json`、DLL、Web body/mini/runtime 文件后统一重启 PaperTodo 生效。
 
@@ -617,7 +617,7 @@ Top Bar 不提供另一套 `GetBodyText/SetBodyText`。需要读写目标纸片�
 Top Bar 有两个明确 owner：
 
 - **Paper**：`PaperBodyContext.TopBar` / body session；只显示在承载当前 session 的插件纸片，每 session 最多 4 个；
-- **Global**：`PaperAppRuntimeContext.GlobalTopBar` / provider app runtime；显示在所有 PaperTodo 纸片，协议不限制 provider 声明的 Global action 数量。Global runtime 要求该 provider 当前至少有一张实体插件 paper，但不要求任何 paper 可见、展开或拥有 live body session。
+- **Global**：`PaperAppRuntimeContext.GlobalTopBar` / provider app runtime；显示在所有 PaperTodo 纸片，每个 provider app runtime 最多声明 256 个 Global action。Global runtime 要求该 provider 当前至少有一张实体插件 paper，但不要求任何 paper 可见、展开或拥有 live body session。
 
 Global action 使用 `Priority` 排序，数值越大越靠前；同优先级先按 provider runtime 注册顺序，再按插件声明顺序，保证稳定。**PaperTodo 自己的宿主 action 不进入这个数值空间，拥有不可被插件覆盖的最高优先级。** 窗口宽度不足时插件 contribution 先让位，不会因为插件声明很多 Global action 而先把宿主 action 挤掉。
 
@@ -1055,7 +1055,7 @@ Native 插件是 fully trusted / unsandboxed .NET/WPF 代码，与 PaperTodo 当
 - 把 Top Bar 当 Workspace 数据 API；
 - 给 PaperTodo 传 `FrameworkElement` / Button / 完整 SVG，而不是 action descriptor；
 - action ID 重复、超过 64 字符或含非法字符；
-- 一个 session 超过 4 个 Paper action；Global action 没有数量上限，但不应滥用无意义按钮；
+- 一个 session 超过 4 个 Paper action；每个 provider app runtime 最多 256 个 Global action；
 - 误以为插件 `Priority` 可以超过宿主按钮；宿主 action 永远拥有更高优先级；
 - SVG 传完整 `<svg>` 而不是 Path Data；
 - `Stroke` 使用非有限或 0.1～4.0 之外的 `strokeWidth`；

--- a/plugin-samples/README.md
+++ b/plugin-samples/README.md
@@ -84,7 +84,7 @@ plugins/com.example.hello/
 Native 项目使用 .NET 10 + WPF，并引用：
 
 ```text
-PaperTodo.Plugin.Abstractions/PaperBodyPluginContracts.csproj
+PaperTodo.Plugin.Abstractions/PaperTodo.Plugin.Abstractions.csproj
 ```
 
 示例项目配置：

--- a/plugin-samples/README.md
+++ b/plugin-samples/README.md
@@ -84,7 +84,7 @@ plugins/com.example.hello/
 Native 项目使用 .NET 10 + WPF，并引用：
 
 ```text
-PaperTodo.Plugin.Abstractions/PaperTodo.Plugin.Abstractions.csproj
+PaperTodo.Plugin.Abstractions/PaperBodyPluginContracts.csproj
 ```
 
 示例项目配置：
@@ -330,7 +330,7 @@ Native 最终目录只保留运行所需内容。不要分发无必要的 PDB/XM
 - 隐藏、折叠、没有展开正文、没有 live body session 都不影响 runtime；只有实体 paper 是否存在/仍使用这个 provider 才影响它；
 - 未声明 `appRuntime` 的 Native 插件仍保持 manifest-only discovery，不会因为仅安装就加载 DLL；
 - Native 声明后必须实现 `IPaperAppRuntimeProvider`；
-- Web 声明后可以用 manifest `runtime` 指定入口；省略时默认使用 `entry` 同目录 `runtime.html`；显式路径必须仍位于 Web `entry` 静态目录内并在插件发现阶段通过存在性检查；
+- Web 声明后可以用 manifest `runtime` 指定入口；省略时默认使用 `entry` 同目录的 `runtime.html`；显式路径必须仍位于 Web `entry` 静态目录内并在插件发现阶段通过存在性检查；
 - PaperTodo 不等待第三方 runtime 完成才继续主程序自身启动；不同 provider 的 runtime 也独立启动；
 - 插件文件没有热重载入口；修改 `plugin.json`、DLL、Web body/mini/runtime 文件后统一重启 PaperTodo 生效。
 

--- a/src/WebPaperBodySession.cs
+++ b/src/WebPaperBodySession.cs
@@ -312,19 +312,25 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
               let sequence = 0;
               let stateProvider = null;
               let documentToken = null;
+              let pendingState = null;
+              let hasPendingState = false;
               let markHostReady;
               const hostReady = new Promise(resolve => { markHostReady = resolve; });
               const rawPost = (type, payload = null) => {
                 window.chrome.webview.postMessage({ type, payload, documentToken });
               };
               const post = (type, payload = null) => {
-                if (type === 'saveState' && documentToken) {
-                  rawPost(type, payload);
-                  return;
-                }
                 void hostReady.then(() => rawPost(type, payload));
               };
-              const saveState = state => post('saveState', state ?? {});
+              const saveState = state => {
+                const nextState = state ?? {};
+                if (documentToken) {
+                  rawPost('saveState', nextState);
+                  return;
+                }
+                pendingState = nextState;
+                hasPendingState = true;
+              };
               const flushState = () => {
                 if (typeof stateProvider !== 'function') return;
                 try { saveState(stateProvider()); } catch { }
@@ -412,6 +418,11 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
                   documentToken = typeof message.documentToken === 'string'
                     ? message.documentToken
                     : null;
+                  if (documentToken && hasPendingState) {
+                    rawPost('saveState', pendingState);
+                  }
+                  pendingState = null;
+                  hasPendingState = false;
                   markHostReady();
                 }
                 if (message?.type === 'commitRequested') flushState();
@@ -467,8 +478,11 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
 
         _documentNavigationId = e.NavigationId;
         _hasDocumentNavigation = true;
-        _departingDocumentToken = _activeDocumentToken;
-        _activeDocumentToken = null;
+        if (!string.IsNullOrWhiteSpace(_activeDocumentToken))
+        {
+            _departingDocumentToken = _activeDocumentToken;
+            _activeDocumentToken = null;
+        }
         _documentGeneration++;
         ClearHostSubscriptions();
         _documentReady = false;
@@ -518,10 +532,10 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
             return;
         }
 
-        if (Uri.TryCreate(e.Uri, UriKind.Absolute, out var uri) &&
-            TryOpenExternalNavigation(uri))
+        e.Handled = true;
+        if (Uri.TryCreate(e.Uri, UriKind.Absolute, out var uri))
         {
-            e.Handled = true;
+            _ = TryOpenExternalNavigation(uri);
         }
     }
 

--- a/src/WebPaperBodySession.cs
+++ b/src/WebPaperBodySession.cs
@@ -318,13 +318,13 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
                 window.chrome.webview.postMessage({ type, payload, documentToken });
               };
               const post = (type, payload = null) => {
-                if (type === 'saveState') {
+                if (type === 'saveState' && documentToken) {
                   rawPost(type, payload);
                   return;
                 }
                 void hostReady.then(() => rawPost(type, payload));
               };
-              const saveState = state => rawPost('saveState', state ?? {});
+              const saveState = state => post('saveState', state ?? {});
               const flushState = () => {
                 if (typeof stateProvider !== 'function') return;
                 try { saveState(stateProvider()); } catch { }

--- a/src/WebPaperBodySession.cs
+++ b/src/WebPaperBodySession.cs
@@ -12,8 +12,9 @@ using PaperTodo.Plugin;
 namespace PaperTodo;
 
 // Web plugins are trusted. Top-level body navigation stays on the plugin's local origin; normal
-// http/https/mailto external navigation is handed to the system shell. Frames, popups and permission
-// behavior remain WebView2-owned, and PaperTodo's host bridge is restricted to the local top-level origin.
+// http/https/mailto external navigation and external new-window requests are handed to the system
+// shell. Same-origin frames/popups and permission behavior remain WebView2-owned, and PaperTodo's
+// host bridge is restricted to the local top-level origin.
 internal sealed partial class WebPaperBodySession : IPaperBodySession
 {
     private static readonly object EnvironmentGate = new();
@@ -136,6 +137,8 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
     private bool _pluginDocumentReady;
     private ulong _documentNavigationId;
     private bool _hasDocumentNavigation;
+    private string? _activeDocumentToken;
+    private string? _departingDocumentToken;
     private bool _disposed;
     private bool _runtimeVisible;
     private bool _presentationVisible;
@@ -253,6 +256,7 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
             core.ProcessFailed += OnProcessFailed;
             core.NavigationStarting += OnNavigationStarting;
             core.NavigationCompleted += OnNavigationCompleted;
+            core.NewWindowRequested += OnNewWindowRequested;
             core.DownloadStarting += OnDownloadStarting;
             await core.AddScriptToExecuteOnDocumentCreatedAsync(
                 BuildBridgeScript(_expectedOrigin));
@@ -307,10 +311,11 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
               const pending = new Map();
               let sequence = 0;
               let stateProvider = null;
+              let documentToken = null;
               let markHostReady;
               const hostReady = new Promise(resolve => { markHostReady = resolve; });
               const rawPost = (type, payload = null) => {
-                window.chrome.webview.postMessage({ type, payload });
+                window.chrome.webview.postMessage({ type, payload, documentToken });
               };
               const post = (type, payload = null) => {
                 if (type === 'saveState') {
@@ -403,7 +408,12 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
               });
               window.chrome.webview.addEventListener('message', event => {
                 const message = event.data;
-                if (message?.type === 'initialize') markHostReady();
+                if (message?.type === 'initialize') {
+                  documentToken = typeof message.documentToken === 'string'
+                    ? message.documentToken
+                    : null;
+                  markHostReady();
+                }
                 if (message?.type === 'commitRequested') flushState();
                 if (message?.type === 'hostResponse') {
                   const waiter = pending.get(message.requestId);
@@ -457,6 +467,8 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
 
         _documentNavigationId = e.NavigationId;
         _hasDocumentNavigation = true;
+        _departingDocumentToken = _activeDocumentToken;
+        _activeDocumentToken = null;
         _documentGeneration++;
         ClearHostSubscriptions();
         _documentReady = false;
@@ -485,7 +497,31 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
         ShowWebView();
         if (_pluginDocumentReady)
         {
+            _activeDocumentToken = Guid.NewGuid().ToString("N");
+            _departingDocumentToken = null;
             SendInitialize();
+        }
+        else
+        {
+            _activeDocumentToken = null;
+            _departingDocumentToken = null;
+        }
+    }
+
+    private void OnNewWindowRequested(
+        object? sender,
+        CoreWebView2NewWindowRequestedEventArgs e)
+    {
+        if (!ReferenceEquals(sender, _webView.CoreWebView2) ||
+            IsAllowedDocumentUri(e.Uri))
+        {
+            return;
+        }
+
+        if (Uri.TryCreate(e.Uri, UriKind.Absolute, out var uri) &&
+            TryOpenExternalNavigation(uri))
+        {
+            e.Handled = true;
         }
     }
 
@@ -667,6 +703,8 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
         if (ReferenceEquals(webView, _webView))
         {
             _hasDocumentNavigation = false;
+            _activeDocumentToken = null;
+            _departingDocumentToken = null;
             _documentGeneration++;
             ClearHostSubscriptions();
         }
@@ -684,6 +722,7 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
             core.ProcessFailed -= OnProcessFailed;
             core.NavigationStarting -= OnNavigationStarting;
             core.NavigationCompleted -= OnNavigationCompleted;
+            core.NewWindowRequested -= OnNewWindowRequested;
             core.DownloadStarting -= OnDownloadStarting;
         }
         try { webView.Dispose(); } catch { }
@@ -695,6 +734,7 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
         {
             type = "initialize",
             surface = "body",
+            documentToken = _activeDocumentToken,
             paperId = _context.PaperId,
             providerId = _context.ProviderId,
             apiVersion = _context.ApiVersion,
@@ -733,6 +773,15 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
                     type,
                     _documentReady,
                     _pluginDocumentReady))
+            {
+                return;
+            }
+
+            var documentToken = root.TryGetProperty("documentToken", out var tokenElement) &&
+                                tokenElement.ValueKind == JsonValueKind.String
+                ? tokenElement.GetString()
+                : null;
+            if (!HasDocumentAuthority(type, documentToken))
             {
                 return;
             }
@@ -791,6 +840,25 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
         bool pluginDocumentReady) =>
         string.Equals(type, "saveState", StringComparison.Ordinal) ||
         (documentReady && pluginDocumentReady);
+
+    private bool HasDocumentAuthority(string type, string? documentToken)
+    {
+        if (string.IsNullOrWhiteSpace(documentToken))
+        {
+            return false;
+        }
+
+        if (_documentReady &&
+            _pluginDocumentReady &&
+            string.Equals(documentToken, _activeDocumentToken, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return string.Equals(type, "saveState", StringComparison.Ordinal) &&
+            !_documentReady &&
+            string.Equals(documentToken, _departingDocumentToken, StringComparison.Ordinal);
+    }
 
     private void HandleHostRequest(JsonElement payload)
     {
@@ -1051,6 +1119,8 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
         }
 
         _hasDocumentNavigation = false;
+        _activeDocumentToken = null;
+        _departingDocumentToken = null;
         _documentGeneration++;
         ClearHostSubscriptions();
         ShowFailure(Strings.Format("PluginsWebProcessFailedFormat", e.ProcessFailedKind));
@@ -1140,6 +1210,8 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
         }
 
         _hasDocumentNavigation = false;
+        _activeDocumentToken = null;
+        _departingDocumentToken = null;
         _documentGeneration++;
         ClearHostSubscriptions();
         _documentReady = false;
@@ -1347,6 +1419,8 @@ internal sealed partial class WebPaperBodySession : IPaperBodySession
         _miniViewHost?.Dispose();
         _miniViewHost = null;
         _hasDocumentNavigation = false;
+        _activeDocumentToken = null;
+        _departingDocumentToken = null;
         _documentGeneration++;
         ClearHostSubscriptions();
         _lifetime.Cancel();

--- a/src/WebPluginAppRuntime.cs
+++ b/src/WebPluginAppRuntime.cs
@@ -470,22 +470,25 @@ internal sealed class WebPluginAppRuntime : IDisposable
         PaperTopBarAction[] actions;
         try
         {
-            var hasActions = parameters.ValueKind == JsonValueKind.Object &&
-                             parameters.TryGetProperty("actions", out var actionsValue) &&
-                             actionsValue.ValueKind != JsonValueKind.Null;
-            if (hasActions &&
-                actionsValue.ValueKind == JsonValueKind.Array &&
-                actionsValue.GetArrayLength() > MaximumGlobalTopBarActions)
+            if (parameters.ValueKind != JsonValueKind.Object ||
+                !parameters.TryGetProperty("actions", out var actionsValue) ||
+                actionsValue.ValueKind == JsonValueKind.Null)
             {
-                throw new PaperTodoPluginException(
-                    "too_many_topbar_actions",
-                    $"A plugin can contribute at most {MaximumGlobalTopBarActions} global top-bar actions.");
+                actions = [];
             }
+            else
+            {
+                if (actionsValue.ValueKind == JsonValueKind.Array &&
+                    actionsValue.GetArrayLength() > MaximumGlobalTopBarActions)
+                {
+                    throw new PaperTodoPluginException(
+                        "too_many_topbar_actions",
+                        $"A plugin can contribute at most {MaximumGlobalTopBarActions} global top-bar actions.");
+                }
 
-            actions = hasActions
-                ? actionsValue.Deserialize<PaperTopBarAction[]>(
-                    WebPluginRuntimeInfrastructure.JsonOptions) ?? []
-                : [];
+                actions = actionsValue.Deserialize<PaperTopBarAction[]>(
+                    WebPluginRuntimeInfrastructure.JsonOptions) ?? [];
+            }
         }
         catch (Exception ex) when (ex is JsonException or NotSupportedException)
         {

--- a/src/WebPluginAppRuntime.cs
+++ b/src/WebPluginAppRuntime.cs
@@ -10,6 +10,8 @@ namespace PaperTodo;
 
 internal sealed class WebPluginAppRuntime : IDisposable
 {
+    private const int MaximumGlobalTopBarActions = 256;
+
     private readonly PaperBodyPluginDescriptor _descriptor;
     private readonly IPaperTodoHostApi _workspace;
     private readonly IPaperAppRuntimeSettings _settings;
@@ -468,9 +470,19 @@ internal sealed class WebPluginAppRuntime : IDisposable
         PaperTopBarAction[] actions;
         try
         {
-            actions = parameters.ValueKind == JsonValueKind.Object &&
-                      parameters.TryGetProperty("actions", out var actionsValue) &&
-                      actionsValue.ValueKind != JsonValueKind.Null
+            var hasActions = parameters.ValueKind == JsonValueKind.Object &&
+                             parameters.TryGetProperty("actions", out var actionsValue) &&
+                             actionsValue.ValueKind != JsonValueKind.Null;
+            if (hasActions &&
+                actionsValue.ValueKind == JsonValueKind.Array &&
+                actionsValue.GetArrayLength() > MaximumGlobalTopBarActions)
+            {
+                throw new PaperTodoPluginException(
+                    "too_many_topbar_actions",
+                    $"A plugin can contribute at most {MaximumGlobalTopBarActions} global top-bar actions.");
+            }
+
+            actions = hasActions
                 ? actionsValue.Deserialize<PaperTopBarAction[]>(
                     WebPluginRuntimeInfrastructure.JsonOptions) ?? []
                 : [];


### PR DESCRIPTION
- bind Web body messages to a per-document token so a departing page cannot overwrite state after the replacement document is ready
- hand external target=_blank/window.open requests to the system shell
- reject Web Global Top Bar arrays above 256 before deserialization
- align plugin documentation with the 256-action limit

No new policy/test framework changes.