### PR TITLE
feat: Protocol 2.1 Todo actions and top-bar labels

### DIFF
--- a/PaperTodo.Plugin.Abstractions/PaperPluginRuntimeContracts.cs
+++ b/PaperTodo.Plugin.Abstractions/PaperPluginRuntimeContracts.cs
@@ -41,6 +41,70 @@ public interface IPaperGlobalShortcutApi
     void Clear();
 }
 
+[Flags]
+public enum PaperTodoActionPlacement
+{
+    None = 0,
+    Inline = 1 << 0,
+    ContextMenu = 1 << 1
+}
+
+/// <summary>
+/// Protocol 2.1 host-rendered action contributed to one existing Todo. Plugins provide only the
+/// descriptor and click behavior; PaperTodo owns the Todo row/menu visual tree, theme, DPI, hover,
+/// layout and input. Icon uses the same restricted Character/SVG Path contract as Top Bar actions.
+/// </summary>
+public sealed record PaperTodoAction
+{
+    public string Id { get; init; } = string.Empty;
+    public PaperTopBarIcon Icon { get; init; } = new();
+    public string Text { get; init; } = string.Empty;
+    public string ToolTip { get; init; } = string.Empty;
+    public int Priority { get; init; }
+    public bool Enabled { get; init; } = true;
+    public bool Visible { get; init; } = true;
+    public PaperTodoActionPlacement Placement { get; init; } =
+        PaperTodoActionPlacement.Inline | PaperTodoActionPlacement.ContextMenu;
+}
+
+/// <summary>
+/// Click delivered from a host-rendered Todo action. Todo is captured at invocation time rather
+/// than registration time, so plugins receive the current text/completion/binding state.
+/// </summary>
+public sealed record PaperTodoActionInvocation(
+    string ActionId,
+    string PaperId,
+    string TodoId,
+    TodoSnapshot Todo);
+
+/// <summary>
+/// Protocol 2.1 Runtime capability for binding host-rendered actions to arbitrary existing Todos.
+/// Registrations are volatile presentation contributions: a Runtime rebuilds them from its own
+/// state and PaperTodo removes them automatically when that Runtime ends.
+/// </summary>
+public interface IPaperPluginRuntimeTodoActions
+{
+    void SetActionHandler(Action<PaperTodoActionInvocation>? handler);
+    void SetActions(
+        string paperId,
+        string todoId,
+        IReadOnlyList<PaperTodoAction> actions);
+    void Clear(string paperId, string todoId);
+    void Clear();
+}
+
+/// <summary>
+/// Protocol 2.1 host-rendered, non-interactive top-bar metadata. Unlike Runtime.Papers, this surface
+/// may target any existing Paper visible through the Workspace, so an enhancement plugin can label
+/// built-in Markdown Notes as well as plugin-owned Papers. PaperTodo owns layout/theme/DPI.
+/// </summary>
+public interface IPaperPluginRuntimeTopBarLabels
+{
+    void SetLabels(string paperId, IReadOnlyList<PaperTopBarLabel> labels);
+    void Clear(string paperId);
+    void Clear();
+}
+
 /// <summary>
 /// Context for the one provider-level backend Runtime. The Runtime exists while PaperTodo has at
 /// least one real Note paper whose BodyProviderId is this plugin. It does not depend on any Paper
@@ -65,10 +129,20 @@ public sealed class PaperPluginRuntimeContext
     public required IPaperPluginRuntimePapers Papers { get; init; }
     public required IPaperGlobalTopBarApi GlobalTopBar { get; init; }
     public required IPaperGlobalShortcutApi GlobalShortcuts { get; init; }
+
+    public IPaperPluginRuntimeTodoActions TodoActions =>
+        Workspace as IPaperPluginRuntimeTodoActions
+        ?? throw new InvalidOperationException(
+            "This PaperTodo host does not expose Protocol 2.1 Todo actions.");
+
+    public IPaperPluginRuntimeTopBarLabels TopBarLabels =>
+        Workspace as IPaperPluginRuntimeTopBarLabels
+        ?? throw new InvalidOperationException(
+            "This PaperTodo host does not expose Protocol 2.1 top-bar labels.");
 }
 
 /// <summary>
-/// Optional protocol-2.0 Native capability. A plugin declaring manifest capability "runtime"
+/// Optional protocol-2.x Native capability. A plugin declaring manifest capability "runtime"
 /// implements this interface. PaperTodo starts exactly one provider Runtime when the first real
 /// Paper uses the provider and disposes it when the last such Paper disappears. If a plugin needs
 /// multiple workers, processes or isolation domains, it owns those internally behind this Runtime.

--- a/PaperTodo.Plugin.Abstractions/PaperTodoHostContracts.cs
+++ b/PaperTodo.Plugin.Abstractions/PaperTodoHostContracts.cs
@@ -109,7 +109,14 @@ public sealed record TodoSnapshot(
     int Order,
     string? LinkedPaperId,
     string? LinkedPath,
-    DateTimeOffset? ReminderAt);
+    DateTimeOffset? ReminderAt)
+{
+    /// <summary>
+    /// Protocol 2.1 additive metadata for LinkedPath. Null means there is no linked path or the
+    /// host cannot classify it; true means directory and false means file.
+    /// </summary>
+    public bool? LinkedPathIsDirectory { get; init; }
+}
 
 public sealed record NoteSnapshot(
     string PaperId,

--- a/PaperTodo.Plugin.Abstractions/PluginRuntimeContracts.cs
+++ b/PaperTodo.Plugin.Abstractions/PluginRuntimeContracts.cs
@@ -43,6 +43,20 @@ public sealed record PaperPluginRuntimeEvent(
     JsonElement? Message = null);
 
 /// <summary>
+/// Protocol 2.1 non-interactive top-bar metadata. PaperTodo owns rendering, truncation, theme, DPI
+/// and responsive layout. Icon is optional and uses the same restricted host-rendered icon contract
+/// as top-bar actions.
+/// </summary>
+public sealed record PaperTopBarLabel
+{
+    public string Text { get; init; } = string.Empty;
+    public PaperTopBarIcon? Icon { get; init; }
+    public string ToolTip { get; init; } = string.Empty;
+    public int Priority { get; init; }
+    public bool Visible { get; init; } = true;
+}
+
+/// <summary>
 /// Provider-scoped view of the plugin's own Paper instances. It deliberately does not create one
 /// runtime per Paper: presentation is addressed by PaperId while one plugin Runtime owns the
 /// backend. Plugins needing extra workers/processes create and manage those internally.

--- a/plugin-samples/PaperTodo.Plugin.Protocol21Web/README.md
+++ b/plugin-samples/PaperTodo.Plugin.Protocol21Web/README.md
@@ -1,0 +1,14 @@
+# Protocol 2.1 Web 示例
+
+这个示例只验证 Protocol 2.1 新增的宿主原生 contribution surface，不实现具体产品业务。
+
+它声明一个 provider Runtime，并演示：
+
+- `papertodo.todoActions.set(paperId, todoId, actions)`：给普通 Todo 行右侧发布 `SVG Path + 文字` 按钮；同一 descriptor 默认也进入 Todo 右键菜单。
+- `todoActionInvoked`：点击时返回当前 `PaperId`、`TodoId` 和最新 `TodoSnapshot`；示例会把 `linkedPaperId`、`linkedPath`、`linkedPathIsDirectory` 打到控制台。
+- `papertodo.topBarLabels.set(paperId, labels)`：给任意现有 Paper 发布不可点击的宿主原生顶栏标签。
+- 顶栏“刷新 2.1”动作：手动重新扫描当前 Workspace 并重发 contribution；示例不通过轮询维持状态。
+
+这些 contribution 都是 Runtime 生命周期内的易失 presentation。插件自己的业务状态应保存在 Runtime state；Runtime 结束、Web document 被替换或失败恢复时，宿主撤销旧 contribution，由新 Runtime/document 根据业务状态重新发布。
+
+按钮和标签都由 PaperTodo 渲染。插件不返回 WPF 控件、不拥有 Todo 行或顶栏 visual tree，也不能借此修改宿主布局/输入生命周期。

--- a/plugin-samples/PaperTodo.Plugin.Protocol21Web/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.Protocol21Web/plugin.json
@@ -1,0 +1,35 @@
+{
+  "kind": "web",
+  "id": "sample.protocol21.web",
+  "name": "Protocol 2.1 示例",
+  "description": "演示 Runtime 向普通 Todo 发布宿主原生行内/右键动作，以及向任意 Paper 发布静态顶栏标签。",
+  "version": "1.0.0",
+  "apiVersion": "2.1",
+  "stateVersion": 1,
+  "entry": "web/index.html",
+  "runtime": "web/runtime.html",
+  "capabilities": [
+    "runtime"
+  ],
+  "permissions": [
+    "papers.read",
+    "todos.read"
+  ],
+  "maxPaperInstances": 1,
+  "startupPaper": {
+    "enabledSetting": "autoStart",
+    "instanceKey": "main",
+    "presentation": "expanded",
+    "title": "Protocol 2.1"
+  },
+  "settings": [
+    {
+      "id": "autoStart",
+      "type": "boolean",
+      "name": "自动启动示例",
+      "description": "保持一张示例 Paper，使 provider Runtime 可以持续发布 2.1 contribution。",
+      "default": true,
+      "quick": true
+    }
+  ]
+}

--- a/plugin-samples/PaperTodo.Plugin.Protocol21Web/web/index.html
+++ b/plugin-samples/PaperTodo.Plugin.Protocol21Web/web/index.html
@@ -15,7 +15,17 @@
 <body>
   <h1>Protocol 2.1</h1>
   <p>这个 Paper 只负责让 provider Runtime 保持存在。</p>
-  <p>Runtime 会向当前 Todo 发布 <code>SVG + 文字</code> 的行内/右键动作，并向当前 Paper 发布静态顶栏标签。</p>
+  <p>Runtime 会向当前 Todo 发布 <code>SVG + 文字</code> 的行内/右键动作，并向任意 Workspace Paper 发布静态顶栏标签。</p>
   <p>可用任意 Paper 顶栏的“刷新 2.1”动作重新扫描当前 Workspace。</p>
+  <script>
+    papertodo.paper.setHeaderText('Protocol 2.1');
+    papertodo.paper.setCapsulePresentation({
+      preferredWidth: 0,
+      plainText: 'P2.1',
+      components: [
+        { kind: 'text', text: 'P2.1', fill: true }
+      ]
+    });
+  </script>
 </body>
 </html>

--- a/plugin-samples/PaperTodo.Plugin.Protocol21Web/web/index.html
+++ b/plugin-samples/PaperTodo.Plugin.Protocol21Web/web/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Protocol 2.1 示例</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { margin: 0; padding: 18px; font-family: system-ui, sans-serif; line-height: 1.55; }
+    h1 { margin: 0 0 10px; font-size: 18px; }
+    p { margin: 6px 0; opacity: .82; }
+    code { font-family: ui-monospace, Consolas, monospace; }
+  </style>
+</head>
+<body>
+  <h1>Protocol 2.1</h1>
+  <p>这个 Paper 只负责让 provider Runtime 保持存在。</p>
+  <p>Runtime 会向当前 Todo 发布 <code>SVG + 文字</code> 的行内/右键动作，并向当前 Paper 发布静态顶栏标签。</p>
+  <p>可用任意 Paper 顶栏的“刷新 2.1”动作重新扫描当前 Workspace。</p>
+</body>
+</html>

--- a/plugin-samples/PaperTodo.Plugin.Protocol21Web/web/runtime.html
+++ b/plugin-samples/PaperTodo.Plugin.Protocol21Web/web/runtime.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <title>PaperTodo Protocol 2.1 Runtime</title>
+</head>
+<body>
+<script>
+  const todoKeys = new Set();
+  const labeledPapers = new Set();
+
+  const inspectIcon = {
+    kind: 'svgPath',
+    value: 'M3,3 L13,3 13,13 3,13 Z M6,8 L10,8',
+    renderMode: 'stroke',
+    strokeWidth: 1.5
+  };
+
+  async function clearPublished() {
+    for (const key of [...todoKeys]) {
+      const split = key.indexOf('\n');
+      const paperId = key.slice(0, split);
+      const todoId = key.slice(split + 1);
+      try { await papertodo.todoActions.clear(paperId, todoId); } catch { }
+    }
+    todoKeys.clear();
+
+    for (const paperId of [...labeledPapers]) {
+      try { await papertodo.topBarLabels.clear(paperId); } catch { }
+    }
+    labeledPapers.clear();
+  }
+
+  async function publishCurrentWorkspace() {
+    await clearPublished();
+
+    const todos = await papertodo.workspace.request('todos.list', {
+      includeBlank: false
+    });
+    for (const todo of Array.isArray(todos) ? todos : []) {
+      const paperId = String(todo?.paperId || '').trim();
+      const todoId = String(todo?.id || '').trim();
+      if (!paperId || !todoId) continue;
+
+      await papertodo.todoActions.set(paperId, todoId, [
+        {
+          id: 'inspect-binding',
+          icon: inspectIcon,
+          text: '绑定',
+          toolTip: '查看插件收到的当前 Todo 与绑定信息',
+          priority: 100
+        }
+      ]);
+      todoKeys.add(`${paperId}\n${todoId}`);
+    }
+
+    const papers = await papertodo.workspace.request('papers.list', {});
+    for (const paper of Array.isArray(papers) ? papers : []) {
+      const paperId = String(paper?.id || '').trim();
+      if (!paperId) continue;
+
+      await papertodo.topBarLabels.set(paperId, [
+        {
+          text: 'P2.1',
+          toolTip: 'Protocol 2.1 Runtime 发布的宿主原生静态标签',
+          priority: 10
+        }
+      ]);
+      labeledPapers.add(paperId);
+    }
+  }
+
+  async function registerGlobalTopBar() {
+    await papertodo.globalTopBar.setActions([
+      {
+        id: 'refresh-protocol21',
+        icon: {
+          kind: 'svgPath',
+          value: 'M12.5,5 A5,5 0 1 0 13,9 M13,3 L13,7 9,7',
+          renderMode: 'stroke',
+          strokeWidth: 1.5
+        },
+        toolTip: '重新发布 Protocol 2.1 Todo 动作与顶栏标签',
+        priority: 100
+      }
+    ]);
+  }
+
+  papertodo.onEvent(message => {
+    if (message.type === 'todoActionInvoked' &&
+        message.action?.actionId === 'inspect-binding') {
+      const todo = message.action.todo || {};
+      console.log('Protocol 2.1 Todo action', {
+        paperId: message.action.paperId,
+        todoId: message.action.todoId,
+        text: todo.text,
+        linkedPaperId: todo.linkedPaperId,
+        linkedPath: todo.linkedPath,
+        linkedPathIsDirectory: todo.linkedPathIsDirectory
+      });
+      return;
+    }
+
+    if (message.type === 'topBarActionInvoked' &&
+        message.action?.actionId === 'refresh-protocol21') {
+      publishCurrentWorkspace().catch(error => {
+        console.error('Protocol 2.1 refresh failed', error);
+      });
+    }
+  });
+
+  window.addEventListener('papertodo', event => {
+    const message = event.detail || {};
+    if (message.type !== 'initialize') return;
+
+    registerGlobalTopBar()
+      .then(publishCurrentWorkspace)
+      .catch(error => {
+        console.error('Protocol 2.1 initialization failed', error);
+      });
+  });
+</script>
+</body>
+</html>

--- a/src/AppController.PluginApi.cs
+++ b/src/AppController.PluginApi.cs
@@ -49,7 +49,10 @@ public sealed partial class AppController
             item.Order,
             item.LinkedPaperId,
             item.LinkedPath,
-            item.ReminderAt);
+            item.ReminderAt)
+        {
+            LinkedPathIsDirectory = item.LinkedPathIsDirectory
+        };
 
     internal NoteSnapshot CaptureNoteSnapshot(PaperData paper)
     {

--- a/src/AppController.PluginTodoActions.cs
+++ b/src/AppController.PluginTodoActions.cs
@@ -1,0 +1,269 @@
+using System.Diagnostics;
+using PaperTodo.Plugin;
+
+namespace PaperTodo;
+
+internal sealed record PluginTodoActionBinding(
+    Guid OwnerId,
+    string ProviderId,
+    PaperTodoAction Action);
+
+public sealed partial class AppController
+{
+    private sealed class PluginTodoActionRegistration
+    {
+        public required Guid OwnerId { get; init; }
+        public required string ProviderId { get; init; }
+        public required Func<bool> IsActive { get; set; }
+        public required Action<PaperTodoActionInvocation> Invoke { get; set; }
+        public required long Order { get; init; }
+        public Dictionary<(string PaperId, string TodoId), PaperTodoAction[]> Actions { get; } = [];
+    }
+
+    private readonly Dictionary<string, PluginTodoActionRegistration>
+        _pluginTodoActionRegistrations = new(StringComparer.Ordinal);
+    private long _pluginTodoActionRegistrationOrder;
+
+    internal void SetPluginTodoActions(
+        Guid ownerId,
+        string providerId,
+        string paperId,
+        string todoId,
+        IReadOnlyList<PaperTodoAction> actions,
+        Func<bool> isActive,
+        Action<PaperTodoActionInvocation> invoke)
+    {
+        EnsurePluginApiAtLeast(providerId, 2, 1, "todo_actions_requires_api_2_1");
+        var (paper, item) = RequirePluginTodoTarget(paperId, todoId);
+        var normalized = PluginContributionPolicy.NormalizeTodoActions(actions);
+
+        if (_pluginTodoActionRegistrations.TryGetValue(providerId, out var current) &&
+            current.OwnerId != ownerId)
+        {
+            throw new PaperTodoPluginException(
+                "todo_action_runtime_conflict",
+                "A provider can have only one active Runtime Todo-action owner.");
+        }
+
+        if (current == null)
+        {
+            current = new PluginTodoActionRegistration
+            {
+                OwnerId = ownerId,
+                ProviderId = providerId,
+                IsActive = isActive,
+                Invoke = invoke,
+                Order = ++_pluginTodoActionRegistrationOrder
+            };
+            _pluginTodoActionRegistrations.Add(providerId, current);
+        }
+        else
+        {
+            current.IsActive = isActive;
+            current.Invoke = invoke;
+        }
+
+        var key = (PaperId: paper.Id, TodoId: item.Id);
+        if (normalized.Length == 0)
+        {
+            current.Actions.Remove(key);
+        }
+        else
+        {
+            current.Actions[key] = normalized;
+            PaperWindow.EnsurePluginTodoActionsLoadedHandler();
+        }
+        RefreshPluginTodoActions(key.PaperId, key.TodoId);
+    }
+
+    internal void ClearPluginTodoActions(
+        Guid ownerId,
+        string providerId,
+        string paperId,
+        string todoId)
+    {
+        if (!_pluginTodoActionRegistrations.TryGetValue(providerId, out var registration) ||
+            registration.OwnerId != ownerId)
+        {
+            return;
+        }
+
+        var normalizedPaperId = paperId?.Trim() ?? string.Empty;
+        var normalizedTodoId = todoId?.Trim() ?? string.Empty;
+        if (normalizedPaperId.Length == 0 || normalizedTodoId.Length == 0)
+        {
+            return;
+        }
+        if (registration.Actions.Remove((normalizedPaperId, normalizedTodoId)))
+        {
+            RefreshPluginTodoActions(normalizedPaperId, normalizedTodoId);
+        }
+    }
+
+    internal void RemovePluginTodoActionsOwner(Guid ownerId, string providerId)
+    {
+        if (!_pluginTodoActionRegistrations.TryGetValue(providerId, out var registration) ||
+            registration.OwnerId != ownerId)
+        {
+            return;
+        }
+
+        var affected = registration.Actions.Keys.ToArray();
+        _pluginTodoActionRegistrations.Remove(providerId);
+        foreach (var (paperId, todoId) in affected)
+        {
+            RefreshPluginTodoActions(paperId, todoId);
+        }
+    }
+
+    internal IReadOnlyList<PluginTodoActionBinding> GetPluginTodoActions(
+        string paperId,
+        string todoId)
+    {
+        var normalizedPaperId = paperId?.Trim() ?? string.Empty;
+        var normalizedTodoId = todoId?.Trim() ?? string.Empty;
+        if (normalizedPaperId.Length == 0 || normalizedTodoId.Length == 0 ||
+            !TryGetTodoTarget(normalizedPaperId, normalizedTodoId, out _, out _))
+        {
+            return [];
+        }
+
+        var candidates = new List<(
+            PluginTodoActionRegistration Registration,
+            PaperTodoAction Action,
+            int DeclarationOrder)>();
+        foreach (var registration in _pluginTodoActionRegistrations.Values)
+        {
+            if (!IsActive(registration.IsActive) ||
+                !registration.Actions.TryGetValue(
+                    (normalizedPaperId, normalizedTodoId),
+                    out var actions))
+            {
+                continue;
+            }
+
+            for (var index = 0; index < actions.Length; index++)
+            {
+                if (actions[index].Visible)
+                {
+                    candidates.Add((registration, actions[index], index));
+                }
+            }
+        }
+
+        return candidates
+            .OrderByDescending(candidate => candidate.Action.Priority)
+            .ThenBy(candidate => candidate.Registration.Order)
+            .ThenBy(candidate => candidate.DeclarationOrder)
+            .Select(candidate => new PluginTodoActionBinding(
+                candidate.Registration.OwnerId,
+                candidate.Registration.ProviderId,
+                candidate.Action))
+            .ToArray();
+    }
+
+    internal void InvokePluginTodoAction(
+        PluginTodoActionBinding binding,
+        string paperId,
+        string todoId)
+    {
+        if (!_pluginTodoActionRegistrations.TryGetValue(binding.ProviderId, out var registration) ||
+            registration.OwnerId != binding.OwnerId ||
+            !IsActive(registration.IsActive) ||
+            !registration.Actions.TryGetValue((paperId, todoId), out var actions))
+        {
+            return;
+        }
+
+        var action = actions.FirstOrDefault(candidate =>
+            string.Equals(candidate.Id, binding.Action.Id, StringComparison.Ordinal));
+        if (action == null || !action.Visible || !action.Enabled ||
+            !TryGetTodoTarget(paperId, todoId, out var paper, out var item))
+        {
+            return;
+        }
+
+        try
+        {
+            registration.Invoke(new PaperTodoActionInvocation(
+                action.Id,
+                paper.Id,
+                item.Id,
+                CaptureTodoSnapshot(paper, item)));
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceWarning(
+                "Plugin Todo action failed. Provider={0}; Action={1}; Paper={2}; Todo={3}; Exception={4}",
+                binding.ProviderId,
+                action.Id,
+                paperId,
+                todoId,
+                ex.GetBaseException());
+        }
+    }
+
+    private void EnsurePluginApiAtLeast(
+        string providerId,
+        int major,
+        int minor,
+        string errorCode)
+    {
+        if (PaperBodyPlugins.TryGet(providerId, out var descriptor) &&
+            PluginContributionPolicy.ApiAtLeast(descriptor.ApiVersion, major, minor))
+        {
+            return;
+        }
+
+        throw new PaperTodoPluginException(
+            errorCode,
+            $"This plugin contribution requires apiVersion {major}.{minor} or newer.");
+    }
+
+    private (PaperData Paper, PaperItem Item) RequirePluginTodoTarget(
+        string paperId,
+        string todoId)
+    {
+        var normalizedPaperId = paperId?.Trim() ?? string.Empty;
+        var normalizedTodoId = todoId?.Trim() ?? string.Empty;
+        if (TryGetTodoTarget(normalizedPaperId, normalizedTodoId, out var paper, out var item))
+        {
+            return (paper, item);
+        }
+
+        throw new PaperTodoPluginException(
+            "todo_not_found",
+            "The requested Todo does not exist.");
+    }
+
+    private bool TryGetTodoTarget(
+        string paperId,
+        string todoId,
+        out PaperData paper,
+        out PaperItem item)
+    {
+        var foundPaper = State.Papers.FirstOrDefault(candidate =>
+            candidate.Type == PaperTypes.Todo &&
+            string.Equals(candidate.Id, paperId, StringComparison.Ordinal));
+        var foundItem = foundPaper?.Items.FirstOrDefault(candidate =>
+            string.Equals(candidate.Id, todoId, StringComparison.Ordinal));
+        if (foundPaper == null || foundItem == null)
+        {
+            paper = null!;
+            item = null!;
+            return false;
+        }
+
+        paper = foundPaper;
+        item = foundItem;
+        return true;
+    }
+
+    private void RefreshPluginTodoActions(string paperId, string todoId)
+    {
+        if (_windows.TryGetValue(paperId, out var window) && !window.IsClosed)
+        {
+            window.RefreshPluginTodoActions(todoId);
+        }
+    }
+}

--- a/src/AppController.PluginTopBar.cs
+++ b/src/AppController.PluginTopBar.cs
@@ -110,11 +110,9 @@ public sealed partial class AppController
         Func<bool> isActive,
         Action<PaperTopBarActionInvocation> invoke)
     {
-        // The app-runtime manager validates protocol 2.0 before creating this capability. Once a
-        // runtime is alive, it owns its process-lifetime lease even if the user rescans plugin
-        // manifests; ordinary plugin Reload does not silently replace a running plugin runtime.
-        // The protocol accepts a broad descriptor set, while the window still materializes only
-        // the fitting prefix after current-paper actions have taken first claim on plugin space.
+        // Runtime creation already validated an accepted protocol version. The protocol accepts a
+        // broad descriptor set, while the window still materializes only the fitting prefix after
+        // current-paper actions have taken first claim on plugin space.
         var normalized = NormalizePluginTopBarActions(
             actions,
             MaximumGlobalTopBarActions,
@@ -157,17 +155,14 @@ public sealed partial class AppController
     private void EnsurePluginTopBarProtocol(string providerId)
     {
         if (PaperBodyPlugins.TryGet(providerId, out var descriptor) &&
-            string.Equals(
-                descriptor.ApiVersion,
-                PaperBodyPluginRegistry.SupportedPluginApiVersion,
-                StringComparison.Ordinal))
+            PluginContributionPolicy.ApiAtLeast(descriptor.ApiVersion, 2, 0))
         {
             return;
         }
 
         throw new PaperTodoPluginException(
             "topbar_requires_api_2_0",
-            "Plugin top-bar extensions require apiVersion 2.0.");
+            "Plugin top-bar extensions require apiVersion 2.0 or newer.");
     }
 
     internal void RemovePluginPaperTopBarSession(Guid sessionId)

--- a/src/AppController.PluginTopBarLabels.cs
+++ b/src/AppController.PluginTopBarLabels.cs
@@ -1,0 +1,165 @@
+using PaperTodo.Plugin;
+
+namespace PaperTodo;
+
+internal sealed record PluginTopBarLabelBinding(
+    Guid OwnerId,
+    string ProviderId,
+    PaperTopBarLabel Label);
+
+public sealed partial class AppController
+{
+    private sealed class PluginTopBarLabelRegistration
+    {
+        public required Guid OwnerId { get; init; }
+        public required string ProviderId { get; init; }
+        public required Func<bool> IsActive { get; set; }
+        public required long Order { get; init; }
+        public Dictionary<string, PaperTopBarLabel[]> Labels { get; } =
+            new(StringComparer.Ordinal);
+    }
+
+    private readonly Dictionary<string, PluginTopBarLabelRegistration>
+        _pluginTopBarLabelRegistrations = new(StringComparer.Ordinal);
+    private long _pluginTopBarLabelRegistrationOrder;
+
+    internal void SetPluginTopBarLabels(
+        Guid ownerId,
+        string providerId,
+        string paperId,
+        IReadOnlyList<PaperTopBarLabel> labels,
+        Func<bool> isActive)
+    {
+        EnsurePluginApiAtLeast(providerId, 2, 1, "topbar_labels_require_api_2_1");
+        var normalizedPaperId = RequirePluginLabelTarget(paperId).Id;
+        var normalized = PluginContributionPolicy.NormalizeTopBarLabels(labels);
+
+        if (_pluginTopBarLabelRegistrations.TryGetValue(providerId, out var current) &&
+            current.OwnerId != ownerId)
+        {
+            throw new PaperTodoPluginException(
+                "topbar_label_runtime_conflict",
+                "A provider can have only one active Runtime top-bar-label owner.");
+        }
+
+        if (current == null)
+        {
+            current = new PluginTopBarLabelRegistration
+            {
+                OwnerId = ownerId,
+                ProviderId = providerId,
+                IsActive = isActive,
+                Order = ++_pluginTopBarLabelRegistrationOrder
+            };
+            _pluginTopBarLabelRegistrations.Add(providerId, current);
+        }
+        else
+        {
+            current.IsActive = isActive;
+        }
+
+        if (normalized.Length == 0)
+        {
+            current.Labels.Remove(normalizedPaperId);
+        }
+        else
+        {
+            current.Labels[normalizedPaperId] = normalized;
+            PaperWindow.EnsurePluginTopBarLabelsLoadedHandler();
+        }
+        RefreshPluginTopBarLabels(normalizedPaperId);
+    }
+
+    internal void ClearPluginTopBarLabels(
+        Guid ownerId,
+        string providerId,
+        string paperId)
+    {
+        if (!_pluginTopBarLabelRegistrations.TryGetValue(providerId, out var registration) ||
+            registration.OwnerId != ownerId)
+        {
+            return;
+        }
+
+        var normalizedPaperId = paperId?.Trim() ?? string.Empty;
+        if (normalizedPaperId.Length > 0 && registration.Labels.Remove(normalizedPaperId))
+        {
+            RefreshPluginTopBarLabels(normalizedPaperId);
+        }
+    }
+
+    internal void RemovePluginTopBarLabelsOwner(Guid ownerId, string providerId)
+    {
+        if (!_pluginTopBarLabelRegistrations.TryGetValue(providerId, out var registration) ||
+            registration.OwnerId != ownerId)
+        {
+            return;
+        }
+
+        var affectedPaperIds = registration.Labels.Keys.ToArray();
+        _pluginTopBarLabelRegistrations.Remove(providerId);
+        foreach (var paperId in affectedPaperIds)
+        {
+            RefreshPluginTopBarLabels(paperId);
+        }
+    }
+
+    internal IReadOnlyList<PluginTopBarLabelBinding> GetPluginTopBarLabels(string paperId)
+    {
+        var normalizedPaperId = paperId?.Trim() ?? string.Empty;
+        if (normalizedPaperId.Length == 0 ||
+            !State.Papers.Any(paper => string.Equals(paper.Id, normalizedPaperId, StringComparison.Ordinal)))
+        {
+            return [];
+        }
+
+        var candidates = new List<(
+            PluginTopBarLabelRegistration Registration,
+            PaperTopBarLabel Label,
+            int DeclarationOrder)>();
+        foreach (var registration in _pluginTopBarLabelRegistrations.Values)
+        {
+            if (!IsActive(registration.IsActive) ||
+                !registration.Labels.TryGetValue(normalizedPaperId, out var labels))
+            {
+                continue;
+            }
+
+            for (var index = 0; index < labels.Length; index++)
+            {
+                if (labels[index].Visible)
+                {
+                    candidates.Add((registration, labels[index], index));
+                }
+            }
+        }
+
+        return candidates
+            .OrderByDescending(candidate => candidate.Label.Priority)
+            .ThenBy(candidate => candidate.Registration.Order)
+            .ThenBy(candidate => candidate.DeclarationOrder)
+            .Select(candidate => new PluginTopBarLabelBinding(
+                candidate.Registration.OwnerId,
+                candidate.Registration.ProviderId,
+                candidate.Label))
+            .ToArray();
+    }
+
+    private PaperData RequirePluginLabelTarget(string paperId)
+    {
+        var normalized = paperId?.Trim() ?? string.Empty;
+        var paper = State.Papers.FirstOrDefault(candidate =>
+            string.Equals(candidate.Id, normalized, StringComparison.Ordinal));
+        return paper ?? throw new PaperTodoPluginException(
+            "paper_not_found",
+            "The requested Paper does not exist.");
+    }
+
+    private void RefreshPluginTopBarLabels(string paperId)
+    {
+        if (_windows.TryGetValue(paperId, out var window) && !window.IsClosed)
+        {
+            window.RefreshPluginTopBarLabels();
+        }
+    }
+}

--- a/src/PaperBodyPluginHostApi.Presentation.cs
+++ b/src/PaperBodyPluginHostApi.Presentation.cs
@@ -57,17 +57,14 @@ internal sealed partial class PaperBodyPluginHostApi
     private void EnsurePresentationProtocol()
     {
         if (_controller.PaperBodyPlugins.TryGet(_providerId, out var descriptor) &&
-            string.Equals(
-                descriptor.ApiVersion,
-                PaperBodyPluginRegistry.SupportedPluginApiVersion,
-                StringComparison.Ordinal))
+            PluginContributionPolicy.ApiAtLeast(descriptor.ApiVersion, 2, 0))
         {
             return;
         }
 
         throw Error(
             "presentation_requires_api_2_0",
-            "Own-paper presentation controls require plugin apiVersion 2.0.");
+            "Own-paper presentation controls require plugin apiVersion 2.0 or newer.");
     }
 
     private void QueuePresentation(Func<string, bool> action)

--- a/src/PaperBodyPluginRegistry.cs
+++ b/src/PaperBodyPluginRegistry.cs
@@ -82,13 +82,13 @@ internal sealed class PaperBodyPluginMiniSizeManifest
 
 /// <summary>
 /// Discovers one fully trusted, unsandboxed native or local Web plugin from each self-contained
-/// plugins/&lt;plugin-id&gt;/plugin.json folder. Protocol 2.0 has no plugin hot-reload contract: code,
+/// plugins/&lt;plugin-id&gt;/plugin.json folder. Protocol 2.x has no plugin hot-reload contract: code,
 /// manifest and Web file changes are discovered on the next app start. Loaded native assemblies
 /// remain loaded for the process lifetime.
 /// </summary>
 internal sealed partial class PaperBodyPluginRegistry : IDisposable
 {
-    internal const string SupportedPluginApiVersion = "2.0";
+    internal const string SupportedPluginApiVersion = "2.1";
     internal const string MinimumPluginApiVersion = "2.0";
     private static readonly Regex PluginIdPattern = PluginIdRegex();
     private static readonly StringComparer UiDisplayNameComparer =
@@ -355,7 +355,6 @@ internal sealed partial class PaperBodyPluginRegistry : IDisposable
             }
         }
 
-
         return manifest;
     }
 
@@ -592,7 +591,6 @@ internal sealed partial class PaperBodyPluginRegistry : IDisposable
         return result;
     }
 
-
     private static string NormalizeApiVersion(string? value)
     {
         value = value?.Trim();
@@ -604,7 +602,7 @@ internal sealed partial class PaperBodyPluginRegistry : IDisposable
             minor < 0)
         {
             throw new InvalidDataException(
-                "apiVersion must be a quoted major.minor string such as \"2.0\".");
+                "apiVersion must be a quoted major.minor string such as \"2.1\".");
         }
 
         return $"{major}.{minor}";
@@ -612,16 +610,14 @@ internal sealed partial class PaperBodyPluginRegistry : IDisposable
 
     private static void ValidateManifestApiVersion(string pluginApiVersion)
     {
-        if (string.Equals(
-                pluginApiVersion,
-                SupportedPluginApiVersion,
-                StringComparison.Ordinal))
+        if (string.Equals(pluginApiVersion, "2.0", StringComparison.Ordinal) ||
+            string.Equals(pluginApiVersion, "2.1", StringComparison.Ordinal))
         {
             return;
         }
 
         throw new InvalidDataException(
-            $"Unsupported plugin API version {pluginApiVersion}; host requires {SupportedPluginApiVersion}.");
+            $"Unsupported plugin API version {pluginApiVersion}; host supports 2.0 through {SupportedPluginApiVersion}.");
     }
 
     private static Version ParseVersion(string? value)

--- a/src/PaperPluginRuntimeHostApi.cs
+++ b/src/PaperPluginRuntimeHostApi.cs
@@ -6,14 +6,25 @@ namespace PaperTodo;
 
 /// <summary>
 /// Hides paper-session presentation capabilities from plugin runtimes while reusing the same reviewed
-/// Workspace implementation and permission/event semantics. Unlike a paper body context, an app
-/// runtime has no View.Dispatcher, so this facade marshals synchronous Workspace calls to the UI
-/// dispatcher before entering PaperCommandService.
+/// Workspace implementation and permission/event semantics. Unlike a paper body context, a Runtime
+/// has no View.Dispatcher, so this facade marshals synchronous Workspace calls to the UI dispatcher
+/// before entering PaperCommandService. Protocol 2.1 Runtime contribution surfaces are exposed by
+/// capability interfaces on this same lease so teardown has one owner.
 /// </summary>
-internal sealed class PaperPluginRuntimeWorkspaceApi : IPaperTodoHostApi, IDisposable
+internal sealed class PaperPluginRuntimeWorkspaceApi :
+    IPaperTodoHostApi,
+    IPaperPluginRuntimeTodoActions,
+    IPaperPluginRuntimeTopBarLabels,
+    IDisposable
 {
+    private readonly AppController _controller;
     private readonly PaperBodyPluginHostApi _inner;
     private readonly Dispatcher _dispatcher;
+    private readonly string _providerId;
+    private readonly Func<bool> _isActive;
+    private readonly Guid _contributionOwnerId = Guid.NewGuid();
+    private Action<PaperTodoActionInvocation>? _todoActionHandler;
+    private bool _disposed;
 
     public PaperPluginRuntimeWorkspaceApi(
         AppController controller,
@@ -21,6 +32,9 @@ internal sealed class PaperPluginRuntimeWorkspaceApi : IPaperTodoHostApi, IDispo
         IEnumerable<string> permissions,
         Func<bool> isActive)
     {
+        _controller = controller;
+        _providerId = providerId;
+        _isActive = isActive;
         _dispatcher = Application.Current.Dispatcher;
         _inner = new PaperBodyPluginHostApi(
             controller,
@@ -58,22 +72,169 @@ internal sealed class PaperPluginRuntimeWorkspaceApi : IPaperTodoHostApi, IDispo
     public IDisposable Subscribe(PaperTodoEventFilter filter, Action<PaperTodoEvent> handler) =>
         OnUi(() => _inner.Subscribe(filter, handler));
 
+    void IPaperPluginRuntimeTodoActions.SetActionHandler(
+        Action<PaperTodoActionInvocation>? handler) =>
+        OnUi(() =>
+        {
+            EnsureUsable();
+            _todoActionHandler = handler;
+            if (handler == null)
+            {
+                _controller.RemovePluginTodoActionsOwner(
+                    _contributionOwnerId,
+                    _providerId);
+            }
+        });
+
+    void IPaperPluginRuntimeTodoActions.SetActions(
+        string paperId,
+        string todoId,
+        IReadOnlyList<PaperTodoAction> actions)
+    {
+        ArgumentNullException.ThrowIfNull(actions);
+        var snapshot = actions.ToArray();
+        OnUi(() =>
+        {
+            EnsureUsable();
+            EnsurePermission(
+                PaperTodoPermissionNames.TodosRead,
+                "Todo action contributions require the todos.read permission because invocation includes a Todo snapshot.");
+            if (snapshot.Length > 0 && _todoActionHandler == null)
+            {
+                throw new PaperTodoPluginException(
+                    "todo_action_handler_missing",
+                    "Register a Todo action handler before contributing Todo actions.");
+            }
+            _controller.SetPluginTodoActions(
+                _contributionOwnerId,
+                _providerId,
+                paperId,
+                todoId,
+                snapshot,
+                () => !_disposed && _isActive(),
+                DispatchTodoAction);
+        });
+    }
+
+    void IPaperPluginRuntimeTodoActions.Clear(string paperId, string todoId) =>
+        OnUi(() =>
+        {
+            EnsureUsable();
+            _controller.ClearPluginTodoActions(
+                _contributionOwnerId,
+                _providerId,
+                paperId,
+                todoId);
+        });
+
+    void IPaperPluginRuntimeTodoActions.Clear() =>
+        OnUi(() =>
+        {
+            EnsureUsable();
+            _controller.RemovePluginTodoActionsOwner(
+                _contributionOwnerId,
+                _providerId);
+        });
+
+    void IPaperPluginRuntimeTopBarLabels.SetLabels(
+        string paperId,
+        IReadOnlyList<PaperTopBarLabel> labels)
+    {
+        ArgumentNullException.ThrowIfNull(labels);
+        var snapshot = labels.ToArray();
+        OnUi(() =>
+        {
+            EnsureUsable();
+            EnsurePermission(
+                PaperTodoPermissionNames.PapersRead,
+                "Top-bar label contributions require the papers.read permission.");
+            _controller.SetPluginTopBarLabels(
+                _contributionOwnerId,
+                _providerId,
+                paperId,
+                snapshot,
+                () => !_disposed && _isActive());
+        });
+    }
+
+    void IPaperPluginRuntimeTopBarLabels.Clear(string paperId) =>
+        OnUi(() =>
+        {
+            EnsureUsable();
+            _controller.ClearPluginTopBarLabels(
+                _contributionOwnerId,
+                _providerId,
+                paperId);
+        });
+
+    void IPaperPluginRuntimeTopBarLabels.Clear() =>
+        OnUi(() =>
+        {
+            EnsureUsable();
+            _controller.RemovePluginTopBarLabelsOwner(
+                _contributionOwnerId,
+                _providerId);
+        });
+
+    private void DispatchTodoAction(PaperTodoActionInvocation invocation)
+    {
+        if (_disposed || !_isActive())
+        {
+            return;
+        }
+        _todoActionHandler?.Invoke(invocation);
+    }
+
+    private void EnsurePermission(string permission, string message)
+    {
+        if (!GrantedPermissions.Contains(permission))
+        {
+            throw new PaperTodoPluginException("permission_denied", message);
+        }
+    }
+
+    private void EnsureUsable()
+    {
+        if (_disposed || !_isActive())
+        {
+            throw new PaperTodoPluginException(
+                "runtime_closed",
+                "The plugin Runtime is no longer active.");
+        }
+    }
+
     private T OnUi<T>(Func<T> action) =>
         _dispatcher.CheckAccess()
             ? action()
             : _dispatcher.Invoke(action);
 
+    private void OnUi(Action action)
+    {
+        if (_dispatcher.CheckAccess())
+        {
+            action();
+            return;
+        }
+        _dispatcher.Invoke(action);
+    }
+
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+        _todoActionHandler = null;
         try
         {
             if (_dispatcher.CheckAccess())
             {
-                _inner.Dispose();
+                RemoveContributionsAndDisposeInner();
             }
             else if (!_dispatcher.HasShutdownStarted && !_dispatcher.HasShutdownFinished)
             {
-                _dispatcher.Invoke(_inner.Dispose);
+                _dispatcher.Invoke(RemoveContributionsAndDisposeInner);
             }
         }
         catch
@@ -81,6 +242,13 @@ internal sealed class PaperPluginRuntimeWorkspaceApi : IPaperTodoHostApi, IDispo
             // App shutdown owns final process teardown; do not turn dispatcher shutdown into a
             // second plugin-runtime failure.
         }
+    }
+
+    private void RemoveContributionsAndDisposeInner()
+    {
+        _controller.RemovePluginTodoActionsOwner(_contributionOwnerId, _providerId);
+        _controller.RemovePluginTopBarLabelsOwner(_contributionOwnerId, _providerId);
+        _inner.Dispose();
     }
 }
 

--- a/src/PaperWindow.PluginTodoActions.cs
+++ b/src/PaperWindow.PluginTodoActions.cs
@@ -1,0 +1,320 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using PaperTodo.Plugin;
+
+namespace PaperTodo;
+
+public sealed partial class PaperWindow
+{
+    private static readonly object PluginTodoInlineWrapperMarker = new();
+    private static readonly object PluginTodoInlineHostMarker = new();
+    private static readonly object PluginTodoContextSeparatorMarker = new();
+    private static bool _pluginTodoActionsLoadedHandlerRegistered;
+
+    private bool _pluginTodoActionHooksInstalled;
+    private int _pluginTodoActionsAppliedRowsGeneration = -1;
+
+    internal static void EnsurePluginTodoActionsLoadedHandler()
+    {
+        if (_pluginTodoActionsLoadedHandlerRegistered)
+        {
+            return;
+        }
+        _pluginTodoActionsLoadedHandlerRegistered = true;
+        EventManager.RegisterClassHandler(
+            typeof(PaperWindow),
+            LoadedEvent,
+            new RoutedEventHandler((sender, _) =>
+            {
+                if (sender is PaperWindow window && !window.IsClosed)
+                {
+                    window.RefreshPluginTodoActions();
+                }
+            }));
+    }
+
+    internal void RefreshPluginTodoActions(string? todoId = null)
+    {
+        if (_paper.Type != PaperTypes.Todo || IsClosed)
+        {
+            return;
+        }
+
+        EnsurePluginTodoActionHooks();
+        foreach (var row in _todoRows)
+        {
+            if (row.Tag is not string itemId ||
+                !string.IsNullOrWhiteSpace(todoId) &&
+                !string.Equals(itemId, todoId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var actions = _controller.GetPluginTodoActions(_paper.Id, itemId);
+            ApplyPluginTodoInlineActions(row, itemId, actions);
+        }
+        _pluginTodoActionsAppliedRowsGeneration = _todoRowsGeneration;
+    }
+
+    private void EnsurePluginTodoActionHooks()
+    {
+        if (_pluginTodoActionHooksInstalled)
+        {
+            return;
+        }
+        _pluginTodoActionHooksInstalled = true;
+        ContextMenuOpening += OnPluginTodoContextMenuOpening;
+        LayoutUpdated += (_, _) =>
+        {
+            if (_paper.Type != PaperTypes.Todo ||
+                _pluginTodoActionsAppliedRowsGeneration == _todoRowsGeneration)
+            {
+                return;
+            }
+            RefreshPluginTodoActions();
+        };
+    }
+
+    private void ApplyPluginTodoInlineActions(
+        Border row,
+        string todoId,
+        IReadOnlyList<PluginTodoActionBinding> bindings)
+    {
+        if (row.Child is not Grid grid)
+        {
+            return;
+        }
+
+        var inline = bindings
+            .Where(binding =>
+                binding.Action.Visible &&
+                (binding.Action.Placement & PaperTodoActionPlacement.Inline) != 0)
+            .ToArray();
+
+        var wrapper = grid.Children
+            .OfType<StackPanel>()
+            .FirstOrDefault(panel => ReferenceEquals(panel.Tag, PluginTodoInlineWrapperMarker));
+        if (wrapper == null && inline.Length == 0)
+        {
+            return;
+        }
+
+        StackPanel pluginHost;
+        if (wrapper == null)
+        {
+            var nativeColumnChildren = grid.Children
+                .Cast<UIElement>()
+                .Where(element => Grid.GetColumn(element) == 2)
+                .ToArray();
+            foreach (var child in nativeColumnChildren)
+            {
+                grid.Children.Remove(child);
+            }
+
+            wrapper = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                VerticalAlignment = VerticalAlignment.Center,
+                Tag = PluginTodoInlineWrapperMarker
+            };
+            foreach (var child in nativeColumnChildren)
+            {
+                wrapper.Children.Add(child);
+            }
+
+            pluginHost = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                VerticalAlignment = VerticalAlignment.Center,
+                Tag = PluginTodoInlineHostMarker
+            };
+            wrapper.Children.Add(pluginHost);
+            Grid.SetColumn(wrapper, 2);
+            grid.Children.Add(wrapper);
+        }
+        else
+        {
+            pluginHost = wrapper.Children
+                .OfType<StackPanel>()
+                .First(panel => ReferenceEquals(panel.Tag, PluginTodoInlineHostMarker));
+        }
+
+        pluginHost.Children.Clear();
+        foreach (var binding in inline)
+        {
+            pluginHost.Children.Add(CreatePluginTodoInlineAction(binding, todoId));
+        }
+    }
+
+    private FrameworkElement CreatePluginTodoInlineAction(
+        PluginTodoActionBinding binding,
+        string todoId)
+    {
+        var action = binding.Action;
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        content.Children.Add(CreatePluginTodoActionIcon(
+            action.Icon,
+            action.Enabled ? WeakTextBrush : BrightWeakTextBrush,
+            AppTypography.Scale(11)));
+        content.Children.Add(new TextBlock
+        {
+            Text = action.Text,
+            Foreground = action.Enabled ? WeakTextBrush : BrightWeakTextBrush,
+            FontFamily = AppTypography.UiFontFamily,
+            FontSize = AppTypography.Scale(10.5),
+            FontWeight = FontWeights.SemiBold,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(3, 0, 0, 0),
+            TextWrapping = TextWrapping.NoWrap,
+            IsHitTestVisible = false
+        });
+
+        var button = new Border
+        {
+            Margin = new Thickness(1, 0, 1, 0),
+            Padding = new Thickness(5, 1, 5, 1),
+            MinHeight = AppTypography.Scale(22),
+            CornerRadius = new CornerRadius(RadiusControl),
+            Background = LinkedPaperNormalBgBrush,
+            Cursor = action.Enabled ? Cursors.Hand : Cursors.Arrow,
+            Opacity = action.Enabled ? 0.82 : 0.48,
+            ToolTip = string.IsNullOrWhiteSpace(action.ToolTip) ? action.Text : action.ToolTip,
+            Child = content
+        };
+        if (action.Enabled)
+        {
+            button.MouseEnter += (_, _) =>
+            {
+                button.Background = LinkedPaperLightBgBrush;
+                button.Opacity = 1.0;
+            };
+            button.MouseLeave += (_, _) =>
+            {
+                button.Background = LinkedPaperNormalBgBrush;
+                button.Opacity = 0.82;
+            };
+            button.PreviewMouseLeftButtonUp += (_, e) =>
+            {
+                _controller.InvokePluginTodoAction(binding, _paper.Id, todoId);
+                e.Handled = true;
+            };
+        }
+        return button;
+    }
+
+    private void OnPluginTodoContextMenuOpening(object sender, ContextMenuEventArgs e)
+    {
+        if (_paper.Type != PaperTypes.Todo)
+        {
+            return;
+        }
+
+        var row = FindTodoRowAncestor(e.OriginalSource as DependencyObject);
+        if (row?.Tag is not string itemId)
+        {
+            return;
+        }
+
+        var menu = (e.Source as FrameworkElement)?.ContextMenu ?? row.ContextMenu;
+        if (menu == null)
+        {
+            return;
+        }
+
+        for (var index = menu.Items.Count - 1; index >= 0; index--)
+        {
+            if (menu.Items[index] is FrameworkElement element &&
+                (element.Tag is PluginTodoActionBinding ||
+                 ReferenceEquals(element.Tag, PluginTodoContextSeparatorMarker)))
+            {
+                menu.Items.RemoveAt(index);
+            }
+        }
+
+        var actions = _controller.GetPluginTodoActions(_paper.Id, itemId)
+            .Where(binding =>
+                binding.Action.Visible &&
+                (binding.Action.Placement & PaperTodoActionPlacement.ContextMenu) != 0)
+            .ToArray();
+        if (actions.Length == 0)
+        {
+            return;
+        }
+
+        var insertIndex = Math.Min(1, menu.Items.Count);
+        foreach (var binding in actions)
+        {
+            var action = binding.Action;
+            var menuItem = new MenuItem
+            {
+                Header = new TextBlock { Text = action.Text },
+                ToolTip = string.IsNullOrWhiteSpace(action.ToolTip) ? null : action.ToolTip,
+                Icon = CreatePluginTodoActionIcon(
+                    action.Icon,
+                    TextBrush,
+                    AppTypography.Scale(12)),
+                IsEnabled = action.Enabled,
+                Tag = binding
+            };
+            menuItem.Click += (_, _) =>
+                _controller.InvokePluginTodoAction(binding, _paper.Id, itemId);
+            menu.Items.Insert(insertIndex++, menuItem);
+        }
+        menu.Items.Insert(insertIndex, new Separator
+        {
+            Tag = PluginTodoContextSeparatorMarker
+        });
+    }
+
+    private static UIElement CreatePluginTodoActionIcon(
+        PaperTopBarIcon icon,
+        Brush foreground,
+        double size)
+    {
+        if (icon.Kind == PaperTopBarIconKind.SvgPath)
+        {
+            var path = new Path
+            {
+                Data = Geometry.Parse(icon.Value),
+                Width = size,
+                Height = size,
+                Stretch = Stretch.Uniform,
+                SnapsToDevicePixels = true,
+                IsHitTestVisible = false
+            };
+            if (icon.RenderMode == PaperTopBarSvgRenderMode.Stroke)
+            {
+                path.Fill = Brushes.Transparent;
+                path.Stroke = foreground;
+                path.StrokeThickness = icon.StrokeWidth;
+                path.StrokeLineJoin = PenLineJoin.Round;
+                path.StrokeStartLineCap = PenLineCap.Round;
+                path.StrokeEndLineCap = PenLineCap.Round;
+            }
+            else
+            {
+                path.Fill = foreground;
+            }
+            return path;
+        }
+
+        return new TextBlock
+        {
+            Text = icon.Value,
+            Foreground = foreground,
+            FontFamily = AppTypography.UiFontFamily,
+            FontSize = size,
+            FontWeight = FontWeights.SemiBold,
+            VerticalAlignment = VerticalAlignment.Center,
+            TextAlignment = TextAlignment.Center,
+            IsHitTestVisible = false
+        };
+    }
+}

--- a/src/PaperWindow.PluginTopBarLabels.cs
+++ b/src/PaperWindow.PluginTopBarLabels.cs
@@ -1,0 +1,100 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace PaperTodo;
+
+public sealed partial class PaperWindow
+{
+    private static bool _pluginTopBarLabelsLoadedHandlerRegistered;
+    private StackPanel? _pluginTopBarLabelsHost;
+
+    internal static void EnsurePluginTopBarLabelsLoadedHandler()
+    {
+        if (_pluginTopBarLabelsLoadedHandlerRegistered)
+        {
+            return;
+        }
+        _pluginTopBarLabelsLoadedHandlerRegistered = true;
+        EventManager.RegisterClassHandler(
+            typeof(PaperWindow),
+            LoadedEvent,
+            new RoutedEventHandler((sender, _) =>
+            {
+                if (sender is PaperWindow window && !window.IsClosed)
+                {
+                    window.RefreshPluginTopBarLabels();
+                }
+            }));
+    }
+
+    internal void RefreshPluginTopBarLabels()
+    {
+        if (IsClosed || !_isShellBuilt || _topBarActionButtonsHost == null)
+        {
+            return;
+        }
+
+        _pluginTopBarLabelsHost ??= new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        if (_pluginTopBarLabelsHost.Parent == null)
+        {
+            _topBarActionButtonsHost.Children.Insert(0, _pluginTopBarLabelsHost);
+        }
+
+        _pluginTopBarLabelsHost.Children.Clear();
+        foreach (var binding in _controller.GetPluginTopBarLabels(_paper.Id))
+        {
+            var label = binding.Label;
+            var content = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                VerticalAlignment = VerticalAlignment.Center,
+                IsHitTestVisible = false
+            };
+            if (label.Icon != null)
+            {
+                content.Children.Add(CreatePluginTodoActionIcon(
+                    label.Icon,
+                    WeakTextBrush,
+                    AppTypography.Scale(10.5)));
+            }
+            content.Children.Add(new TextBlock
+            {
+                Text = label.Text,
+                Foreground = WeakTextBrush,
+                FontFamily = AppTypography.UiFontFamily,
+                FontSize = AppTypography.Scale(10.5),
+                FontWeight = FontWeights.Normal,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = label.Icon == null
+                    ? new Thickness(0)
+                    : new Thickness(3, 0, 0, 0),
+                TextWrapping = TextWrapping.NoWrap,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                MaxWidth = AppTypography.Scale(120),
+                IsHitTestVisible = false
+            });
+
+            _pluginTopBarLabelsHost.Children.Add(new Border
+            {
+                Padding = new Thickness(4, 1, 4, 1),
+                Margin = new Thickness(1, 0, 1, 0),
+                Background = Brushes.Transparent,
+                VerticalAlignment = VerticalAlignment.Center,
+                ToolTip = string.IsNullOrWhiteSpace(label.ToolTip) ? null : label.ToolTip,
+                Child = content
+            });
+        }
+
+        _pluginTopBarLabelsHost.Visibility =
+            _pluginTopBarLabelsHost.Children.Count > 0
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        UpdateTopBarResponsiveLayout();
+        RefreshPluginTopBarActions();
+    }
+}

--- a/src/PluginContributionPolicy.cs
+++ b/src/PluginContributionPolicy.cs
@@ -1,0 +1,244 @@
+using System.Windows.Media;
+using PaperTodo.Plugin;
+
+namespace PaperTodo;
+
+internal static class PluginContributionPolicy
+{
+    internal const int MaximumTodoActionsPerItem = 64;
+    internal const int MaximumTopBarLabelsPerPaper = 8;
+    private const int MaximumIdentifierLength = 64;
+    private const int MaximumActionTextLength = 64;
+    private const int MaximumLabelTextLength = 80;
+    private const int MaximumToolTipLength = 160;
+    private const int MaximumCharacterIconLength = 8;
+    private const int MaximumSvgPathLength = 4096;
+    private const double MinimumSvgStrokeWidth = 0.1;
+    private const double MaximumSvgStrokeWidth = 4.0;
+
+    internal static PaperTodoAction[] NormalizeTodoActions(
+        IReadOnlyList<PaperTodoAction>? actions)
+    {
+        actions ??= [];
+        if (actions.Count > MaximumTodoActionsPerItem)
+        {
+            throw new PaperTodoPluginException(
+                "too_many_todo_actions",
+                $"A plugin can contribute at most {MaximumTodoActionsPerItem} actions to one Todo.");
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<PaperTodoAction>(actions.Count);
+        foreach (var source in actions)
+        {
+            if (source == null)
+            {
+                throw new PaperTodoPluginException(
+                    "invalid_todo_action",
+                    "Todo actions cannot contain null entries.");
+            }
+
+            var id = NormalizeIdentifier(source.Id, "invalid_todo_action_id", "Todo action");
+            if (!seen.Add(id))
+            {
+                throw new PaperTodoPluginException(
+                    "invalid_todo_action_id",
+                    "Todo action ids must be unique for one Todo contribution.");
+            }
+
+            var text = NormalizeText(
+                source.Text,
+                MaximumActionTextLength,
+                required: true,
+                "invalid_todo_action_text",
+                "Todo action text");
+            var tooltip = NormalizeText(
+                source.ToolTip,
+                MaximumToolTipLength,
+                required: false,
+                "invalid_todo_action_tooltip",
+                "Todo action tooltip");
+            var icon = NormalizeIcon(source.Icon, required: true, "invalid_todo_action_icon");
+            const PaperTodoActionPlacement supported =
+                PaperTodoActionPlacement.Inline |
+                PaperTodoActionPlacement.ContextMenu;
+            if (source.Placement == PaperTodoActionPlacement.None ||
+                (source.Placement & ~supported) != 0)
+            {
+                throw new PaperTodoPluginException(
+                    "invalid_todo_action_placement",
+                    "Todo action placement must include inline and/or contextMenu.");
+            }
+
+            result.Add(source with
+            {
+                Id = id,
+                Text = text,
+                ToolTip = tooltip,
+                Icon = icon,
+                Placement = source.Placement & supported
+            });
+        }
+        return result.ToArray();
+    }
+
+    internal static PaperTopBarLabel[] NormalizeTopBarLabels(
+        IReadOnlyList<PaperTopBarLabel>? labels)
+    {
+        labels ??= [];
+        if (labels.Count > MaximumTopBarLabelsPerPaper)
+        {
+            throw new PaperTodoPluginException(
+                "too_many_topbar_labels",
+                $"A plugin can contribute at most {MaximumTopBarLabelsPerPaper} top-bar labels to one Paper.");
+        }
+
+        var result = new List<PaperTopBarLabel>(labels.Count);
+        foreach (var label in labels)
+        {
+            if (label == null)
+            {
+                throw new PaperTodoPluginException(
+                    "invalid_topbar_label",
+                    "Top-bar labels cannot contain null entries.");
+            }
+
+            result.Add(label with
+            {
+                Text = NormalizeText(
+                    label.Text,
+                    MaximumLabelTextLength,
+                    required: true,
+                    "invalid_topbar_label_text",
+                    "Top-bar label text"),
+                ToolTip = NormalizeText(
+                    label.ToolTip,
+                    MaximumToolTipLength,
+                    required: false,
+                    "invalid_topbar_label_tooltip",
+                    "Top-bar label tooltip"),
+                Icon = label.Icon == null
+                    ? null
+                    : NormalizeIcon(label.Icon, required: false, "invalid_topbar_label_icon")
+            });
+        }
+
+        return result
+            .OrderByDescending(label => label.Priority)
+            .ToArray();
+    }
+
+    internal static bool ApiAtLeast(string? value, int major, int minor)
+    {
+        var parts = value?.Split('.', StringSplitOptions.None);
+        return parts is { Length: 2 } &&
+            int.TryParse(parts[0], out var actualMajor) &&
+            int.TryParse(parts[1], out var actualMinor) &&
+            (actualMajor > major || actualMajor == major && actualMinor >= minor);
+    }
+
+    private static string NormalizeIdentifier(
+        string? value,
+        string code,
+        string noun)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        if (normalized.Length is 0 or > MaximumIdentifierLength ||
+            normalized.Any(ch =>
+                !(char.IsAsciiLetterOrDigit(ch) || ch is '.' or '_' or '-')))
+        {
+            throw new PaperTodoPluginException(
+                code,
+                $"{noun} ids must contain 1-{MaximumIdentifierLength} ASCII letters, digits, '.', '_' or '-'.");
+        }
+        return normalized;
+    }
+
+    private static string NormalizeText(
+        string? value,
+        int maximumLength,
+        bool required,
+        string code,
+        string noun)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        if ((required && normalized.Length == 0) ||
+            normalized.Length > maximumLength ||
+            normalized.Any(char.IsControl))
+        {
+            throw new PaperTodoPluginException(
+                code,
+                $"{noun} must be {(required ? "1-" : "0-")}{maximumLength} characters and contain no control characters.");
+        }
+        return normalized;
+    }
+
+    private static PaperTopBarIcon NormalizeIcon(
+        PaperTopBarIcon? source,
+        bool required,
+        string code)
+    {
+        if (source == null)
+        {
+            if (!required)
+            {
+                return new PaperTopBarIcon();
+            }
+            throw new PaperTodoPluginException(code, "An icon is required.");
+        }
+
+        var value = source.Value?.Trim() ?? string.Empty;
+        switch (source.Kind)
+        {
+            case PaperTopBarIconKind.Character:
+                if (value.Length == 0 && !required)
+                {
+                    return source with { Value = string.Empty };
+                }
+                if (value.Length is 0 or > MaximumCharacterIconLength || value.Any(char.IsControl))
+                {
+                    throw new PaperTodoPluginException(
+                        code,
+                        $"Character icons must contain 1-{MaximumCharacterIconLength} UTF-16 characters and no control characters.");
+                }
+                break;
+
+            case PaperTopBarIconKind.SvgPath:
+                if (value.Length is 0 or > MaximumSvgPathLength)
+                {
+                    throw new PaperTodoPluginException(
+                        code,
+                        $"SVG path data must contain 1-{MaximumSvgPathLength} characters.");
+                }
+                if (!Enum.IsDefined(source.RenderMode))
+                {
+                    throw new PaperTodoPluginException(code, "Unknown SVG render mode.");
+                }
+                if (source.RenderMode == PaperTopBarSvgRenderMode.Stroke &&
+                    (!double.IsFinite(source.StrokeWidth) ||
+                     source.StrokeWidth < MinimumSvgStrokeWidth ||
+                     source.StrokeWidth > MaximumSvgStrokeWidth))
+                {
+                    throw new PaperTodoPluginException(
+                        code,
+                        $"SVG strokeWidth must be between {MinimumSvgStrokeWidth} and {MaximumSvgStrokeWidth}.");
+                }
+                try
+                {
+                    _ = Geometry.Parse(value);
+                }
+                catch (Exception ex)
+                {
+                    throw new PaperTodoPluginException(
+                        code,
+                        $"SVG path data is invalid: {ex.GetBaseException().Message}");
+                }
+                break;
+
+            default:
+                throw new PaperTodoPluginException(code, "Unknown icon kind.");
+        }
+
+        return source with { Value = value };
+    }
+}

--- a/src/WebPluginRuntime.cs
+++ b/src/WebPluginRuntime.cs
@@ -85,6 +85,18 @@ internal sealed class WebPluginRuntime : IDisposable
         _documentReady &&
         _isActive();
 
+    private IPaperPluginRuntimeTodoActions TodoActions =>
+        _workspace as IPaperPluginRuntimeTodoActions
+        ?? throw new PaperTodoPluginException(
+            "todo_actions_unavailable",
+            "This PaperTodo host does not expose Runtime Todo actions.");
+
+    private IPaperPluginRuntimeTopBarLabels TopBarLabels =>
+        _workspace as IPaperPluginRuntimeTopBarLabels
+        ?? throw new PaperTodoPluginException(
+            "topbar_labels_unavailable",
+            "This PaperTodo host does not expose Runtime top-bar labels.");
+
     public async Task StartAsync()
     {
         ThrowIfInactive();
@@ -204,6 +216,36 @@ internal sealed class WebPluginRuntime : IDisposable
                   });
                 }
               });
+              const todoActions = Object.freeze({
+                set(paperId, todoId, actions) {
+                  return request('todoActions.set', {
+                    paperId: String(paperId ?? ''),
+                    todoId: String(todoId ?? ''),
+                    actions: Array.isArray(actions) ? actions : []
+                  });
+                },
+                clear(paperId, todoId) {
+                  return request('todoActions.clear', {
+                    paperId: String(paperId ?? ''),
+                    todoId: String(todoId ?? '')
+                  });
+                },
+                clearAll() { return request('todoActions.clearAll'); }
+              });
+              const topBarLabels = Object.freeze({
+                set(paperId, labels) {
+                  return request('topbar.labels.set', {
+                    paperId: String(paperId ?? ''),
+                    labels: Array.isArray(labels) ? labels : []
+                  });
+                },
+                clear(paperId) {
+                  return request('topbar.labels.clear', {
+                    paperId: String(paperId ?? '')
+                  });
+                },
+                clearAll() { return request('topbar.labels.clearAll'); }
+              });
               window.papertodo = Object.freeze({
                 surface: 'runtime',
                 workspace,
@@ -211,6 +253,8 @@ internal sealed class WebPluginRuntime : IDisposable
                 state,
                 papers,
                 globalTopBar,
+                todoActions,
+                topBarLabels,
                 request,
                 onEvent(listener) {
                   if (typeof listener !== 'function') return () => {};
@@ -271,6 +315,8 @@ internal sealed class WebPluginRuntime : IDisposable
         _documentReady = false;
         TryClearGlobalTopBar();
         TryClearGlobalShortcuts();
+        TryClearTodoActions();
+        TryClearTopBarLabels();
     }
 
     private void OnNavigationCompleted(
@@ -291,6 +337,8 @@ internal sealed class WebPluginRuntime : IDisposable
             _documentReady = false;
             TryClearGlobalTopBar();
             TryClearGlobalShortcuts();
+            TryClearTodoActions();
+            TryClearTopBarLabels();
             FailStartupOrRestart(
                 $"Web Runtime navigation failed ({e.WebErrorStatus}).");
             return;
@@ -348,6 +396,8 @@ internal sealed class WebPluginRuntime : IDisposable
         _documentReady = false;
         TryClearGlobalTopBar();
         TryClearGlobalShortcuts();
+        TryClearTodoActions();
+        TryClearTopBarLabels();
 
         var dispatcher = _webView.Dispatcher;
         if (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
@@ -389,6 +439,8 @@ internal sealed class WebPluginRuntime : IDisposable
         _documentReady = false;
         TryClearGlobalTopBar();
         TryClearGlobalShortcuts();
+        TryClearTodoActions();
+        TryClearTopBarLabels();
 
         if (!_startupCompleted &&
             _startupReady.TrySetException(new InvalidOperationException(message)))
@@ -412,6 +464,8 @@ internal sealed class WebPluginRuntime : IDisposable
         _documentReady = false;
         TryClearGlobalTopBar();
         TryClearGlobalShortcuts();
+        TryClearTodoActions();
+        TryClearTopBarLabels();
         try { _requestRestart(); } catch { }
     }
 
@@ -464,6 +518,12 @@ internal sealed class WebPluginRuntime : IDisposable
                 "papers.setCapsulePresentation" => SetPaperCapsule(parameters),
                 "papers.postBody" => PostPaperBody(parameters),
                 "topbar.global.set" => SetGlobalActions(parameters),
+                "todoActions.set" => SetTodoActions(parameters),
+                "todoActions.clear" => ClearTodoActions(parameters),
+                "todoActions.clearAll" => ClearTodoActions(),
+                "topbar.labels.set" => SetTopBarLabels(parameters),
+                "topbar.labels.clear" => ClearTopBarLabels(parameters),
+                "topbar.labels.clearAll" => ClearTopBarLabels(),
                 _ => WebPluginWorkspaceRequests.Execute(_workspace, method, parameters)
             };
             Send(new { type = "hostResponse", requestId, ok = true, result });
@@ -546,6 +606,84 @@ internal sealed class WebPluginRuntime : IDisposable
         var paperId = WebPluginRuntimeInfrastructure.RequiredString(parameters, "paperId");
         var message = RequiredProperty(parameters, "message");
         return new { delivered = _papers.PostToBody(paperId, message) };
+    }
+
+    private object SetTodoActions(JsonElement parameters)
+    {
+        var paperId = WebPluginRuntimeInfrastructure.RequiredString(parameters, "paperId");
+        var todoId = WebPluginRuntimeInfrastructure.RequiredString(parameters, "todoId");
+        var actionsValue = RequiredProperty(parameters, "actions");
+        if (actionsValue.ValueKind != JsonValueKind.Array)
+        {
+            throw new PaperTodoPluginException("invalid_params", "actions must be an array.");
+        }
+
+        PaperTodoAction[] actions;
+        try
+        {
+            actions = actionsValue.Deserialize<PaperTodoAction[]>(
+                WebPluginRuntimeInfrastructure.JsonOptions) ?? [];
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException)
+        {
+            throw new PaperTodoPluginException("invalid_params", ex.GetBaseException().Message);
+        }
+
+        TodoActions.SetActionHandler(invocation =>
+            Send(new { type = "todoActionInvoked", action = invocation }));
+        TodoActions.SetActions(paperId, todoId, actions);
+        return new { updated = actions.Length };
+    }
+
+    private object ClearTodoActions(JsonElement parameters)
+    {
+        var paperId = WebPluginRuntimeInfrastructure.RequiredString(parameters, "paperId");
+        var todoId = WebPluginRuntimeInfrastructure.RequiredString(parameters, "todoId");
+        TodoActions.Clear(paperId, todoId);
+        return new { updated = 0 };
+    }
+
+    private object ClearTodoActions()
+    {
+        TodoActions.Clear();
+        return new { updated = 0 };
+    }
+
+    private object SetTopBarLabels(JsonElement parameters)
+    {
+        var paperId = WebPluginRuntimeInfrastructure.RequiredString(parameters, "paperId");
+        var labelsValue = RequiredProperty(parameters, "labels");
+        if (labelsValue.ValueKind != JsonValueKind.Array)
+        {
+            throw new PaperTodoPluginException("invalid_params", "labels must be an array.");
+        }
+
+        PaperTopBarLabel[] labels;
+        try
+        {
+            labels = labelsValue.Deserialize<PaperTopBarLabel[]>(
+                WebPluginRuntimeInfrastructure.JsonOptions) ?? [];
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException)
+        {
+            throw new PaperTodoPluginException("invalid_params", ex.GetBaseException().Message);
+        }
+
+        TopBarLabels.SetLabels(paperId, labels);
+        return new { updated = labels.Length };
+    }
+
+    private object ClearTopBarLabels(JsonElement parameters)
+    {
+        var paperId = WebPluginRuntimeInfrastructure.RequiredString(parameters, "paperId");
+        TopBarLabels.Clear(paperId);
+        return new { updated = 0 };
+    }
+
+    private object ClearTopBarLabels()
+    {
+        TopBarLabels.Clear();
+        return new { updated = 0 };
     }
 
     private static JsonElement RequiredProperty(JsonElement value, string name)
@@ -693,6 +831,21 @@ internal sealed class WebPluginRuntime : IDisposable
         try { _globalShortcuts.Clear(); } catch { }
     }
 
+    private void TryClearTodoActions()
+    {
+        try
+        {
+            TodoActions.Clear();
+            TodoActions.SetActionHandler(null);
+        }
+        catch { }
+    }
+
+    private void TryClearTopBarLabels()
+    {
+        try { TopBarLabels.Clear(); } catch { }
+    }
+
     private void ThrowIfInactive()
     {
         if (_disposed || !_isActive())
@@ -710,6 +863,8 @@ internal sealed class WebPluginRuntime : IDisposable
         _documentReady = false;
         TryClearGlobalTopBar();
         TryClearGlobalShortcuts();
+        TryClearTodoActions();
+        TryClearTopBarLabels();
         _disposed = true;
         try { _papersSubscription.Dispose(); } catch { }
         try { _settingsSubscription.Dispose(); } catch { }

--- a/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
+++ b/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
@@ -23,6 +23,7 @@ internal static class Program
             CheckManifestRuntimeAndMiniContracts(host);
             CheckGlobalTopBarPriority(host, abstractions);
             CheckPluginRuntimeSettings(host, abstractions);
+            CheckProtocol21Contributions(host, abstractions);
             CheckPluginRuntimePersistenceGuards(host);
             Console.WriteLine("PaperTodo protocol policy checks passed.");
             return 0;
@@ -286,8 +287,8 @@ internal static class Program
         var minimum = registryType.GetField(
             "MinimumPluginApiVersion",
             BindingFlags.Static | BindingFlags.NonPublic)?.GetRawConstantValue()?.ToString();
-        Assert(supported == "2.0" && minimum == "2.0",
-            "The plugin host must be 2.0-only; 1.8 compatibility must not remain enabled.");
+        Assert(supported == "2.1" && minimum == "2.0",
+            "The plugin host must advertise Protocol 2.1 while retaining Protocol 2.0 compatibility.");
     }
 
     private static void CheckProtocolBoundaries(Assembly host)
@@ -477,6 +478,40 @@ internal static class Program
                 "RetryFailedPluginRuntimeAfterSettingsChanged",
                 BindingFlags.Instance | BindingFlags.NonPublic) != null,
             "A Failed/Backoff app runtime must have a settings-change recovery path.");
+    }
+
+    private static void CheckProtocol21Contributions(Assembly host, Assembly abstractions)
+    {
+        var todoSnapshot = RequireType(abstractions, "PaperTodo.Plugin.TodoSnapshot");
+        Assert(
+            todoSnapshot.GetConstructors().Any(ctor => ctor.GetParameters().Length == 9),
+            "Protocol 2.1 must preserve the Protocol 2.0 nine-parameter TodoSnapshot constructor.");
+        Assert(
+            todoSnapshot.GetProperty("LinkedPathIsDirectory")?.PropertyType == typeof(bool?),
+            "Protocol 2.1 must add LinkedPathIsDirectory without changing TodoSnapshot's positional ABI.");
+
+        var context = RequireType(abstractions, "PaperTodo.Plugin.PaperPluginRuntimeContext");
+        var todoActions = RequireType(abstractions, "PaperTodo.Plugin.IPaperPluginRuntimeTodoActions");
+        var topBarLabels = RequireType(abstractions, "PaperTodo.Plugin.IPaperPluginRuntimeTopBarLabels");
+        Assert(context.GetProperty("TodoActions")?.PropertyType == todoActions,
+            "Protocol 2.1 Runtime context must expose host-rendered Todo actions.");
+        Assert(context.GetProperty("TopBarLabels")?.PropertyType == topBarLabels,
+            "Protocol 2.1 Runtime context must expose host-rendered top-bar labels.");
+
+        var controller = RequireType(host, "PaperTodo.AppController");
+        Assert(
+            controller.GetMethod("SetPluginTodoActions", BindingFlags.Instance | BindingFlags.NonPublic) != null &&
+            controller.GetMethod("InvokePluginTodoAction", BindingFlags.Instance | BindingFlags.NonPublic) != null,
+            "Protocol 2.1 Todo action registration/dispatch is incomplete.");
+        Assert(
+            controller.GetMethod("SetPluginTopBarLabels", BindingFlags.Instance | BindingFlags.NonPublic) != null,
+            "Protocol 2.1 top-bar label registration is incomplete.");
+
+        var webRuntime = RequireType(host, "PaperTodo.WebPluginRuntime");
+        Assert(
+            webRuntime.GetMethod("SetTodoActions", BindingFlags.Instance | BindingFlags.NonPublic) != null &&
+            webRuntime.GetMethod("SetTopBarLabels", BindingFlags.Instance | BindingFlags.NonPublic) != null,
+            "Web Runtime must expose the same Protocol 2.1 contribution surfaces as Native.");
     }
 
     private static Type RequireType(Assembly assembly, string name) =>


### PR DESCRIPTION
## Protocol 2.1

- Keep Protocol 2.0 plugins loadable while advertising 2.1 as the latest minor.
- Add host-rendered Todo inline/context actions: plugins publish SVG/character icon + text descriptors; PaperTodo owns layout, theme, DPI, hover and input.
- Deliver `ActionId + PaperId + TodoId + current TodoSnapshot` on click.
- Add `LinkedPathIsDirectory` to `TodoSnapshot` as an additive property while preserving the existing positional constructor.
- Add host-rendered non-interactive top-bar labels that a Runtime can publish to any existing Workspace Paper.
- Expose the same 2.1 surfaces to Native and Web Runtime implementations.
- Add a minimal Web 2.1 sample; keep the existing 2.0 TopBar sample for backward-compat validation.

This branch was developed against a frozen unified-runtime baseline, then finally rebased onto main after #155 merged. Final build/policy validation runs from this synchronized state.