### PR TITLE
chore: verify 3.x image reuse prune

### DIFF
--- a/.tmp-verify-image-reuse-prune
+++ b/.tmp-verify-image-reuse-prune
@@ -1,0 +1,1 @@
+temporary verification trigger


### PR DESCRIPTION
Temporary verification PR only. Runs the 3.x maintenance build for the resize prune scheduling change; do not merge.