### PR TITLE
fix: tighten plugin protocol 2.1 baseline

### DIFF
--- a/.github/workflows/plugin-samples.yml
+++ b/.github/workflows/plugin-samples.yml
@@ -73,8 +73,11 @@ jobs:
           }
           foreach ($manifest in $manifests) {
             Write-Host "Validating $($manifest.FullName)"
-            $null = Get-Content $manifest.FullName -Raw -Encoding UTF8 |
+            $document = Get-Content $manifest.FullName -Raw -Encoding UTF8 |
               ConvertFrom-Json -Depth 100
+            if ($document.apiVersion -ne "2.1") {
+              throw "$($manifest.FullName) must target apiVersion 2.1."
+            }
           }
 
       - name: Validate capsule sample coverage
@@ -106,7 +109,7 @@ jobs:
             throw "SampleClock must exercise native custom capsule views."
           }
 
-      - name: Validate protocol 2.0 top bar sample
+      - name: Validate protocol 2.1 top bar sample
         shell: pwsh
         run: |
           $root = "plugin-samples/PaperTodo.Plugin.TopBarWeb"
@@ -114,8 +117,8 @@ jobs:
           $bodySource = Get-Content (Join-Path $root "web/index.html") -Raw -Encoding UTF8
           $runtimeSource = Get-Content (Join-Path $root "web/runtime.html") -Raw -Encoding UTF8
 
-          if ($manifest.apiVersion -ne "2.0") {
-            throw "TopBarWeb must target apiVersion 2.0."
+          if ($manifest.apiVersion -ne "2.1") {
+            throw "TopBarWeb must target apiVersion 2.1."
           }
           if ($manifest.capabilities -notcontains "runtime") {
             throw "TopBarWeb must declare the runtime capability."
@@ -136,7 +139,7 @@ jobs:
           )
           foreach ($pattern in $runtimePatterns) {
             if ($runtimeSource -notmatch $pattern) {
-              throw "TopBarWeb Runtime is missing required protocol 2.0 coverage: $pattern"
+              throw "TopBarWeb Runtime is missing required protocol 2.1 coverage: $pattern"
             }
           }
 
@@ -169,7 +172,7 @@ jobs:
               $runtimeContract -notmatch 'interface\s+IPaperGlobalTopBarApi' -or
               $runtimeContract -notmatch 'interface\s+IPaperGlobalShortcutApi' -or
               $runtimeContract -notmatch 'interface\s+IPaperPluginRuntimeProvider') {
-            throw "Protocol 2.0 top-bar/Runtime/shortcut/presentation contracts are incomplete."
+            throw "Protocol 2.1 top-bar/Runtime/shortcut/presentation contracts are incomplete."
           }
 
       - name: Validate Web source and runtime copies

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,7 +68,7 @@ PaperTodo.exe
 | 外部 Paper/Todo/Note 命令 | `PaperCommandService` | 插件/MCP 共用的验证、mutation、同步提交/回滚和事件发布 |
 | 单纸片 UI | `PaperWindow` | paper WPF shell、普通交互、provider 选择、子系统适配 |
 | paper-body session | `PaperBodyHost` | 当前 `IPaperBodySession` 的 attach / invoke / commit / dispose |
-| plugin Runtime | `AppController.PluginRuntime` | 每 provider 最多一个后端 Runtime；0→1 张实体插件 Paper 时启动、1→0 时释放，按 `paperId` 管理逻辑实例、后端 state、长期 presentation、Global Top Bar/Shortcuts 与 Workspace |
+| plugin Runtime | `AppController.PluginRuntime` | 每 provider 最多一个后端 Runtime；0→1 张实体插件 Paper 时启动、1→0 时释放，按 `paperId` 管理逻辑实例、后端 state、长期 presentation、Global Top Bar/Shortcuts、Todo actions、Top Bar labels 与 Workspace |
 | 插件发现与合同 | `PaperBodyPluginRegistry` | builtin / Native / Web provider 发现、校验、激活 |
 | 插件 Top Bar 注册 | `AppController.PluginTopBar` | Paper session action 与 Runtime Global action 的分域注册、输入校验 |
 | 插件 Top Bar 绘制 | `PaperWindow.PluginTopBar` | 宿主按钮、字符/SVG 图标、主题/字体/响应式与 suppression reconcile |
@@ -100,7 +100,7 @@ MCP 的 transport、权限策略和 bridge 生命周期不拥有 Paper/Todo/Note
 
 Web 插件使用 WebView2；Native 插件可以自行创建线程、Worker、子进程或第三方运行环境。这些实现细节属于插件内部，不成为 PaperTodo 的第二套 `AppState` authority。
 
-插件协议当前只接受 **2.0**。需要在可见 Body/Mini 不存在时仍持续工作的插件声明 `runtime`：PaperTodo 对每个 provider **最多只创建一个 Runtime 后端**。`startupPaper` 先处理真实 Paper；之后只要最终至少有一张 `Note` Paper 的 `BodyProviderId` 指向该 provider，Runtime 就存在。0→1 启动，1→0 释放；隐藏、折叠、Body 重建、Mini 回收和当前没有 `PaperWindow` 都不改变 Runtime lifetime。
+插件协议当前只接受 **2.1**。清理前的实验性 2.0 不属于当前兼容范围。需要在可见 Body/Mini 不存在时仍持续工作的插件声明 `runtime`：PaperTodo 对每个 provider **最多只创建一个 Runtime 后端**。`startupPaper` 先处理真实 Paper；之后只要最终至少有一张 `Note` Paper 的 `BodyProviderId` 指向该 provider，Runtime 就存在。0→1 启动，1→0 释放；隐藏、折叠、Body 重建、Mini 回收和当前没有 `PaperWindow` 都不改变 Runtime lifetime。
 
 一张 Paper 不再对应一个后台 Runtime。多开插件仍然只有一个 provider Runtime，Runtime 通过 `PaperId` 管理 N 个逻辑实例；需要额外线程、Web Worker、子进程或隔离域时，由插件在自己的 Runtime 内部创建和回收，宿主不提供第二种“每 Paper 后台”协议。
 
@@ -108,7 +108,7 @@ Native 与 Web 使用同一生命周期语义：Native Runtime 是一个长期 C
 
 Runtime 的 provider `State` 与 Body/Mini 的 per-paper frontend state 分开保存。Runtime 可以在一份后端 JSON 中按 `paperId` 保存自己的业务实例；Body/Mini 的 `StateJson` 只保存前端/纸片 UI 状态。这样后台和前端不会争抢同一个持久化 writer。
 
-当 provider 声明 Runtime 时，**长期 Paper presentation 由 Runtime 唯一负责**：标题、Header、胶囊通过 `Papers` 按 `paperId` 发布。Body/Mini 负责可见 UI，并通过 `Runtime.Post(...)` 发送用户操作；Runtime 可以通过 `Papers.PostToBody(...)` 向当前存在的 Body 前端推送消息。宿主只保证薄路由和明确失败，不提供业务消息总线、ACK、exactly-once、自动 retry 或状态冲突合并。
+当 provider 声明 Runtime 时，**长期 Paper presentation 由 Runtime 唯一负责**：标题、Header、胶囊通过 `Papers` 按 `paperId` 发布。Body/Mini 负责可见 UI，并通过 `Runtime.Post(...)` 发送用户操作；Runtime 可以通过 `Papers.PostToBody(...)` 向当前存在的 Body 前端推送消息。2.1 的 Todo actions 与 Top Bar labels 同样属于 Runtime 生命周期内的易失宿主 presentation。宿主只保证薄路由和明确失败，不提供业务消息总线、ACK、exactly-once、自动 retry 或状态冲突合并。
 
 ### Web 生命周期边界
 
@@ -120,8 +120,7 @@ Body/Mini 是 Paper 的前端 surface，可以被隐藏、重建或回收；Web 
 
 PaperTodo 不提供插件热重载入口。插件 manifest、DLL、Web body/mini/runtime 等文件的安装、删除或修改统一在下次启动 PaperTodo 时重新发现并生效。
 
-
-### Plugin Runtime 2.0 最终边界
+### Plugin Runtime 2.1 最终边界
 
 - 一个插件最多只有一个 `PluginRuntime` 后台；真实 Paper 通过 `paperId` 作为逻辑实例接入。Runtime 是否存在只取决于是否至少有一张真实 Note Paper 使用该 provider，与 Paper 当前隐藏、折叠、Body/Mini 是否存活无关。
 - `Body` / `Mini` 是前端 surface。声明 `runtime` 后，长期后台状态和动态 Header/Capsule presentation 由 PluginRuntime 持有；宿主不创建 per-Paper 后台 Runtime。
@@ -130,6 +129,8 @@ PaperTodo 不提供插件热重载入口。插件 manifest、DLL、Web body/mini
 - Body/Mini -> Runtime 消息不跨 Runtime interruption 排队。Web renderer 暂不可接收时 `runtime.post(...)` 明确失败为 `runtime_unavailable`，绝不返回成功后静默丢消息。业务重试、去重和时效判断属于插件。
 - 自动恢复 Backoff 期间保留最后一次 Runtime presentation，避免 UI 闪烁；进入最终 `Failed` 后清除 Runtime 动态 Header/Capsule 并回退到 Paper/插件的普通静态展示。
 - `Papers.List()` 是 Runtime 启动时的全量快照；`Papers.Subscribe(...)` 只报告订阅后的增量，不为启动前已存在的 Paper 重放 `PaperAdded`。删除最后一张 Paper 时，宿主先发布最终 `PaperRemoved`，再撤销 Runtime lifetime。
+- Todo actions 与 Top Bar labels 是 2.1 的 Runtime contribution，随 Runtime/目标对象生命周期撤销，不进入长期业务持久化。
+
 ## 4. 状态与持久化架构
 
 ### 4.1 三个数据域
@@ -206,7 +207,7 @@ Provider 当前分三类：
 
 transport 权限、Web/Native surface 生命周期、Top Bar presentation 和 MCP protocol 不下沉到 `PaperCommandService`；反过来，transport/presentation 层也不建立另一套核心 mutation 实现。
 
-### 5.4 Protocol 2.0 Top Bar
+### 5.4 Protocol 2.1 Top Bar
 
 Top Bar 是宿主 chrome/presentation capability，不是 Workspace 数据 API，而且 **Paper 与 Global 有不同 owner**：
 

--- a/PaperTodo.Plugin.Abstractions/PaperTodoHostContracts.cs
+++ b/PaperTodo.Plugin.Abstractions/PaperTodoHostContracts.cs
@@ -250,7 +250,10 @@ public sealed record AppendTodosResult(
 
 public sealed record TodoMutationResult(
     string PaperId,
-    string TodoId);
+    string TodoId)
+{
+    public bool Deleted { get; init; }
+}
 
 public sealed record NoteMutationResult(
     string PaperId,

--- a/plugin-samples/PROTOCOL-2.1-SHORTCUTS.md
+++ b/plugin-samples/PROTOCOL-2.1-SHORTCUTS.md
@@ -1,6 +1,6 @@
-# PaperTodo 2.0：插件快捷键与自身纸片控制
+# PaperTodo 2.1：插件快捷键与自身纸片控制
 
-这页只说明协议 2.0 新增的两类能力：
+这页说明 Protocol 2.1 中的两类能力：
 
 - 插件在自己的设置中声明全局快捷键；
 - paper body session 请求显示、隐藏、展开、折叠或激活承载自己的纸片。
@@ -91,7 +91,7 @@ paper.toggle
 
 自定义 action 必须满足：
 
-- 协议版本为 `2.0`；
+- 协议版本为 `2.1`；
 - 插件声明 `runtime`；
 - action id 为 1～80 个 ASCII 字母、数字、`.`、`_`、`-`；
 - plugin runtime 注册快捷键 action handler。

--- a/plugin-samples/PaperTodo.Plugin.CloudGenshin/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.CloudGenshin/plugin.json
@@ -4,7 +4,7 @@
   "name": "云·原神（实验）",
   "description": "在 PaperTodo 纸片中直接打开云·原神网页版。",
   "version": "1.3.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "entry": "PaperTodo.Plugin.CloudGenshin.dll",
   "capabilities": []

--- a/plugin-samples/PaperTodo.Plugin.FocusTimer/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.FocusTimer/plugin.json
@@ -4,7 +4,7 @@
   "name": "专注计时器",
   "description": "可关联 PaperTodo 待办的 WPF 番茄钟，支持完成联动、自动选择下一项和折叠后台计时。",
   "version": "1.4.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 3,
   "entry": "PaperTodo.Plugin.FocusTimer.dll",
   "capabilities": [

--- a/plugin-samples/PaperTodo.Plugin.OfficialClockWeb/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.OfficialClockWeb/plugin.json
@@ -4,7 +4,7 @@
   "name": "Web 时钟",
   "description": "完整的 Web 插件示例：主题、时区、日期格式、标题和日进度均可配置。",
   "version": "1.5.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "maxPaperInstances": 1,
   "entry": "web/index.html",

--- a/plugin-samples/PaperTodo.Plugin.ReviewArchive/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.ReviewArchive/plugin.json
@@ -4,7 +4,7 @@
   "name": "待办复盘记录池",
   "description": "实时记录待办生命周期、提醒变化和完成趋势，长期保存并导出 Excel 可直接打开的 CSV。",
   "version": "1.2.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "entry": "PaperTodo.Plugin.ReviewArchive.dll",
   "capabilities": [

--- a/plugin-samples/PaperTodo.Plugin.SampleClock/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.SampleClock/plugin.json
@@ -4,7 +4,7 @@
   "name": "原生时钟",
   "description": "完整的 WPF 时钟示例：时区、日期格式、标题和日进度均可配置。",
   "version": "1.5.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "entry": "PaperTodo.Plugin.SampleClock.dll",
   "capabilities": [

--- a/plugin-samples/PaperTodo.Plugin.TopBarWeb/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.TopBarWeb/plugin.json
@@ -1,10 +1,10 @@
 {
   "kind": "web",
   "id": "sample.topbar.web",
-  "name": "Top Bar 2.0 示例",
-  "description": "演示 app-runtime Global 顶栏、Paper 顶栏、插件快捷键、自身纸片控制与 Workspace。",
+  "name": "Top Bar 2.1 示例",
+  "description": "演示 Plugin Runtime Global 顶栏、Paper 顶栏、插件快捷键、自身纸片控制与 Workspace。",
   "version": "1.0.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "entry": "web/index.html",
   "capabilities": [

--- a/plugin-samples/PaperTodo.Plugin.TopBarWeb/web/index.html
+++ b/plugin-samples/PaperTodo.Plugin.TopBarWeb/web/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>PaperTodo Top Bar 2.0</title>
+  <title>PaperTodo Top Bar 2.1</title>
   <style>
     html, body { margin: 0; min-height: 100%; background: transparent; }
     body {
@@ -18,7 +18,7 @@
 </head>
 <body>
   <main>
-    <strong>Protocol 2.0 Paper Top Bar</strong>
+    <strong>Protocol 2.1 Paper Top Bar</strong>
     <p id="status">等待宿主初始化…</p>
     <div class="actions">
       <button id="toggle-collapsed">折叠 / 展开自身纸片</button>

--- a/plugin-samples/PaperTodo.Plugin.TopBarWeb/web/runtime.html
+++ b/plugin-samples/PaperTodo.Plugin.TopBarWeb/web/runtime.html
@@ -25,14 +25,14 @@
 
   function publishPaper(paperId) {
     if (!paperId) return;
-    void papertodo.papers.setHeaderText(paperId, 'Top Bar 2.0');
+    void papertodo.papers.setHeaderText(paperId, 'Top Bar 2.1');
     void papertodo.papers.setCapsulePresentation(paperId, {
       preferredWidth: 0,
-      plainText: 'Top Bar 2.0',
-      toolTip: 'Protocol 2.0 Top Bar 示例',
+      plainText: 'Top Bar 2.1',
+      toolTip: 'Protocol 2.1 Top Bar 示例',
       components: [
         { kind: 'glyph', text: 'T' },
-        { kind: 'text', text: 'Top Bar 2.0', fill: true }
+        { kind: 'text', text: 'Top Bar 2.1', fill: true }
       ]
     });
   }

--- a/plugin-samples/README.md
+++ b/plugin-samples/README.md
@@ -5,10 +5,10 @@
 新插件使用：
 
 ```json
-"apiVersion": "2.0"
+"apiVersion": "2.1"
 ```
 
-当前宿主只接受 `2.0` 插件；旧 `1.8` manifest 不再兼容加载。
+当前宿主只接受 `2.1` 插件。清理前的实验性 `2.0` 以及更早 manifest 不再兼容加载；旧插件需要更新 manifest，并使用当前 `PaperTodo.Plugin.Abstractions` 重新构建。
 
 插件公开类型以 [`../PaperTodo.Plugin.Abstractions/`](../PaperTodo.Plugin.Abstractions/) 为编译期合同；宿主实际校验和运行行为以当前代码为准。需要理解 PaperTodo 内部 ownership 时再看 [`../ARCHITECTURE.md`](../ARCHITECTURE.md)，插件作者不需要先阅读主程序架构才能开始开发。
 
@@ -50,7 +50,7 @@ plugins/com.example.hello/
   "id": "com.example.hello",
   "name": "Hello",
   "version": "1.0.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "entry": "web/index.html"
 }
@@ -154,7 +154,7 @@ Native `plugin.json`：
   "id": "com.example.hello-native",
   "name": "Hello Native",
   "version": "1.0.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "entry": "HelloPlugin.dll"
 }
@@ -225,15 +225,15 @@ Native 最终目录只保留运行所需内容。不要分发无必要的 PDB/XM
 | `name` | 显示名称；为空时回退到 ID |
 | `description` | 插件说明 |
 | `version` | 插件版本，必须能解析为 `Version` |
-| `apiVersion` | 必须为 `"2.0"` |
+| `apiVersion` | 必须为 `"2.1"` |
 | `stateVersion` | per-paper state 版本，至少为 1 |
 | `maxPaperInstances` | 可选；同一 Provider 最多允许存在的真实 Paper 数。省略默认 `1`，`0` 表示不限制；隐藏/折叠 Paper 仍计数 |
 | `entry` | Web 主页面或 Native 入口 DLL，必须位于插件目录内 |
 | `miniEntry` | 可选，仅 Web；专属 Edge Mini 页面 |
 | `miniSize` | 可选，仅与 `miniEntry` 一起使用；Mini 首选尺寸 |
-| `miniMaxSize` | 可选，2.0；插件承诺的 Mini 最大容量，用于宿主 bounded capacity 规划 |
+| `miniMaxSize` | 可选；插件承诺的 Mini 最大容量，用于宿主 bounded capacity 规划 |
 | `runtime` | 可选，仅 Web `runtime`；一个 provider 最多一个 Runtime，省略时默认 `entry` 同目录 `runtime.html` |
-| `capabilities` | 可选：`textZoom`、`noteLinks`；2.0 还支持生命周期能力 `runtime` |
+| `capabilities` | 可选：`textZoom`、`noteLinks`，以及生命周期能力 `runtime` |
 | `permissions` | 可选；Paper/Todo/Note Workspace 权限 |
 | `advancedSettings` | 可选，默认 `false`；声明 `true` 后启用独立完整设置页 |
 | `primarySettings` | 可选；仅 `advancedSettings: true` 时有效，插件卡片直接显示前 1～3 个设置，省略时默认 3 |
@@ -255,7 +255,7 @@ Native 最终目录只保留运行所需内容。不要分发无必要的 PDB/XM
   "id": "com.example.weather",
   "name": "天气",
   "version": "1.0.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "entry": "web/index.html",
   "miniEntry": "web/mini.html",
@@ -298,7 +298,7 @@ Native 最终目录只保留运行所需内容。不要分发无必要的 PDB/XM
 - 创建时机、去重和恢复由宿主管理；插件只声明意图；
 - 如果用户已经把原自动创建纸片改造成其他 provider/type，宿主不会强行接管或偷偷再创建副本。
 
-### 3.4 `runtime`（2.0）
+### 3.4 `runtime`（2.1）
 
 插件需要脱离 Body/Mini UI 生命周期持续运行时声明：
 
@@ -387,7 +387,8 @@ public sealed class MyPlugin : IPaperBodyPlugin, IPaperPluginRuntimeProvider
 - `State`：provider Runtime 自己的一份持久 JSON；
 - `Papers`：列出逻辑 Paper，按 `paperId` 设置长期 presentation、向 Body 发消息、接收 Paper 增删/前端消息；
 - `Workspace`；
-- `GlobalTopBar` / `GlobalShortcuts`。
+- `GlobalTopBar` / `GlobalShortcuts`；
+- `TodoActions` / `TopBarLabels`：Protocol 2.1 的宿主绘制 contribution。
 
 Web Runtime 获得对应的 `papertodo.settings`、`papertodo.state`、`papertodo.papers`、`papertodo.workspace`。一个 provider 只创建一个隐藏 Runtime WebView。
 
@@ -408,7 +409,7 @@ plugins/data/<插件 ID>.json
 - `settings`：该插件所有纸片共享；
 - `runtime`：provider Runtime 的一份后端 state；
 - `papers`：按 Paper ID 保存 Body/Mini 前端 state；
-- 每张纸片 state 的保存上限是 **1 MiB UTF-8 JSON**。
+- 每张纸片 state 的保存上限是 **10 MiB UTF-8 JSON**。
 
 Native 使用：
 
@@ -574,7 +575,7 @@ Top Bar 不提供另一套 `GetBodyText/SetBodyText`。需要读写目标纸片�
 
 插件 Workspace 与 MCP 共用 `PaperCommandService` 业务边界，因此保存、失败回滚、UI reconcile 和事件顺序不因为入口不同而复制第二套实现。
 
-## 7. Top Bar 扩展（2.0）
+## 7. Top Bar 扩展（2.1）
 
 **PaperTodo 始终拥有顶栏 WPF tree、按钮尺寸、位置、主题、Hover、DPI 和 responsive layout；插件只贡献 action descriptor。** 不接受插件直接塞 `FrameworkElement`、Button、WebView 或任意顶栏控件。
 
@@ -691,7 +692,7 @@ manifest：
 
 ```json
 {
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "entry": "web/index.html",
   "runtime": "web/background.html",
   "capabilities": ["runtime"]
@@ -740,6 +741,22 @@ papertodo.onEvent(async message => {
 Runtime 是独立 app surface，不获得 `paper`、`body`、`mini` presentation API。runtime document 导航、renderer failure、最后一张实体插件 paper 消失或 Runtime Dispose 都会撤掉 Global action。Web Mini 也不能注册 Global Top Bar。
 
 完整可运行示例见 `PaperTodo.Plugin.TopBarWeb`。
+
+### 7.6 Protocol 2.1 Todo 与顶栏展示扩展
+
+Protocol 2.1 的 provider Runtime 还可以向宿主发布两类轻量 contribution：
+
+- `TodoActions`：给现有 Todo 行发布宿主绘制的操作按钮；点击时插件收到目标 Paper/Todo 和最新 `TodoSnapshot`；
+- `TopBarLabels`：给现有 Paper 顶栏发布不可点击的宿主绘制标签。
+
+Web Runtime 对应：
+
+```js
+papertodo.todoActions.set(paperId, todoId, actions);
+papertodo.topBarLabels.set(paperId, labels);
+```
+
+这两类内容只在当前 Runtime 生命周期内存在，不成为长期业务状态。完整示例见 `PaperTodo.Plugin.Protocol21Web`。
 
 ## 8. 胶囊 presentation
 
@@ -799,7 +816,7 @@ Edge Mini 是快速浏览 surface。**插件贡献内容，PaperTodo 始终拥�
 
 协议没有固定的 120×90 下限或 480×420 上限。插件声明的 `width` / `height` 必须是**正且有限的数值**；宿主只按当前显示器可用工作区约束最终尺寸。
 
-`miniMaxSize` 是 2.0 的可选**容量上界声明**：插件承诺该 Mini 在当前协议下不会请求超过它的宽高，宿主可据此准备 bounded host，而不是无理由预留一个很大的 WebView/HWND/承载面。它不是插件取得窗口尺寸 authority；最终尺寸仍由 PaperTodo 的显示器工作区和宿主规则限制。Web 插件声明 `miniMaxSize` 时必须有 `miniEntry`，且 `miniSize` 不能大于它。Native 也可以在 manifest 中声明同一上界；省略时宿主使用兼容容量策略。
+`miniMaxSize` 是可选的**容量上界声明**：插件承诺该 Mini 在当前协议下不会请求超过它的宽高，宿主可据此准备 bounded host，而不是无理由预留一个很大的 WebView/HWND/承载面。它不是插件取得窗口尺寸 authority；最终尺寸仍由 PaperTodo 的显示器工作区和宿主规则限制。Web 插件声明 `miniMaxSize` 时必须有 `miniEntry`，且 `miniSize` 不能大于它。Native 也可以在 manifest 中声明同一上界；省略时宿主使用兼容容量策略。
 
 默认首选尺寸：
 
@@ -816,7 +833,7 @@ Edge Mini 是快速浏览 surface。**插件贡献内容，PaperTodo 始终拥�
 规则：
 
 - `CreateMiniView` 必须返回 fresh / unparented / pure-WPF tree；
-- 不接受 `Window`、`HwndHost`、`WindowsFormsHost`、WebView2；
+- 不接受 `Window`、`HwndHost`、WindowsFormsHost、WebView2；
 - 返回 `null` 或创建失败不会让正文 session 失败；
 - `OnMiniViewVisibilityChanged(false)` 从收起开始发送；可暂停刷新和输入，但保留最后绘制内容完成离场；
 - Edge host 不取得键盘焦点，mini 不应依赖文本输入。
@@ -947,6 +964,8 @@ papertodo.surface;                    // 'app'
 papertodo.workspace.request(method, params);
 papertodo.settings.get();
 papertodo.globalTopBar.setActions(actions);
+papertodo.todoActions.set(paperId, todoId, actions);
+papertodo.topBarLabels.set(paperId, labels);
 papertodo.onEvent(listener);
 ```
 
@@ -979,7 +998,8 @@ Native 插件是 fully trusted / unsandboxed .NET/WPF 代码，与 PaperTodo 当
 
 | 示例 | 重点 |
 | --- | --- |
-| `PaperTodo.Plugin.TopBarWeb` | **Protocol 2.0 Top Bar 专项示例**：body Paper action + Web Runtime Global action、字符/Stroke SVG、目标 Paper context、Workspace 复用 |
+| `PaperTodo.Plugin.Protocol21Web` | **Protocol 2.1 contribution 专项示例**：Todo 行操作、顶栏标签、最新 TodoSnapshot |
+| `PaperTodo.Plugin.TopBarWeb` | **Protocol 2.1 Top Bar 专项示例**：body Paper action + Web Runtime Global action、字符/Stroke SVG、目标 Paper context、Workspace 复用 |
 | `PaperTodo.Plugin.SampleClock` | Native 主示例：settings、background updates、标准 capsule、自定义 WPF capsule、dedicated WPF mini |
 | `PaperTodo.Plugin.OfficialClockWeb` | Web 主示例：body/mini 双页面、`miniEntry`、state/settings 同步、startup paper、background updates |
 | `PaperTodo.Plugin.FocusTimer` | Native 有状态交互：正文与 dedicated mini 共享计时 model，mini 内直接开始/暂停/继续 |
@@ -992,7 +1012,7 @@ Native 插件是 fully trusted / unsandboxed .NET/WPF 代码，与 PaperTodo 当
 
 ### Manifest / Runtime
 
-- 新插件仍以 `apiVersion: "1.8"` 为目标，导致无法使用 2.0 Top Bar / Runtime；
+- 新插件仍以 `apiVersion: "2.0"` 或更早版本为目标；当前宿主只接受 `2.1`；
 - 插件目录名和 `id` 不一致；
 - `id` 使用非法字符或保留 ID `data`；
 - Web 声明 `runtime`，但默认 `runtime.html` 不存在，或显式 `runtime` 路径不存在/跑出 Web `entry` 静态目录；
@@ -1045,7 +1065,7 @@ Native 插件是 fully trusted / unsandboxed .NET/WPF 代码，与 PaperTodo 当
 - 收到 `stateChanged` 后原样 `saveState` 造成 body/mini 回声；
 - 把普通 per-paper state 同时写进 `plugins/data` 和 `.runtime/`；
 - state 迁移失败时写空对象覆盖旧数据；
-- 单张 paper state 超过 1 MiB。
+- 单张 paper state 超过 10 MiB。
 
 ### Workspace / 生命周期
 
@@ -1059,7 +1079,7 @@ Native 插件是 fully trusted / unsandboxed .NET/WPF 代码，与 PaperTodo 当
 
 ## 14. 提交插件前
 
-- `plugin.json` 使用当前目标 `apiVersion: "2.0"`；
+- `plugin.json` 使用当前目标 `apiVersion: "2.1"`；
 - Native manifest 与入口 DLL metadata/runtime requirements 一致；
 - 声明 `runtime` 时：Native 实现 `IPaperPluginRuntimeProvider`；Web 默认提供 `entry` 同目录 `runtime.html`，或用 `runtime` 指定同一 Web 静态目录内的其他入口；
 - Runtime 需要插件设置时只读取自己的 `context.Settings.Json` / `papertodo.settings.get()`，不借用隐藏 paper session；
@@ -1077,6 +1097,7 @@ Native 插件是 fully trusted / unsandboxed .NET/WPF 代码，与 PaperTodo 当
 - Edge Mini 不依赖键盘输入；
 - 只声明实际需要的 permissions / `runtime`；
 - 切换 provider、删除 paper 时 0↔1 Runtime ownership 正确；退出 PaperTodo 后 Runtime 与 Global Top Bar 完整撤销。
+
 ### PluginRuntime 初始化与状态约定
 
 Runtime 启动时先调用 `Papers.List()` 获取当前全部 Paper，再用 `Papers.Subscribe(...)` 接收后续 `PaperAdded` / `PaperRemoved` / `Message`；订阅不会补发启动前已经存在的 Paper。每张 Paper 的 frontend/body state 最多 10 MiB，整个 provider 的 PluginRuntime state 最多 20 MiB，两者互不占用对方额度。`runtime.post(...)` 只表示当前 Runtime 真正接受了消息；Runtime/Web renderer 暂不可用时会明确失败，插件按自己的业务语义决定是否重试。

--- a/plugins/official.clock.web/plugin.json
+++ b/plugins/official.clock.web/plugin.json
@@ -4,7 +4,7 @@
   "name": "Web 时钟",
   "description": "完整的 Web 插件示例：主题、时区、日期格式、标题和日进度均可配置。",
   "version": "1.5.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "maxPaperInstances": 1,
   "entry": "web/index.html",

--- a/plugins/sample.clock.native/plugin.json
+++ b/plugins/sample.clock.native/plugin.json
@@ -4,7 +4,7 @@
   "name": "原生时钟",
   "description": "完整的 WPF 时钟示例：时区、日期格式、标题和日进度均可配置。",
   "version": "1.5.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "entry": "PaperTodo.Plugin.SampleClock.dll",
   "capabilities": [

--- a/plugins/sample.cloudgenshin.native/plugin.json
+++ b/plugins/sample.cloudgenshin.native/plugin.json
@@ -4,7 +4,7 @@
   "name": "云·原神（实验）",
   "description": "在 PaperTodo 纸片中直接打开云·原神网页版。",
   "version": "1.3.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "entry": "PaperTodo.Plugin.CloudGenshin.dll",
   "capabilities": []

--- a/plugins/sample.focus-timer.native/plugin.json
+++ b/plugins/sample.focus-timer.native/plugin.json
@@ -4,7 +4,7 @@
   "name": "专注计时器",
   "description": "可关联 PaperTodo 待办的 WPF 番茄钟，支持完成联动、自动选择下一项和折叠后台计时。",
   "version": "1.4.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 3,
   "entry": "PaperTodo.Plugin.FocusTimer.dll",
   "capabilities": [

--- a/plugins/sample.review-archive.native/plugin.json
+++ b/plugins/sample.review-archive.native/plugin.json
@@ -4,7 +4,7 @@
   "name": "待办复盘记录池",
   "description": "实时记录待办生命周期、提醒变化和完成趋势，长期保存并导出 Excel 可直接打开的 CSV。",
   "version": "1.2.0",
-  "apiVersion": "2.0",
+  "apiVersion": "2.1",
   "stateVersion": 1,
   "entry": "PaperTodo.Plugin.ReviewArchive.dll",
   "capabilities": [

--- a/src/AppController.PluginApi.cs
+++ b/src/AppController.PluginApi.cs
@@ -104,8 +104,11 @@ public sealed partial class AppController
     internal void FinalizeExternalPaperCreated(PaperData paper, bool show) =>
         FinalizeMcpPaperCreated(paper, show);
 
-    internal void RefreshExternalTodoPaper(PaperData paper) =>
+    internal void RefreshExternalTodoPaper(PaperData paper)
+    {
+        PrunePluginTodoActionsForPaper(paper.Id);
         RefreshMcpTodoPaper(paper);
+    }
 
     internal void RefreshExternalNotePaper(PaperData paper) =>
         RefreshMcpNotePaper(paper);
@@ -150,6 +153,9 @@ public sealed partial class AppController
                 _pendingPluginPaperStateDeletes.Remove(paperId);
                 continue;
             }
+
+            RemovePluginTodoActionsForPaper(paperId);
+            RemovePluginTopBarLabelsForPaper(paperId);
 
             // Runtime Backoff has no live lease to reconcile. Remove any retained rich
             // presentation for the now-deleted Paper here as part of the independent post-commit

--- a/src/AppController.PluginRuntime.cs
+++ b/src/AppController.PluginRuntime.cs
@@ -50,11 +50,6 @@ public sealed partial class AppController
                 ? PluginRuntimeState.Stopped
                 : state;
 
-        public static PluginRuntimeState DescriptorChanged(PluginRuntimeState state) =>
-            state == PluginRuntimeState.Failed
-                ? PluginRuntimeState.Stopped
-                : state;
-
         public static bool RuntimeMatches(Guid currentRuntimeId, Guid callbackRuntimeId) =>
             currentRuntimeId == callbackRuntimeId;
     }
@@ -183,20 +178,7 @@ public sealed partial class AppController
             }
             else
             {
-                var descriptorChanged = slot.Descriptor != null &&
-                    !string.Equals(
-                        slot.Descriptor.Fingerprint,
-                        descriptor.Fingerprint,
-                        StringComparison.Ordinal);
                 slot.Descriptor = descriptor;
-                if (descriptorChanged && slot.State == PluginRuntimeState.Failed)
-                {
-                    slot.State = PluginRuntimeTransitions.DescriptorChanged(slot.State);
-                    slot.FailureCount = 0;
-                    slot.RetryGeneration++;
-                    slot.RestartRequested = false;
-                    statusChanged = true;
-                }
             }
 
             if (slot.State == PluginRuntimeState.Stopped)

--- a/src/AppController.PluginRuntimePapers.cs
+++ b/src/AppController.PluginRuntimePapers.cs
@@ -150,6 +150,53 @@ public sealed partial class AppController
         }
     }
 
+    internal void CompletePluginRuntimeStartupPresentation(
+        string providerId,
+        IReadOnlySet<string> publishedHeaderPaperIds,
+        IReadOnlySet<string> publishedCapsulePaperIds)
+    {
+        var changed = false;
+        foreach (var paper in State.Papers.Where(paper =>
+                     paper.Type == PaperTypes.Note &&
+                     string.Equals(
+                         PluginRuntimeProviderId(paper.BodyProviderId),
+                         providerId,
+                         StringComparison.Ordinal)))
+        {
+            if (!publishedHeaderPaperIds.Contains(paper.Id))
+            {
+                var hadHeader = !string.IsNullOrEmpty(paper.BodyHeaderText);
+                paper.BodyHeaderText = string.Empty;
+                if (_windows.TryGetValue(paper.Id, out var window) && !window.IsClosed)
+                {
+                    window.ApplyPluginRuntimeHeader(providerId, string.Empty);
+                }
+                if (hadHeader)
+                {
+                    changed = true;
+                    NotifyPaperDisplayTitleChanged(paper.Id);
+                }
+            }
+
+            if (!publishedCapsulePaperIds.Contains(paper.Id))
+            {
+                var hadCapsule = !string.IsNullOrEmpty(paper.BodyCapsuleText);
+                RemovePluginRuntimePresentationCache(providerId, paper.Id);
+                paper.BodyCapsuleText = string.Empty;
+                if (_windows.TryGetValue(paper.Id, out var window) && !window.IsClosed)
+                {
+                    window.ApplyPluginRuntimeCapsule(providerId, null);
+                }
+                changed |= hadCapsule;
+            }
+        }
+
+        if (changed)
+        {
+            MarkDirty();
+        }
+    }
+
     internal void RemovePluginRuntimePresentationCache(
         string providerId,
         string paperId)

--- a/src/AppController.PluginTodoActions.cs
+++ b/src/AppController.PluginTodoActions.cs
@@ -33,7 +33,6 @@ public sealed partial class AppController
         Func<bool> isActive,
         Action<PaperTodoActionInvocation> invoke)
     {
-        EnsurePluginApiAtLeast(providerId, 2, 1, "todo_actions_requires_api_2_1");
         var (paper, item) = RequirePluginTodoTarget(paperId, todoId);
         var normalized = PluginContributionPolicy.NormalizeTodoActions(actions);
 
@@ -113,6 +112,52 @@ public sealed partial class AppController
         foreach (var (paperId, todoId) in affected)
         {
             RefreshPluginTodoActions(paperId, todoId);
+        }
+    }
+
+    internal void PrunePluginTodoActionsForPaper(string paperId)
+    {
+        var normalizedPaperId = paperId?.Trim() ?? string.Empty;
+        if (normalizedPaperId.Length == 0 || _pluginTodoActionRegistrations.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var registration in _pluginTodoActionRegistrations.Values)
+        {
+            foreach (var key in registration.Actions.Keys
+                         .Where(key =>
+                             string.Equals(
+                                 key.PaperId,
+                                 normalizedPaperId,
+                                 StringComparison.Ordinal) &&
+                             !TryGetTodoTarget(key.PaperId, key.TodoId, out _, out _))
+                         .ToArray())
+            {
+                registration.Actions.Remove(key);
+            }
+        }
+    }
+
+    internal void RemovePluginTodoActionsForPaper(string paperId)
+    {
+        var normalizedPaperId = paperId?.Trim() ?? string.Empty;
+        if (normalizedPaperId.Length == 0 || _pluginTodoActionRegistrations.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var registration in _pluginTodoActionRegistrations.Values)
+        {
+            foreach (var key in registration.Actions.Keys
+                         .Where(key => string.Equals(
+                             key.PaperId,
+                             normalizedPaperId,
+                             StringComparison.Ordinal))
+                         .ToArray())
+            {
+                registration.Actions.Remove(key);
+            }
         }
     }
 
@@ -201,23 +246,6 @@ public sealed partial class AppController
                 todoId,
                 ex.GetBaseException());
         }
-    }
-
-    private void EnsurePluginApiAtLeast(
-        string providerId,
-        int major,
-        int minor,
-        string errorCode)
-    {
-        if (PaperBodyPlugins.TryGet(providerId, out var descriptor) &&
-            PluginContributionPolicy.ApiAtLeast(descriptor.ApiVersion, major, minor))
-        {
-            return;
-        }
-
-        throw new PaperTodoPluginException(
-            errorCode,
-            $"This plugin contribution requires apiVersion {major}.{minor} or newer.");
     }
 
     private (PaperData Paper, PaperItem Item) RequirePluginTodoTarget(

--- a/src/AppController.PluginTopBar.cs
+++ b/src/AppController.PluginTopBar.cs
@@ -61,7 +61,6 @@ public sealed partial class AppController
         Func<bool> isActive,
         Action<PaperTopBarActionInvocation> invoke)
     {
-        EnsurePluginTopBarProtocol(providerId);
         var normalized = NormalizePluginTopBarActions(
             actions,
             MaximumPaperTopBarActions,
@@ -150,19 +149,6 @@ public sealed partial class AppController
             PaperWindow.EnsurePluginTopBarLoadedHandler();
         }
         RefreshAllPluginTopBars();
-    }
-
-    private void EnsurePluginTopBarProtocol(string providerId)
-    {
-        if (PaperBodyPlugins.TryGet(providerId, out var descriptor) &&
-            PluginContributionPolicy.ApiAtLeast(descriptor.ApiVersion, 2, 0))
-        {
-            return;
-        }
-
-        throw new PaperTodoPluginException(
-            "topbar_requires_api_2_0",
-            "Plugin top-bar extensions require apiVersion 2.0 or newer.");
     }
 
     internal void RemovePluginPaperTopBarSession(Guid sessionId)

--- a/src/AppController.PluginTopBarLabels.cs
+++ b/src/AppController.PluginTopBarLabels.cs
@@ -30,7 +30,6 @@ public sealed partial class AppController
         IReadOnlyList<PaperTopBarLabel> labels,
         Func<bool> isActive)
     {
-        EnsurePluginApiAtLeast(providerId, 2, 1, "topbar_labels_require_api_2_1");
         var normalizedPaperId = RequirePluginLabelTarget(paperId).Id;
         var normalized = PluginContributionPolicy.NormalizeTopBarLabels(labels);
 
@@ -101,6 +100,20 @@ public sealed partial class AppController
         foreach (var paperId in affectedPaperIds)
         {
             RefreshPluginTopBarLabels(paperId);
+        }
+    }
+
+    internal void RemovePluginTopBarLabelsForPaper(string paperId)
+    {
+        var normalizedPaperId = paperId?.Trim() ?? string.Empty;
+        if (normalizedPaperId.Length == 0 || _pluginTopBarLabelRegistrations.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var registration in _pluginTopBarLabelRegistrations.Values)
+        {
+            registration.Labels.Remove(normalizedPaperId);
         }
     }
 

--- a/src/AppController.Plugins.cs
+++ b/src/AppController.Plugins.cs
@@ -514,7 +514,9 @@ public sealed partial class AppController
         DockPanel.SetDock(titleRow, Dock.Top);
         root.Children.Add(titleRow);
 
-        var minimumContentWidth = Math.Max(480, window.MinWidth - 56);
+        var minimumContentWidth = Math.Max(
+            0,
+            Math.Min(480, window.MinWidth - 56));
         var maximumContentWidth = Math.Max(
             minimumContentWidth,
             window.MaxWidth - 56);
@@ -533,7 +535,7 @@ public sealed partial class AppController
             MaxWidth = maximumContentWidth,
             MaxHeight = maximumContentHeight,
             VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
             Margin = new Thickness(0, 2, 0, 0)
         };
         root.Children.Add(scroll);

--- a/src/PaperBodyPluginDataStore.cs
+++ b/src/PaperBodyPluginDataStore.cs
@@ -116,9 +116,11 @@ internal sealed class PaperBodyPluginDataStore : IDisposable
         int stateVersion,
         string? json)
     {
-        var normalized = NormalizePluginRuntimeStateJson(json);
-        using var parsed = JsonDocument.Parse(normalized);
-        var value = parsed.RootElement.Clone();
+        _ = NormalizeStateJson(
+            json,
+            MaximumPluginRuntimeStateBytes,
+            "Plugin Runtime state",
+            out var value);
 
         lock (_gate)
         {
@@ -179,9 +181,11 @@ internal sealed class PaperBodyPluginDataStore : IDisposable
         int stateVersion,
         string? json)
     {
-        var normalized = NormalizeStateJson(json);
-        using var parsed = JsonDocument.Parse(normalized);
-        var value = parsed.RootElement.Clone();
+        _ = NormalizeStateJson(
+            json,
+            MaximumPaperStateBytes,
+            "Plugin paper state",
+            out var value);
 
         lock (_gate)
         {
@@ -324,18 +328,21 @@ internal sealed class PaperBodyPluginDataStore : IDisposable
         NormalizeStateJson(
             json,
             MaximumPaperStateBytes,
-            "Plugin paper state");
+            "Plugin paper state",
+            out _);
 
     internal static string NormalizePluginRuntimeStateJson(string? json) =>
         NormalizeStateJson(
             json,
             MaximumPluginRuntimeStateBytes,
-            "Plugin Runtime state");
+            "Plugin Runtime state",
+            out _);
 
     private static string NormalizeStateJson(
         string? json,
         int maximumBytes,
-        string stateName)
+        string stateName,
+        out JsonElement value)
     {
         var normalized = string.IsNullOrWhiteSpace(json) ? "{}" : json.Trim();
         var byteCount = Encoding.UTF8.GetByteCount(normalized);
@@ -345,9 +352,8 @@ internal sealed class PaperBodyPluginDataStore : IDisposable
                 $"{stateName} cannot exceed {maximumBytes} UTF-8 bytes.");
         }
 
-        using (JsonDocument.Parse(normalized))
-        {
-        }
+        using var parsed = JsonDocument.Parse(normalized);
+        value = parsed.RootElement.Clone();
         return normalized;
     }
 

--- a/src/PaperBodyPluginEventHub.cs
+++ b/src/PaperBodyPluginEventHub.cs
@@ -405,7 +405,11 @@ internal sealed class PaperBodyPluginEventHub : IDisposable
         if (before.Order != after.Order) fields |= TodoChangedFields.Order;
         if (before.ReminderAt != after.ReminderAt) fields |= TodoChangedFields.Reminder;
         if (!string.Equals(before.LinkedPaperId, after.LinkedPaperId, StringComparison.Ordinal)) fields |= TodoChangedFields.LinkedPaper;
-        if (!string.Equals(before.LinkedPath, after.LinkedPath, StringComparison.Ordinal)) fields |= TodoChangedFields.LinkedPath;
+        if (!string.Equals(before.LinkedPath, after.LinkedPath, StringComparison.Ordinal) ||
+            before.LinkedPathIsDirectory != after.LinkedPathIsDirectory)
+        {
+            fields |= TodoChangedFields.LinkedPath;
+        }
         return fields;
     }
 

--- a/src/PaperBodyPluginHostApi.Presentation.cs
+++ b/src/PaperBodyPluginHostApi.Presentation.cs
@@ -44,7 +44,6 @@ internal sealed partial class PaperBodyPluginHostApi
     private string RequireHostPaperId()
     {
         EnsureUsable();
-        EnsurePresentationProtocol();
         if (string.IsNullOrEmpty(_hostPaperId))
         {
             throw Error(
@@ -52,19 +51,6 @@ internal sealed partial class PaperBodyPluginHostApi
                 "This plugin context is not attached to a paper.");
         }
         return _hostPaperId;
-    }
-
-    private void EnsurePresentationProtocol()
-    {
-        if (_controller.PaperBodyPlugins.TryGet(_providerId, out var descriptor) &&
-            PluginContributionPolicy.ApiAtLeast(descriptor.ApiVersion, 2, 0))
-        {
-            return;
-        }
-
-        throw Error(
-            "presentation_requires_api_2_0",
-            "Own-paper presentation controls require plugin apiVersion 2.0 or newer.");
     }
 
     private void QueuePresentation(Func<string, bool> action)

--- a/src/PaperBodyPluginHostApi.cs
+++ b/src/PaperBodyPluginHostApi.cs
@@ -108,9 +108,15 @@ internal sealed partial class PaperBodyPluginHostApi : IPaperTodoHostApi, IPaper
     {
         ArgumentNullException.ThrowIfNull(request);
         Require(PaperTodoPermissionNames.TodosUpdate);
-        return Invoke(() => _commands.UpdateTodo(
+        var result = Invoke(() => _commands.UpdateTodo(
             request,
             PaperOperationContext.Plugin(_providerId)));
+        var deleted = !_controller.State.Papers.Any(paper =>
+            paper.Type == PaperTypes.Todo &&
+            string.Equals(paper.Id, result.PaperId, StringComparison.Ordinal) &&
+            paper.Items.Any(item =>
+                string.Equals(item.Id, result.TodoId, StringComparison.Ordinal)));
+        return result with { Deleted = deleted };
     }
 
     public TodoMutationResult SetTodoReminder(SetTodoReminderRequest request)

--- a/src/PaperBodyPluginRegistry.Permissions.cs
+++ b/src/PaperBodyPluginRegistry.Permissions.cs
@@ -72,24 +72,6 @@ internal sealed partial class PaperBodyPluginRegistry
             throw new InvalidDataException(
                 "maxPaperInstances must be 0 (unlimited) or a positive integer.");
         }
-        if (manifest.Permissions.Length > 0 && !ApiAtLeast(manifest.ApiVersion, 1, 3))
-        {
-            throw new InvalidDataException(
-                "Plugin permissions require apiVersion 1.3 or newer.");
-        }
-        if (manifest.Capabilities.Contains("runtime", StringComparer.Ordinal) &&
-            !ApiAtLeast(manifest.ApiVersion, 2, 0))
-        {
-            throw new InvalidDataException(
-                "The runtime capability requires apiVersion 2.0 or newer.");
-        }
-    }
-
-    private static bool ApiAtLeast(string apiVersion, int major, int minor)
-    {
-        var parts = apiVersion.Split('.');
-        return int.Parse(parts[0]) > major ||
-            (int.Parse(parts[0]) == major && int.Parse(parts[1]) >= minor);
     }
 
     private static void ValidateDeclaredDefault(

--- a/src/PaperBodyPluginRegistry.Settings.cs
+++ b/src/PaperBodyPluginRegistry.Settings.cs
@@ -86,11 +86,6 @@ internal sealed partial class PaperBodyPluginRegistry
                 throw new InvalidDataException(
                     $"Plugin setting '{setting.Id}' has unsupported type '{setting.Type}'.");
             }
-            if (setting.Type == "shortcut" && !ApiAtLeast(manifest.ApiVersion, 2, 0))
-            {
-                throw new InvalidDataException(
-                    $"Plugin shortcut setting '{setting.Id}' requires apiVersion 2.0 or newer.");
-            }
             if (setting.Type == "shortcut" && setting.ShortcutAction.Length == 0)
             {
                 throw new InvalidDataException(

--- a/src/PaperBodyPluginRegistry.cs
+++ b/src/PaperBodyPluginRegistry.cs
@@ -82,14 +82,13 @@ internal sealed class PaperBodyPluginMiniSizeManifest
 
 /// <summary>
 /// Discovers one fully trusted, unsandboxed native or local Web plugin from each self-contained
-/// plugins/&lt;plugin-id&gt;/plugin.json folder. Protocol 2.x has no plugin hot-reload contract: code,
+/// plugins/&lt;plugin-id&gt;/plugin.json folder. Protocol 2.1 has no plugin hot-reload contract: code,
 /// manifest and Web file changes are discovered on the next app start. Loaded native assemblies
 /// remain loaded for the process lifetime.
 /// </summary>
 internal sealed partial class PaperBodyPluginRegistry : IDisposable
 {
     internal const string SupportedPluginApiVersion = "2.1";
-    internal const string MinimumPluginApiVersion = "2.0";
     private static readonly Regex PluginIdPattern = PluginIdRegex();
     private static readonly StringComparer UiDisplayNameComparer =
         StringComparer.Create(UiLanguages.EffectiveUiCulture, ignoreCase: true);
@@ -308,10 +307,6 @@ internal sealed partial class PaperBodyPluginRegistry : IDisposable
 
         if (manifest.MiniMaxSize is { } miniMaximum)
         {
-            if (!ApiAtLeast(manifest.ApiVersion, 2, 0))
-            {
-                throw new InvalidDataException("miniMaxSize requires apiVersion 2.0.");
-            }
             if (kind == PaperBodyPluginKind.Web &&
                 string.IsNullOrWhiteSpace(manifest.MiniEntry))
             {
@@ -610,14 +605,16 @@ internal sealed partial class PaperBodyPluginRegistry : IDisposable
 
     private static void ValidateManifestApiVersion(string pluginApiVersion)
     {
-        if (string.Equals(pluginApiVersion, "2.0", StringComparison.Ordinal) ||
-            string.Equals(pluginApiVersion, "2.1", StringComparison.Ordinal))
+        if (string.Equals(
+                pluginApiVersion,
+                SupportedPluginApiVersion,
+                StringComparison.Ordinal))
         {
             return;
         }
 
         throw new InvalidDataException(
-            $"Unsupported plugin API version {pluginApiVersion}; host supports 2.0 through {SupportedPluginApiVersion}.");
+            $"Unsupported plugin API version {pluginApiVersion}; host requires {SupportedPluginApiVersion}.");
     }
 
     private static Version ParseVersion(string? value)

--- a/src/PaperPluginRuntimePapersApi.cs
+++ b/src/PaperPluginRuntimePapersApi.cs
@@ -19,10 +19,13 @@ internal sealed class PaperPluginRuntimePapersApi : IPaperPluginRuntimePapers, I
     private readonly Func<bool> _isActive;
     private readonly object _gate = new();
     private readonly HashSet<string> _knownPaperIds = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _publishedHeaderPaperIds = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _publishedCapsulePaperIds = new(StringComparer.Ordinal);
     private readonly Dictionary<string, PaperCapsulePresentation> _capsulePresentations =
         new(StringComparer.Ordinal);
     private readonly Dictionary<long, Action<PaperPluginRuntimeEvent>> _handlers = [];
     private long _nextHandlerId;
+    private bool _startupSnapshotCaptured;
     private bool _disposed;
 
     public PaperPluginRuntimePapersApi(
@@ -43,7 +46,29 @@ internal sealed class PaperPluginRuntimePapersApi : IPaperPluginRuntimePapers, I
     public IReadOnlyList<PaperPluginRuntimePaper> List()
     {
         EnsureUsable();
-        return OnUi(() => _controller.GetPluginRuntimePapers(_providerId));
+        var snapshot = OnUi(() => _controller.GetPluginRuntimePapers(_providerId));
+        var completeStartupPresentation = false;
+        lock (_gate)
+        {
+            EnsureUsableLocked();
+            if (!_startupSnapshotCaptured)
+            {
+                _knownPaperIds.Clear();
+                _knownPaperIds.UnionWith(snapshot.Select(paper => paper.PaperId));
+                _startupSnapshotCaptured = true;
+                completeStartupPresentation = true;
+            }
+        }
+
+        if (completeStartupPresentation &&
+            !_dispatcher.HasShutdownStarted &&
+            !_dispatcher.HasShutdownFinished)
+        {
+            _ = _dispatcher.BeginInvoke(
+                (Action)CompleteStartupPresentation,
+                DispatcherPriority.Background);
+        }
+        return snapshot;
     }
 
     public PaperPluginRuntimePaper? Get(string paperId)
@@ -67,6 +92,11 @@ internal sealed class PaperPluginRuntimePapersApi : IPaperPluginRuntimePapers, I
     {
         EnsureUsable();
         var normalized = NormalizePaperId(paperId);
+        lock (_gate)
+        {
+            EnsureUsableLocked();
+            _publishedHeaderPaperIds.Add(normalized);
+        }
         OnUi(() => _controller.SetPluginRuntimePaperHeader(
             _providerId,
             normalized,
@@ -83,6 +113,7 @@ internal sealed class PaperPluginRuntimePapersApi : IPaperPluginRuntimePapers, I
         lock (_gate)
         {
             EnsureUsableLocked();
+            _publishedCapsulePaperIds.Add(paperIdNormalized);
             if (presentationNormalized == null)
             {
                 _capsulePresentations.Remove(paperIdNormalized);
@@ -166,6 +197,8 @@ internal sealed class PaperPluginRuntimePapersApi : IPaperPluginRuntimePapers, I
             foreach (var paperId in removed)
             {
                 _capsulePresentations.Remove(paperId);
+                _publishedHeaderPaperIds.Remove(paperId);
+                _publishedCapsulePaperIds.Remove(paperId);
             }
             _knownPaperIds.Clear();
             _knownPaperIds.UnionWith(current);
@@ -202,6 +235,26 @@ internal sealed class PaperPluginRuntimePapersApi : IPaperPluginRuntimePapers, I
             paperId,
             message.Clone()));
         return true;
+    }
+
+    private void CompleteStartupPresentation()
+    {
+        string[] publishedHeaders;
+        string[] publishedCapsules;
+        lock (_gate)
+        {
+            if (_disposed || !_isActive())
+            {
+                return;
+            }
+            publishedHeaders = _publishedHeaderPaperIds.ToArray();
+            publishedCapsules = _publishedCapsulePaperIds.ToArray();
+        }
+
+        _controller.CompletePluginRuntimeStartupPresentation(
+            _providerId,
+            publishedHeaders.ToHashSet(StringComparer.Ordinal),
+            publishedCapsules.ToHashSet(StringComparer.Ordinal));
     }
 
     private void Publish(PaperPluginRuntimeEvent value)
@@ -285,6 +338,8 @@ internal sealed class PaperPluginRuntimePapersApi : IPaperPluginRuntimePapers, I
             _disposed = true;
             _handlers.Clear();
             _knownPaperIds.Clear();
+            _publishedHeaderPaperIds.Clear();
+            _publishedCapsulePaperIds.Clear();
             _capsulePresentations.Clear();
         }
     }

--- a/src/PaperWindow.PluginTodoActions.cs
+++ b/src/PaperWindow.PluginTodoActions.cs
@@ -74,6 +74,7 @@ public sealed partial class PaperWindow
             {
                 return;
             }
+            _controller.PrunePluginTodoActionsForPaper(_paper.Id);
             RefreshPluginTodoActions();
         };
     }

--- a/src/PaperWindow.PluginTopBarLabels.cs
+++ b/src/PaperWindow.PluginTopBarLabels.cs
@@ -8,6 +8,7 @@ public sealed partial class PaperWindow
 {
     private static bool _pluginTopBarLabelsLoadedHandlerRegistered;
     private StackPanel? _pluginTopBarLabelsHost;
+    private bool _pluginTopBarLabelCapacityHookInstalled;
 
     internal static void EnsurePluginTopBarLabelsLoadedHandler()
     {
@@ -46,6 +47,7 @@ public sealed partial class PaperWindow
         }
 
         _pluginTopBarLabelsHost.Children.Clear();
+        var measuredWidth = 0.0;
         foreach (var binding in _controller.GetPluginTopBarLabels(_paper.Id))
         {
             var label = binding.Label;
@@ -79,7 +81,7 @@ public sealed partial class PaperWindow
                 IsHitTestVisible = false
             });
 
-            _pluginTopBarLabelsHost.Children.Add(new Border
+            var element = new Border
             {
                 Padding = new Thickness(4, 1, 4, 1),
                 Margin = new Thickness(1, 0, 1, 0),
@@ -87,14 +89,54 @@ public sealed partial class PaperWindow
                 VerticalAlignment = VerticalAlignment.Center,
                 ToolTip = string.IsNullOrWhiteSpace(label.ToolTip) ? null : label.ToolTip,
                 Child = content
-            });
+            };
+            element.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            measuredWidth += element.DesiredSize.Width;
+            _pluginTopBarLabelsHost.Children.Add(element);
         }
 
-        _pluginTopBarLabelsHost.Visibility =
-            _pluginTopBarLabelsHost.Children.Count > 0
-                ? Visibility.Visible
-                : Visibility.Collapsed;
-        UpdateTopBarResponsiveLayout();
+        _pluginTopBarLabelsHost.Width = Math.Ceiling(measuredWidth);
+        _pluginTopBarLabelsHost.Visibility = Visibility.Collapsed;
+
+        // Interactive controls settle first; labels only occupy width that remains afterwards.
         RefreshPluginTopBarActions();
+        EnsurePluginTopBarLabelCapacityHook();
+        ReconcilePluginTopBarLabelCapacity();
+    }
+
+    private void EnsurePluginTopBarLabelCapacityHook()
+    {
+        if (_pluginTopBarLabelCapacityHookInstalled || _topBar == null)
+        {
+            return;
+        }
+
+        _pluginTopBarLabelCapacityHookInstalled = true;
+        _topBar.SizeChanged += (_, _) => ReconcilePluginTopBarLabelCapacity();
+    }
+
+    private void ReconcilePluginTopBarLabelCapacity()
+    {
+        if (_pluginTopBarLabelsHost == null || _topBarActionButtonsHost == null)
+        {
+            return;
+        }
+
+        if (_paper.IsCollapsed || _pluginTopBarLabelsHost.Children.Count == 0)
+        {
+            _pluginTopBarLabelsHost.Visibility = Visibility.Collapsed;
+            UpdateTopBarResponsiveLayout();
+            return;
+        }
+
+        _pluginTopBarLabelsHost.Visibility = Visibility.Visible;
+        UpdateTopBarResponsiveLayout();
+        if (_topBarActionButtonsHost.Visibility == Visibility.Visible)
+        {
+            return;
+        }
+
+        _pluginTopBarLabelsHost.Visibility = Visibility.Collapsed;
+        UpdateTopBarResponsiveLayout();
     }
 }

--- a/src/PluginContributionPolicy.cs
+++ b/src/PluginContributionPolicy.cs
@@ -128,15 +128,6 @@ internal static class PluginContributionPolicy
             .ToArray();
     }
 
-    internal static bool ApiAtLeast(string? value, int major, int minor)
-    {
-        var parts = value?.Split('.', StringSplitOptions.None);
-        return parts is { Length: 2 } &&
-            int.TryParse(parts[0], out var actualMajor) &&
-            int.TryParse(parts[1], out var actualMinor) &&
-            (actualMajor > major || actualMajor == major && actualMinor >= minor);
-    }
-
     private static string NormalizeIdentifier(
         string? value,
         string code,

--- a/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
+++ b/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
@@ -204,10 +204,11 @@ internal static class Program
             "The failure after all bounded retries must enter Failed.");
         Assert(InvokeState("RetryElapsed", State("Backoff")) == "Stopped",
             "Expired backoff must return to Stopped so reconcile can restart.");
-        Assert(InvokeState("DescriptorChanged", State("Failed")) == "Stopped",
-            "A changed plugin descriptor must reopen an explicit recovery path from Failed.");
-        Assert(InvokeState("DescriptorChanged", State("Running")) == "Running",
-            "A descriptor recovery signal must not disturb a healthy running runtime.");
+        Assert(
+            transitions.GetMethod(
+                "DescriptorChanged",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic) == null,
+            "Runtime transitions must not retain a descriptor-change hot-reload recovery path.");
 
         var runtimeMatches = transitions.GetMethod(
             "RuntimeMatches",
@@ -284,11 +285,27 @@ internal static class Program
         var supported = registryType.GetField(
             "SupportedPluginApiVersion",
             BindingFlags.Static | BindingFlags.NonPublic)?.GetRawConstantValue()?.ToString();
-        var minimum = registryType.GetField(
-            "MinimumPluginApiVersion",
-            BindingFlags.Static | BindingFlags.NonPublic)?.GetRawConstantValue()?.ToString();
-        Assert(supported == "2.1" && minimum == "2.0",
-            "The plugin host must advertise Protocol 2.1 while retaining Protocol 2.0 compatibility.");
+        Assert(supported == "2.1",
+            "The plugin host must expose Protocol 2.1 as its single supported baseline.");
+        Assert(
+            registryType.GetField(
+                "MinimumPluginApiVersion",
+                BindingFlags.Static | BindingFlags.NonPublic) == null,
+            "The host must not retain a minimum-version compatibility range after Protocol 2.0 removal.");
+
+        var validateApi = registryType.GetMethod(
+            "ValidateManifestApiVersion",
+            BindingFlags.Static | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("ValidateManifestApiVersion was not found.");
+        validateApi.Invoke(null, new object[] { "2.1" });
+        try
+        {
+            validateApi.Invoke(null, new object[] { "2.0" });
+            throw new InvalidOperationException("Protocol 2.0 manifest compatibility is still active.");
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is InvalidDataException)
+        {
+        }
     }
 
     private static void CheckProtocolBoundaries(Assembly host)
@@ -485,10 +502,10 @@ internal static class Program
         var todoSnapshot = RequireType(abstractions, "PaperTodo.Plugin.TodoSnapshot");
         Assert(
             todoSnapshot.GetConstructors().Any(ctor => ctor.GetParameters().Length == 9),
-            "Protocol 2.1 must preserve the Protocol 2.0 nine-parameter TodoSnapshot constructor.");
+            "Protocol 2.1 must preserve the existing nine-parameter TodoSnapshot constructor.");
         Assert(
             todoSnapshot.GetProperty("LinkedPathIsDirectory")?.PropertyType == typeof(bool?),
-            "Protocol 2.1 must add LinkedPathIsDirectory without changing TodoSnapshot's positional ABI.");
+            "Protocol 2.1 must expose LinkedPathIsDirectory without changing TodoSnapshot's positional constructor.");
 
         var context = RequireType(abstractions, "PaperTodo.Plugin.PaperPluginRuntimeContext");
         var todoActions = RequireType(abstractions, "PaperTodo.Plugin.IPaperPluginRuntimeTodoActions");

--- a/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
+++ b/tests/PaperTodo.ProtocolPolicyChecks/Program.cs
@@ -311,9 +311,17 @@ internal static class Program
     private static void CheckProtocolBoundaries(Assembly host)
     {
         var hostApi = RequireType(host, "PaperTodo.PaperBodyPluginHostApi");
+        var controller = RequireType(host, "PaperTodo.AppController");
+        var registry = RequireType(host, "PaperTodo.PaperBodyPluginRegistry");
         Assert(
-            hostApi.GetMethod("EnsurePresentationProtocol", BindingFlags.Instance | BindingFlags.NonPublic) != null,
-            "Own-paper presentation lacks an explicit protocol-version gate.");
+            hostApi.GetMethod("EnsurePresentationProtocol", BindingFlags.Instance | BindingFlags.NonPublic) == null,
+            "Single-baseline Protocol 2.1 must not retain the old presentation version gate.");
+        Assert(
+            controller.GetMethod("EnsurePluginTopBarProtocol", BindingFlags.Instance | BindingFlags.NonPublic) == null,
+            "Single-baseline Protocol 2.1 must not retain the old top-bar version gate.");
+        Assert(
+            registry.GetMethod("ApiAtLeast", BindingFlags.Static | BindingFlags.NonPublic) == null,
+            "Single-baseline Protocol 2.1 must not retain registry compatibility comparisons.");
     }
 
     private static void CheckSharedWebInfrastructure(Assembly host)


### PR DESCRIPTION
## 改动

- 删除已经失去意义的“插件描述变化后从 Failed 恢复 Runtime”热重载残留逻辑。
- 保持插件状态 10 MiB / Runtime 状态 20 MiB 上限不变，只合并保存时的重复 JSON 解析。
- 修复极窄桌面 / 高缩放下高级插件设置窗口横向裁切。
- `LinkedPathIsDirectory` 变化现在会触发 Todo `LinkedPath` 变更通知。
- 清理实验性 Protocol 2.0 兼容范围：宿主只接受 `apiVersion: "2.1"`，同步更新内置示例、打包 manifest、开发文档与 CI 校验；同时移除 Todo action / top-bar label 内部已经失去意义的 `>= 2.1` 二次判断。
- Runtime 首次 `papers.List()` 现在同时重置后续 `PaperAdded/PaperRemoved` 的基线，避免启动期间 Paper 变化造成初始化列表与增量事件错位。
- Runtime 恢复期间仍保留上一代 header/capsule；新 Runtime 完成首次 Paper 快照后，仅清理没有被新一代重新发布的旧 presentation，避免恢复成功后陈旧显示长期残留。
- `TodoMutationResult` 增加 `Deleted`：插件将 Todo 标记完成并触发自动清除时，返回值会明确说明目标已经被删除。
- Todo / Paper 删除后会及时清理对应的 Runtime Todo action 与 top-bar label 注册；隐藏 Paper 的外部 Todo mutation 也会经过同一 prune 链路。
- top-bar label 初次创建时主动测量宽度，并作为最低优先级元数据参与响应式布局：先保留 PaperTodo 宿主控件和交互按钮，空间不足时隐藏标签。
- 历史 `DECISIONS.md` 保留 2.0 演进记录，不改写历史。

## 验证

- 协议策略检查继续确认 2.0 manifest 被拒绝、2.1 被接受、旧热重载状态转换已不存在。
- CI 统一校验所有示例和打包插件 manifest 均为 2.1。
- 状态容量策略检查仍固定验证 10 MiB / 20 MiB，防止本次优化误改限制。
- 最终 squash SHA `f1b238e6` 已通过 host build、protocol policy checks、manifest/capsule/2.1 top-bar 校验、Web 脚本/运行时副本检查以及 Native runtime 重建校验。