### PR TITLE
fix: finish plugin protocol 2.1 polish

### DIFF
--- a/src/PaperPluginRuntimePapersApi.cs
+++ b/src/PaperPluginRuntimePapersApi.cs
@@ -150,6 +150,19 @@ internal sealed class PaperPluginRuntimePapersApi : IPaperPluginRuntimePapers, I
         }
     }
 
+    internal void ResetWebDocumentPresentation()
+    {
+        EnsureUsable();
+        lock (_gate)
+        {
+            EnsureUsableLocked();
+            _publishedHeaderPaperIds.Clear();
+            _publishedCapsulePaperIds.Clear();
+            _capsulePresentations.Clear();
+        }
+        OnUi(() => _controller.ClearPluginRuntimePresentation(_providerId));
+    }
+
     public bool PostToBody(string paperId, JsonElement message)
     {
         EnsureUsable();

--- a/src/PaperWindow.PluginTopBar.cs
+++ b/src/PaperWindow.PluginTopBar.cs
@@ -113,6 +113,13 @@ public sealed partial class PaperWindow
         _reconcilingPluginTopBarCapacity = true;
         try
         {
+            // Labels are passive metadata. Always remove them from the capacity calculation first
+            // so host controls and interactive plugin actions get the available width before labels.
+            if (_pluginTopBarLabelsHost != null)
+            {
+                _pluginTopBarLabelsHost.Visibility = Visibility.Collapsed;
+            }
+
             UpdatePluginTopBarHostWidth();
             UpdateTopBarResponsiveLayout();
 
@@ -198,6 +205,7 @@ public sealed partial class PaperWindow
         finally
         {
             _reconcilingPluginTopBarCapacity = false;
+            ReconcilePluginTopBarLabelCapacity();
         }
     }
 

--- a/src/PaperWindow.PluginTopBarLabels.cs
+++ b/src/PaperWindow.PluginTopBarLabels.cs
@@ -1,6 +1,8 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Windows.Shapes;
+using PaperTodo.Plugin;
 
 namespace PaperTodo;
 
@@ -8,7 +10,6 @@ public sealed partial class PaperWindow
 {
     private static bool _pluginTopBarLabelsLoadedHandlerRegistered;
     private StackPanel? _pluginTopBarLabelsHost;
-    private bool _pluginTopBarLabelCapacityHookInstalled;
 
     internal static void EnsurePluginTopBarLabelsLoadedHandler()
     {
@@ -29,6 +30,15 @@ public sealed partial class PaperWindow
             }));
     }
 
+    protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+    {
+        base.OnPropertyChanged(e);
+        if (e.Property == FontFamilyProperty || e.Property == FontSizeProperty)
+        {
+            RefreshPluginTopBarLabels();
+        }
+    }
+
     internal void RefreshPluginTopBarLabels()
     {
         if (IsClosed || !_isShellBuilt || _topBarActionButtonsHost == null)
@@ -36,6 +46,7 @@ public sealed partial class PaperWindow
             return;
         }
 
+        EnsurePluginTopBarButtonsHost();
         _pluginTopBarLabelsHost ??= new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -47,7 +58,6 @@ public sealed partial class PaperWindow
         }
 
         _pluginTopBarLabelsHost.Children.Clear();
-        var measuredWidth = 0.0;
         foreach (var binding in _controller.GetPluginTopBarLabels(_paper.Id))
         {
             var label = binding.Label;
@@ -59,15 +69,17 @@ public sealed partial class PaperWindow
             };
             if (label.Icon != null)
             {
-                content.Children.Add(CreatePluginTodoActionIcon(
+                var icon = CreatePluginTodoActionIcon(
                     label.Icon,
                     WeakTextBrush,
-                    AppTypography.Scale(10.5)));
+                    AppTypography.Scale(10.5));
+                ApplyPluginTopBarLabelTheme(icon, label.Icon);
+                content.Children.Add(icon);
             }
-            content.Children.Add(new TextBlock
+
+            var text = new TextBlock
             {
                 Text = label.Text,
-                Foreground = WeakTextBrush,
                 FontFamily = AppTypography.UiFontFamily,
                 FontSize = AppTypography.Scale(10.5),
                 FontWeight = FontWeights.Normal,
@@ -79,9 +91,11 @@ public sealed partial class PaperWindow
                 TextTrimming = TextTrimming.CharacterEllipsis,
                 MaxWidth = AppTypography.Scale(120),
                 IsHitTestVisible = false
-            });
+            };
+            text.SetResourceReference(TextBlock.ForegroundProperty, "WeakTextBrushKey");
+            content.Children.Add(text);
 
-            var element = new Border
+            _pluginTopBarLabelsHost.Children.Add(new Border
             {
                 Padding = new Thickness(4, 1, 4, 1),
                 Margin = new Thickness(1, 0, 1, 0),
@@ -89,30 +103,53 @@ public sealed partial class PaperWindow
                 VerticalAlignment = VerticalAlignment.Center,
                 ToolTip = string.IsNullOrWhiteSpace(label.ToolTip) ? null : label.ToolTip,
                 Child = content
-            };
-            element.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
-            measuredWidth += element.DesiredSize.Width;
-            _pluginTopBarLabelsHost.Children.Add(element);
+            });
         }
 
-        _pluginTopBarLabelsHost.Width = Math.Ceiling(measuredWidth);
         _pluginTopBarLabelsHost.Visibility = Visibility.Collapsed;
+        MeasurePluginTopBarLabelsWidth();
 
-        // Interactive controls settle first; labels only occupy width that remains afterwards.
-        RefreshPluginTopBarActions();
-        EnsurePluginTopBarLabelCapacityHook();
-        ReconcilePluginTopBarLabelCapacity();
+        // One layout authority: interactive controls settle first, then labels use the remainder.
+        ReconcilePluginTopBarCapacity();
     }
 
-    private void EnsurePluginTopBarLabelCapacityHook()
+    private static void ApplyPluginTopBarLabelTheme(
+        UIElement element,
+        PaperTopBarIcon icon)
     {
-        if (_pluginTopBarLabelCapacityHookInstalled || _topBar == null)
+        if (element is TextBlock text)
+        {
+            text.SetResourceReference(TextBlock.ForegroundProperty, "WeakTextBrushKey");
+            return;
+        }
+
+        if (element is not Path path)
         {
             return;
         }
 
-        _pluginTopBarLabelCapacityHookInstalled = true;
-        _topBar.SizeChanged += (_, _) => ReconcilePluginTopBarLabelCapacity();
+        if (icon.RenderMode == PaperTopBarSvgRenderMode.Stroke)
+        {
+            path.SetResourceReference(Shape.StrokeProperty, "WeakTextBrushKey");
+        }
+        else
+        {
+            path.SetResourceReference(Shape.FillProperty, "WeakTextBrushKey");
+        }
+    }
+
+    private void MeasurePluginTopBarLabelsWidth()
+    {
+        if (_pluginTopBarLabelsHost == null)
+        {
+            return;
+        }
+
+        _pluginTopBarLabelsHost.Width = double.NaN;
+        _pluginTopBarLabelsHost.Measure(
+            new Size(double.PositiveInfinity, double.PositiveInfinity));
+        _pluginTopBarLabelsHost.Width =
+            Math.Ceiling(_pluginTopBarLabelsHost.DesiredSize.Width);
     }
 
     private void ReconcilePluginTopBarLabelCapacity()

--- a/src/WebPluginRuntime.cs
+++ b/src/WebPluginRuntime.cs
@@ -345,6 +345,10 @@ internal sealed class WebPluginRuntime : IDisposable
         }
 
         _reloadRecoveryPending = false;
+        if (_papers is PaperPluginRuntimePapersApi runtimePapers)
+        {
+            runtimePapers.ResetWebDocumentPresentation();
+        }
         _documentReady = true;
         RegisterGlobalShortcutHandler();
         var runtimeState = ReadRuntimeState();


### PR DESCRIPTION
## 改动

- Web Runtime 页面 reload / renderer 恢复时继续保留旧 Header/Capsule 到新页面加载成功；成功后旧 presentation 立即作废，由新页面重新发布需要的状态。
- Top Bar 统一布局顺序：先隐藏插件 labels，优先计算宿主控件和可交互插件 actions，最后仅在剩余空间足够时显示 labels。
- label 更新不再调用 `RefreshPluginTopBarActions()`，避免动态标签反复销毁/重建插件按钮。
- label 文本/图标使用动态主题资源；窗口字体或整体缩放变化时只刷新 labels 自身。

## 目标

保持 Protocol 2.1 当前结构不扩张，只收掉 reload 陈旧 presentation、label/action 抢位、label 更新重建按钮以及 label 样式滞后这四个小问题。