### PR TITLE
fix: keep passive papers from auto collapsing

### DIFF
--- a/src/PaperWindow.Experimental.cs
+++ b/src/PaperWindow.Experimental.cs
@@ -54,6 +54,11 @@ public sealed partial class PaperWindow
         _controller.CompleteEdgeCapsuleQueueCompositionProxyFor(this);
         _experimentalPassiveReasons = next;
 
+        if (!wasPassive && IsExperimentalPassive)
+        {
+            CancelExperimentalAutoCollapse();
+        }
+
         if (_experimentalPassiveReasons != ExperimentalPassiveReason.None)
         {
             AbortAllInteractions(InteractionAbortReason.Deactivated);
@@ -226,10 +231,10 @@ public sealed partial class PaperWindow
         _experimentalAutoCollapseGeneration++;
     }
 
-    private void ScheduleExperimentalAutoCollapse(bool interactionWasActive)
+    private void ScheduleExperimentalAutoCollapse(bool blockedAtDeactivation)
     {
         var generation = ++_experimentalAutoCollapseGeneration;
-        if (interactionWasActive ||
+        if (blockedAtDeactivation ||
             !_controller.State.ExperimentalCollapsePaperOnDeactivate ||
             !_controller.State.UseCapsuleMode ||
             _paper.IsCollapsed)
@@ -253,16 +258,7 @@ public sealed partial class PaperWindow
             }
 
             if (generation != _experimentalAutoCollapseGeneration ||
-                _windowLifecycle != PaperWindowLifecycleState.Alive ||
-                IsActive ||
-                !IsVisible ||
-                !_paper.IsVisible ||
-                _paper.IsCollapsed ||
-                WindowState == WindowState.Minimized ||
-                !_controller.State.ExperimentalCollapsePaperOnDeactivate ||
-                !_controller.State.UseCapsuleMode ||
-                HasExperimentalAutoCollapseBlocker() ||
-                !CanDisplayAsCapsule())
+                !CanAutomaticallyCollapseNow())
             {
                 return;
             }
@@ -273,7 +269,20 @@ public sealed partial class PaperWindow
         timer.Start();
     }
 
+    private bool CanAutomaticallyCollapseNow() =>
+        _windowLifecycle == PaperWindowLifecycleState.Alive &&
+        _controller.State.ExperimentalCollapsePaperOnDeactivate &&
+        _controller.State.UseCapsuleMode &&
+        !IsActive &&
+        IsVisible &&
+        _paper.IsVisible &&
+        !_paper.IsCollapsed &&
+        WindowState != WindowState.Minimized &&
+        !HasExperimentalAutoCollapseBlocker() &&
+        CanDisplayAsCapsule();
+
     private bool HasExperimentalAutoCollapseBlocker() =>
+        IsExperimentalPassive ||
         _advancedInteractionLocked ||
         _isEditingTitle ||
         _titleBarDragSession != null ||


### PR DESCRIPTION
## 目的
修复 Passive 与普通失焦 Auto Collapse 的状态冲突，不引入新的 FSM 或 suppress flag。

## 修改
- `IsExperimentalPassive` 直接作为普通 Auto Collapse blocker。
- 进入 Passive 时复用现有 generation 取消已经挂起的旧 Auto Collapse timer，避免 Passive 很快关闭后旧失焦补偿性收起。
- 保留失焦当下 blocker 快照和 timer 到期二次检查。
- 将 timer 到期的实时条件集中到 `CanAutomaticallyCollapseNow()`，不改变手动 Collapse、Lock、Passive native style 或 Edge Capsule 架构。

## 范围
仅修改 `src/PaperWindow.Experimental.cs`，1 commit。

## 基线
PR #145 尚未合并，因此本 PR 基于并指向 `cleanup/remove-obsolete-collapse-and-virtual-desktop`。