### PR TITLE
perf: optimize inline image resizing

### DIFF
--- a/.tmp-build-trigger-perf
+++ b/.tmp-build-trigger-perf
@@ -1,0 +1,1 @@
+temporary build trigger

--- a/.tmp-build-trigger-perf
+++ b/.tmp-build-trigger-perf
@@ -1,1 +1,0 @@
-temporary build trigger

--- a/src/MarkdownTextBox.DpiEventFilter.cs
+++ b/src/MarkdownTextBox.DpiEventFilter.cs
@@ -11,6 +11,7 @@ public sealed partial class MarkdownTextBox
         AddHandler(
             Window.DpiChangedEvent,
             new DpiChangedEventHandler(OnDescendantDpiChanged));
+        Loaded += (_, _) => InitializeImageBlockReuse();
     }
 
     private void OnDescendantDpiChanged(object sender, DpiChangedEventArgs e)

--- a/src/MarkdownTextBox.ImageBlockReuse.cs
+++ b/src/MarkdownTextBox.ImageBlockReuse.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Rendering;
+
+namespace PaperTodo;
+
+public sealed partial class MarkdownTextBox
+{
+    private readonly List<CachedImageBlock> _cachedImageBlocks = new();
+    private ReusingMarkdownImageElementGenerator? _reusingImageElementGenerator;
+    private bool _imageBlockReuseInitialized;
+
+    private void InitializeImageBlockReuse()
+    {
+        if (_imageBlockReuseInitialized)
+        {
+            return;
+        }
+
+        var generators = TextArea.TextView.ElementGenerators;
+        var generatorIndex = generators.IndexOf(_imageElementGenerator);
+        if (generatorIndex < 0)
+        {
+            return;
+        }
+
+        _reusingImageElementGenerator = new ReusingMarkdownImageElementGenerator(this);
+        generators.RemoveAt(generatorIndex);
+        generators.Insert(generatorIndex, _reusingImageElementGenerator);
+        Document.Changed += OnImageBlockReuseDocumentChanged;
+        Unloaded += (_, _) => ClearImageBlockCache();
+        _imageBlockReuseInitialized = true;
+    }
+
+    private void OnImageBlockReuseDocumentChanged(object? sender, DocumentChangeEventArgs e)
+    {
+        // Text edits are much rarer than resize-driven VisualLine rebuilds. Clearing here keeps
+        // anchor/context-menu lifetime simple while preserving the hot resize reuse path.
+        ClearImageBlockCache();
+    }
+
+    private void ClearImageBlockCache()
+    {
+        _cachedImageBlocks.Clear();
+    }
+
+    private FrameworkElement GetOrCreateReusableImageBlock(
+        MarkdownImageReference reference,
+        NoteImageAsset? asset,
+        DocumentLine referenceLine)
+    {
+        PruneImageBlockCache();
+
+        for (var index = 0; index < _cachedImageBlocks.Count; index++)
+        {
+            var cached = _cachedImageBlocks[index];
+            if (!string.Equals(cached.NoteId, _noteId, StringComparison.Ordinal) ||
+                !string.Equals(cached.ImageId, reference.ImageId, StringComparison.Ordinal) ||
+                cached.ReferenceAnchor.IsDeleted ||
+                cached.ReferenceAnchor.Offset != referenceLine.Offset)
+            {
+                continue;
+            }
+
+            UpdateReusableImageBlock(cached.Host, reference, asset);
+            return cached.Host;
+        }
+
+        var created = CreateImageBlock(reference, asset, referenceLine);
+        if (created is Border host && host.Tag is ImageBlockTag tag)
+        {
+            _cachedImageBlocks.Add(new CachedImageBlock(
+                _noteId,
+                reference.ImageId,
+                tag.ReferenceAnchor,
+                host,
+                Theme.IsDark));
+            ApplyCurrentScalingMode(host.Child);
+        }
+
+        return created;
+    }
+
+    private void PruneImageBlockCache()
+    {
+        for (var index = _cachedImageBlocks.Count - 1; index >= 0; index--)
+        {
+            var cached = _cachedImageBlocks[index];
+            if (cached.ReferenceAnchor.IsDeleted ||
+                !string.Equals(cached.NoteId, _noteId, StringComparison.Ordinal) ||
+                cached.IsDark != Theme.IsDark)
+            {
+                _cachedImageBlocks.RemoveAt(index);
+            }
+        }
+    }
+
+    private void UpdateReusableImageBlock(
+        Border host,
+        MarkdownImageReference reference,
+        NoteImageAsset? asset)
+    {
+        var targetWidth = ImageTargetWidth();
+        var displayWidth = ResolveImageDisplayWidth(reference.DisplayOptions, asset, targetWidth);
+        var decodePixelWidth = ImageDecodePixelWidth(Math.Min(targetWidth, displayWidth));
+        var bitmap = asset == null
+            ? null
+            : _imageStore?.GetBitmapSource(
+                asset.Id,
+                decodePixelWidth,
+                allowDecodeUpgrade: !_isImageResizePreview,
+                protectInViewport: true);
+        var isCorrupted = _imageStore?.IsImageCorrupted(reference.ImageId) == true;
+        var isSelected = host.Tag is ImageBlockTag oldTag &&
+            !oldTag.ReferenceAnchor.IsDeleted &&
+            Document != null &&
+            IsImageReferenceSelected(Document.GetLineByOffset(
+                Math.Clamp(oldTag.ReferenceAnchor.Offset, 0, Document.TextLength)));
+
+        host.Width = targetWidth;
+        host.ToolTip = asset?.OriginalName;
+        host.BorderBrush = isSelected ? Theme.CapsuleFocusBorderBrush : Brushes.Transparent;
+
+        if (host.Tag is ImageBlockTag tag)
+        {
+            host.Tag = new ImageBlockTag(
+                tag.ReferenceAnchor,
+                tag.CaretAnchor,
+                reference.ImageId,
+                reference.DisplayOptions,
+                Math.Max(1, asset?.Width ?? 180));
+        }
+
+        if (host.ContextMenu?.Items.Count > 0 && host.ContextMenu.Items[0] is MenuItem copyItem)
+        {
+            copyItem.IsEnabled = bitmap != null;
+        }
+
+        if (bitmap == null)
+        {
+            UpdateOrCreateImagePlaceholder(host, targetWidth, displayWidth, isCorrupted);
+            return;
+        }
+
+        if (host.Child is not Image image)
+        {
+            image = new Image
+            {
+                Stretch = Stretch.Uniform,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                SnapsToDevicePixels = true,
+                UseLayoutRounding = true
+            };
+            host.Child = image;
+        }
+
+        if (!ReferenceEquals(image.Source, bitmap))
+        {
+            image.Source = bitmap;
+        }
+        image.Width = displayWidth;
+        ApplyCurrentScalingMode(image);
+    }
+
+    private void UpdateOrCreateImagePlaceholder(
+        Border host,
+        double targetWidth,
+        double displayWidth,
+        bool isCorrupted)
+    {
+        if (host.Child is not Border placeholder || placeholder.Child is not TextBlock label)
+        {
+            label = new TextBlock
+            {
+                VerticalAlignment = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center
+            };
+            placeholder = new Border
+            {
+                Height = 42,
+                CornerRadius = new CornerRadius(5),
+                BorderThickness = new Thickness(1),
+                Child = label
+            };
+            host.Child = placeholder;
+        }
+
+        placeholder.Width = Math.Max(120, Math.Min(targetWidth, displayWidth));
+        placeholder.Background = isCorrupted
+            ? Theme.Danger((byte)(Theme.IsDark ? 30 : 18))
+            : Theme.Tint((byte)(Theme.IsDark ? 30 : 18));
+        placeholder.BorderBrush = isCorrupted ? Theme.Danger(70) : Theme.PaperBorderBrush;
+        label.Text = Strings.Get(isCorrupted ? "ImageCorrupted" : "ImageMissing");
+        label.Foreground = isCorrupted ? Theme.DangerBrush : Theme.WeakTextBrush;
+        label.FontSize = ScaledFontSize(NoteTypography.FontSize);
+    }
+
+    private void ApplyCurrentScalingMode(DependencyObject? element)
+    {
+        if (element is Image image)
+        {
+            System.Windows.Media.RenderOptions.SetBitmapScalingMode(
+                image,
+                _isImageResizePreview
+                    ? BitmapScalingMode.LowQuality
+                    : BitmapScalingMode.HighQuality);
+        }
+    }
+
+    private sealed class ReusingMarkdownImageElementGenerator : VisualLineElementGenerator
+    {
+        private readonly MarkdownTextBox _owner;
+
+        public ReusingMarkdownImageElementGenerator(MarkdownTextBox owner)
+        {
+            _owner = owner;
+        }
+
+        public override int GetFirstInterestedOffset(int startOffset)
+        {
+            if (!_owner.ShouldRenderImages)
+            {
+                return -1;
+            }
+
+            var document = CurrentContext.Document;
+            if (document == null || document.TextLength <= 0)
+            {
+                return -1;
+            }
+
+            var referenceLine = CurrentContext.VisualLine.FirstDocumentLine;
+            return referenceLine.EndOffset >= startOffset &&
+                _owner.TryGetImageReferenceForLine(referenceLine, out _, out _)
+                ? referenceLine.EndOffset
+                : -1;
+        }
+
+        public override VisualLineElement ConstructElement(int offset)
+        {
+            if (!_owner.ShouldRenderImages)
+            {
+                return null!;
+            }
+
+            var document = CurrentContext.Document;
+            if (document == null || offset < 0 || offset > document.TextLength)
+            {
+                return null!;
+            }
+
+            var referenceLine = CurrentContext.VisualLine.FirstDocumentLine;
+            if (referenceLine.EndOffset != offset ||
+                !_owner.TryGetImageReferenceForLine(referenceLine, out var reference, out var asset))
+            {
+                return null!;
+            }
+
+            var element = _owner.GetOrCreateReusableImageBlock(reference, asset, referenceLine);
+            return new BlockImageElement(element);
+        }
+    }
+
+    private sealed class CachedImageBlock
+    {
+        public CachedImageBlock(
+            string noteId,
+            string imageId,
+            TextAnchor referenceAnchor,
+            Border host,
+            bool isDark)
+        {
+            NoteId = noteId;
+            ImageId = imageId;
+            ReferenceAnchor = referenceAnchor;
+            Host = host;
+            IsDark = isDark;
+        }
+
+        public string NoteId { get; }
+        public string ImageId { get; }
+        public TextAnchor ReferenceAnchor { get; }
+        public Border Host { get; }
+        public bool IsDark { get; }
+    }
+}

--- a/src/MarkdownTextBox.ImageBlockReuse.cs
+++ b/src/MarkdownTextBox.ImageBlockReuse.cs
@@ -66,20 +66,28 @@ public sealed partial class MarkdownTextBox
                 continue;
             }
 
-            UpdateReusableImageBlock(cached.Host, reference, asset);
-            return cached.Host;
+            if (TryUpdateReusableImageBlock(cached, reference, asset, referenceLine))
+            {
+                return cached.Host;
+            }
+
+            _cachedImageBlocks.RemoveAt(index);
+            break;
         }
 
         var created = CreateImageBlock(reference, asset, referenceLine);
-        if (created is Border host && host.Tag is ImageBlockTag tag)
+        if (created is Border host &&
+            host.Child is Image image &&
+            host.Tag is ImageBlockTag tag)
         {
             _cachedImageBlocks.Add(new CachedImageBlock(
                 _noteId,
                 reference.ImageId,
                 tag.ReferenceAnchor,
                 host,
+                image,
                 Theme.IsDark));
-            ApplyCurrentScalingMode(host.Child);
+            ApplyCurrentScalingMode(image);
         }
 
         return created;
@@ -99,116 +107,62 @@ public sealed partial class MarkdownTextBox
         }
     }
 
-    private void UpdateReusableImageBlock(
-        Border host,
+    private bool TryUpdateReusableImageBlock(
+        CachedImageBlock cached,
         MarkdownImageReference reference,
-        NoteImageAsset? asset)
+        NoteImageAsset? asset,
+        DocumentLine referenceLine)
     {
+        if (asset == null || !ReferenceEquals(cached.Host.Child, cached.Image))
+        {
+            return false;
+        }
+
         var targetWidth = ImageTargetWidth();
         var displayWidth = ResolveImageDisplayWidth(reference.DisplayOptions, asset, targetWidth);
         var decodePixelWidth = ImageDecodePixelWidth(Math.Min(targetWidth, displayWidth));
-        var bitmap = asset == null
-            ? null
-            : _imageStore?.GetBitmapSource(
-                asset.Id,
-                decodePixelWidth,
-                allowDecodeUpgrade: !_isImageResizePreview,
-                protectInViewport: true);
-        var isCorrupted = _imageStore?.IsImageCorrupted(reference.ImageId) == true;
-        var isSelected = host.Tag is ImageBlockTag oldTag &&
-            !oldTag.ReferenceAnchor.IsDeleted &&
-            Document != null &&
-            IsImageReferenceSelected(Document.GetLineByOffset(
-                Math.Clamp(oldTag.ReferenceAnchor.Offset, 0, Document.TextLength)));
-
-        host.Width = targetWidth;
-        host.ToolTip = asset?.OriginalName;
-        host.BorderBrush = isSelected ? Theme.CapsuleFocusBorderBrush : Brushes.Transparent;
-
-        if (host.Tag is ImageBlockTag tag)
+        var bitmap = _imageStore?.GetBitmapSource(
+            asset.Id,
+            decodePixelWidth,
+            allowDecodeUpgrade: !_isImageResizePreview,
+            protectInViewport: true);
+        if (bitmap == null)
         {
-            host.Tag = new ImageBlockTag(
+            return false;
+        }
+
+        cached.Host.Width = targetWidth;
+        cached.Host.ToolTip = asset.OriginalName;
+        cached.Host.BorderBrush = IsImageReferenceSelected(referenceLine)
+            ? Theme.CapsuleFocusBorderBrush
+            : Brushes.Transparent;
+
+        if (cached.Host.Tag is ImageBlockTag tag)
+        {
+            cached.Host.Tag = new ImageBlockTag(
                 tag.ReferenceAnchor,
                 tag.CaretAnchor,
                 reference.ImageId,
                 reference.DisplayOptions,
-                Math.Max(1, asset?.Width ?? 180));
+                Math.Max(1, asset.Width));
         }
 
-        if (host.ContextMenu?.Items.Count > 0 && host.ContextMenu.Items[0] is MenuItem copyItem)
+        if (!ReferenceEquals(cached.Image.Source, bitmap))
         {
-            copyItem.IsEnabled = bitmap != null;
+            cached.Image.Source = bitmap;
         }
-
-        if (bitmap == null)
-        {
-            UpdateOrCreateImagePlaceholder(host, targetWidth, displayWidth, isCorrupted);
-            return;
-        }
-
-        if (host.Child is not Image image)
-        {
-            image = new Image
-            {
-                Stretch = Stretch.Uniform,
-                HorizontalAlignment = HorizontalAlignment.Left,
-                SnapsToDevicePixels = true,
-                UseLayoutRounding = true
-            };
-            host.Child = image;
-        }
-
-        if (!ReferenceEquals(image.Source, bitmap))
-        {
-            image.Source = bitmap;
-        }
-        image.Width = displayWidth;
-        ApplyCurrentScalingMode(image);
+        cached.Image.Width = displayWidth;
+        ApplyCurrentScalingMode(cached.Image);
+        return true;
     }
 
-    private void UpdateOrCreateImagePlaceholder(
-        Border host,
-        double targetWidth,
-        double displayWidth,
-        bool isCorrupted)
+    private void ApplyCurrentScalingMode(Image image)
     {
-        if (host.Child is not Border placeholder || placeholder.Child is not TextBlock label)
-        {
-            label = new TextBlock
-            {
-                VerticalAlignment = VerticalAlignment.Center,
-                HorizontalAlignment = HorizontalAlignment.Center
-            };
-            placeholder = new Border
-            {
-                Height = 42,
-                CornerRadius = new CornerRadius(5),
-                BorderThickness = new Thickness(1),
-                Child = label
-            };
-            host.Child = placeholder;
-        }
-
-        placeholder.Width = Math.Max(120, Math.Min(targetWidth, displayWidth));
-        placeholder.Background = isCorrupted
-            ? Theme.Danger((byte)(Theme.IsDark ? 30 : 18))
-            : Theme.Tint((byte)(Theme.IsDark ? 30 : 18));
-        placeholder.BorderBrush = isCorrupted ? Theme.Danger(70) : Theme.PaperBorderBrush;
-        label.Text = Strings.Get(isCorrupted ? "ImageCorrupted" : "ImageMissing");
-        label.Foreground = isCorrupted ? Theme.DangerBrush : Theme.WeakTextBrush;
-        label.FontSize = ScaledFontSize(NoteTypography.FontSize);
-    }
-
-    private void ApplyCurrentScalingMode(DependencyObject? element)
-    {
-        if (element is Image image)
-        {
-            System.Windows.Media.RenderOptions.SetBitmapScalingMode(
-                image,
-                _isImageResizePreview
-                    ? BitmapScalingMode.LowQuality
-                    : BitmapScalingMode.HighQuality);
-        }
+        System.Windows.Media.RenderOptions.SetBitmapScalingMode(
+            image,
+            _isImageResizePreview
+                ? BitmapScalingMode.LowQuality
+                : BitmapScalingMode.HighQuality);
     }
 
     private sealed class ReusingMarkdownImageElementGenerator : VisualLineElementGenerator
@@ -272,12 +226,14 @@ public sealed partial class MarkdownTextBox
             string imageId,
             TextAnchor referenceAnchor,
             Border host,
+            Image image,
             bool isDark)
         {
             NoteId = noteId;
             ImageId = imageId;
             ReferenceAnchor = referenceAnchor;
             Host = host;
+            Image = image;
             IsDark = isDark;
         }
 
@@ -285,6 +241,7 @@ public sealed partial class MarkdownTextBox
         public string ImageId { get; }
         public TextAnchor ReferenceAnchor { get; }
         public Border Host { get; }
+        public Image Image { get; }
         public bool IsDark { get; }
     }
 }

--- a/src/MarkdownTextBox.ImageResize.cs
+++ b/src/MarkdownTextBox.ImageResize.cs
@@ -28,7 +28,6 @@ public sealed partial class MarkdownTextBox
             _imageResizeSettleTimer?.Stop();
             _isImageResizePreview = false;
             _lastImageViewportWidth = -1;
-            ClearImageResizeLayoutQuantization();
             SetBitmapScalingMode(BitmapScalingMode.HighQuality);
             ClearViewportProtectedBitmaps();
         }
@@ -67,9 +66,8 @@ public sealed partial class MarkdownTextBox
             SetBitmapScalingMode(BitmapScalingMode.LowQuality);
         }
 
-        // The reuse generator updates stable image blocks whenever a quantized VisualLine rebuild
-        // is actually needed. Keep the old per-SizeChanged preview walk only as a fallback when
-        // the reuse generator was not installed.
+        // The reuse generator updates stable image blocks whenever AvalonEdit rebuilds VisualLines.
+        // Keep the old per-SizeChanged preview walk only as a fallback when reuse was not installed.
         if (!_imageBlockReuseInitialized)
         {
             QueueImageViewportPreviewLayout();
@@ -94,7 +92,6 @@ public sealed partial class MarkdownTextBox
         }
 
         _isImageResizePreview = false;
-        ClearImageResizeLayoutQuantization();
         SetBitmapScalingMode(BitmapScalingMode.HighQuality);
 
         // One final redraw re-resolves display width and may up/down-grade the single cached decode.

--- a/src/MarkdownTextBox.ImageResize.cs
+++ b/src/MarkdownTextBox.ImageResize.cs
@@ -13,6 +13,7 @@ public sealed partial class MarkdownTextBox
     private bool _isImageViewportPreviewQueued;
     private bool _isViewportProtectedRefreshQueued;
     private double _lastImageViewportWidth = -1;
+    private BitmapScalingMode? _lastAppliedBitmapScalingMode;
 
     public void SetImageRenderingSuspended(bool suspended)
     {
@@ -27,6 +28,7 @@ public sealed partial class MarkdownTextBox
             _imageResizeSettleTimer?.Stop();
             _isImageResizePreview = false;
             _lastImageViewportWidth = -1;
+            ClearImageResizeLayoutQuantization();
             SetBitmapScalingMode(BitmapScalingMode.HighQuality);
             ClearViewportProtectedBitmaps();
         }
@@ -58,11 +60,20 @@ public sealed partial class MarkdownTextBox
         }
 
         _lastImageViewportWidth = currentWidth;
+        var enteringResizePreview = !_isImageResizePreview;
         _isImageResizePreview = true;
-        SetBitmapScalingMode(BitmapScalingMode.LowQuality);
+        if (enteringResizePreview)
+        {
+            SetBitmapScalingMode(BitmapScalingMode.LowQuality);
+        }
 
-        // During drag: keep the current decode and only retarget visible image block widths.
-        QueueImageViewportPreviewLayout();
+        // The reuse generator updates stable image blocks whenever a quantized VisualLine rebuild
+        // is actually needed. Keep the old per-SizeChanged preview walk only as a fallback when
+        // the reuse generator was not installed.
+        if (!_imageBlockReuseInitialized)
+        {
+            QueueImageViewportPreviewLayout();
+        }
 
         _imageResizeSettleTimer ??= new DispatcherTimer(
             TimeSpan.FromMilliseconds(200),
@@ -83,6 +94,7 @@ public sealed partial class MarkdownTextBox
         }
 
         _isImageResizePreview = false;
+        ClearImageResizeLayoutQuantization();
         SetBitmapScalingMode(BitmapScalingMode.HighQuality);
 
         // One final redraw re-resolves display width and may up/down-grade the single cached decode.
@@ -308,6 +320,14 @@ public sealed partial class MarkdownTextBox
 
     private void SetBitmapScalingMode(BitmapScalingMode mode)
     {
+        // Stable reused images receive the current mode when the generator updates them, so there
+        // is no reason to walk the same visual tree on every SizeChanged while a drag is active.
+        if (_imageBlockReuseInitialized && _lastAppliedBitmapScalingMode == mode)
+        {
+            return;
+        }
+
+        _lastAppliedBitmapScalingMode = mode;
         ApplyBitmapScalingMode(TextArea.TextView, mode);
     }
 


### PR DESCRIPTION
合入已验证的 Markdown 图片缩放性能优化：

- 复用同一图片引用对应的 Border + Image，避免 AvalonEdit VisualLine 重建时反复创建图片控件
- 拖动缩放时 LowQuality 只在进入 resize preview 时切换一次
- 已启用图片复用时，不再每个 SizeChanged 递归遍历图片树更新宽度；由复用 generator 在 VisualLine 重建时更新
- 保留停止拖动后的 HighQuality 与最终解码确认
- 不包含已撤回的 2 DIP 布局宽度量化

已用无诊断版手动验证窗口边缘拖动手感正常。