### PR TITLE
chore: verify 3.x image reuse cache fix

### DIFF
--- a/.verify-image-reuse-cache-3x
+++ b/.verify-image-reuse-cache-3x
@@ -1,0 +1,1 @@
+temporary build verification


### PR DESCRIPTION
Temporary PR used only to run the 3.x maintenance build against the current image reuse cache lifetime fix. Do not merge.