### PR TITLE
feat: add symmetric copy translation for todos and notes

### DIFF
--- a/Resources/CopyTranslationStrings.en.resx
+++ b/Resources/CopyTranslationStrings.en.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms</value></resheader>
+  <data name="MenuCopyAsMarkdown" xml:space="preserve"><value>Copy as Markdown</value></data>
+  <data name="MenuCopyAsPlainText" xml:space="preserve"><value>Copy as plain text</value></data>
+</root>

--- a/Resources/CopyTranslationStrings.ja.resx
+++ b/Resources/CopyTranslationStrings.ja.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms</value></resheader>
+  <data name="MenuCopyAsMarkdown" xml:space="preserve"><value>Markdown としてコピー</value></data>
+  <data name="MenuCopyAsPlainText" xml:space="preserve"><value>プレーンテキストとしてコピー</value></data>
+</root>

--- a/Resources/CopyTranslationStrings.ko.resx
+++ b/Resources/CopyTranslationStrings.ko.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms</value></resheader>
+  <data name="MenuCopyAsMarkdown" xml:space="preserve"><value>Markdown으로 복사</value></data>
+  <data name="MenuCopyAsPlainText" xml:space="preserve"><value>일반 텍스트로 복사</value></data>
+</root>

--- a/Resources/CopyTranslationStrings.resx
+++ b/Resources/CopyTranslationStrings.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms</value></resheader>
+  <data name="MenuCopyAsMarkdown" xml:space="preserve"><value>复制为 Markdown</value></data>
+  <data name="MenuCopyAsPlainText" xml:space="preserve"><value>复制为纯文本</value></data>
+</root>

--- a/src/CopyTranslationStrings.cs
+++ b/src/CopyTranslationStrings.cs
@@ -1,0 +1,13 @@
+using System.Resources;
+
+namespace PaperTodo;
+
+internal static class CopyTranslationStrings
+{
+    private static readonly ResourceManager Manager = new(
+        "PaperTodo.Resources.CopyTranslationStrings",
+        typeof(CopyTranslationStrings).Assembly);
+
+    internal static string Get(string key) =>
+        Manager.GetString(key, UiLanguages.EffectiveUiCulture) ?? key;
+}

--- a/src/MarkdownSemanticSnapshot.PlainText.cs
+++ b/src/MarkdownSemanticSnapshot.PlainText.cs
@@ -1,0 +1,31 @@
+namespace PaperTodo;
+
+internal sealed partial class MarkdownSemanticSnapshot
+{
+    internal static string ToPlainText(string? markdown)
+    {
+        var source = markdown ?? string.Empty;
+        if (source.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        // Use the exact same Markdig pipeline as PaperTodo's semantic renderer. Shift-copy is a
+        // presentation conversion, not a second Markdown parser with subtly different rules.
+        var text = Markdig.Markdown.ToPlainText(source, Pipeline);
+        return RemoveRendererTerminalLineBreak(text);
+    }
+
+    private static string RemoveRendererTerminalLineBreak(string text)
+    {
+        if (text.EndsWith("\r\n", StringComparison.Ordinal))
+        {
+            return text[..^2];
+        }
+        if (text.EndsWith('\n') || text.EndsWith('\r'))
+        {
+            return text[..^1];
+        }
+        return text;
+    }
+}

--- a/src/MarkdownTextBox.CopyTranslation.cs
+++ b/src/MarkdownTextBox.CopyTranslation.cs
@@ -1,0 +1,16 @@
+namespace PaperTodo;
+
+public sealed partial class MarkdownTextBox
+{
+    internal bool TryCopySelectionAsPlainText()
+    {
+        var markdown = TextArea.Selection.GetText();
+        if (string.IsNullOrEmpty(markdown))
+        {
+            return false;
+        }
+
+        return ClipboardHelper.TrySetText(
+            MarkdownSemanticSnapshot.ToPlainText(markdown));
+    }
+}

--- a/src/PaperWindow.CopyTranslation.cs
+++ b/src/PaperWindow.CopyTranslation.cs
@@ -1,0 +1,159 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace PaperTodo;
+
+public sealed partial class PaperWindow
+{
+    private static readonly object CopyTranslationMenuTag = new();
+
+    static PaperWindow()
+    {
+        EventManager.RegisterClassHandler(
+            typeof(PaperWindow),
+            UIElement.PreviewKeyDownEvent,
+            new KeyEventHandler(OnCopyTranslationPreviewKeyDown),
+            handledEventsToo: true);
+        EventManager.RegisterClassHandler(
+            typeof(PaperWindow),
+            ContextMenuService.ContextMenuOpeningEvent,
+            new ContextMenuEventHandler(OnCopyTranslationContextMenuOpening),
+            handledEventsToo: true);
+    }
+
+    private static void OnCopyTranslationPreviewKeyDown(
+        object sender,
+        KeyEventArgs e)
+    {
+        if (e.Handled ||
+            sender is not PaperWindow window ||
+            e.Key != Key.C ||
+            Keyboard.Modifiers != (ModifierKeys.Control | ModifierKeys.Shift))
+        {
+            return;
+        }
+
+        if (window._paper.Type == PaperTypes.Todo &&
+            window.TryCopySelectedTodoItemsAsMarkdown())
+        {
+            e.Handled = true;
+            return;
+        }
+
+        if (window._paper.Type == PaperTypes.Note &&
+            window._noteBox is { IsKeyboardFocusWithin: true } noteBox &&
+            noteBox.TryCopySelectionAsPlainText())
+        {
+            e.Handled = true;
+        }
+    }
+
+    private static void OnCopyTranslationContextMenuOpening(
+        object sender,
+        ContextMenuEventArgs e)
+    {
+        if (sender is not PaperWindow window)
+        {
+            return;
+        }
+
+        var source = e.OriginalSource as DependencyObject;
+        var owner = FindCopyTranslationContextMenuOwner(source, window);
+        var menu = owner?.ContextMenu;
+        if (menu == null || HasCopyTranslationMenuItem(menu))
+        {
+            return;
+        }
+
+        if (window._paper.Type == PaperTypes.Todo)
+        {
+            var row = window.FindTodoRowAncestor(source);
+            if (row?.Tag is string itemId &&
+                window._selectedTodoItemIds.Count > 1 &&
+                window._selectedTodoItemIds.Contains(itemId))
+            {
+                window.InsertCopyTranslationMenuItem(
+                    menu,
+                    Strings.Get("MenuCopySelectedTodos"),
+                    CopyTranslationStrings.Get("MenuCopyAsMarkdown"),
+                    (_, _) => window.TryCopySelectedTodoItemsAsMarkdown());
+            }
+            return;
+        }
+
+        if (window._paper.Type == PaperTypes.Note &&
+            window._noteBox is { IsPreviewMode: false } noteBox &&
+            IsDescendantOf(source, noteBox))
+        {
+            window.InsertCopyTranslationMenuItem(
+                menu,
+                Strings.Get("MenuCopy"),
+                CopyTranslationStrings.Get("MenuCopyAsPlainText"),
+                (_, _) => noteBox.TryCopySelectionAsPlainText());
+        }
+    }
+
+    private static FrameworkElement? FindCopyTranslationContextMenuOwner(
+        DependencyObject? source,
+        PaperWindow window)
+    {
+        var current = source;
+        while (current != null && !ReferenceEquals(current, window))
+        {
+            if (current is FrameworkElement { ContextMenu: not null } element)
+            {
+                return element;
+            }
+            current = GetSafeParent(current);
+        }
+        return null;
+    }
+
+    private static bool HasCopyTranslationMenuItem(ContextMenu menu) =>
+        menu.Items
+            .OfType<MenuItem>()
+            .Any(item => ReferenceEquals(item.Tag, CopyTranslationMenuTag));
+
+    private void InsertCopyTranslationMenuItem(
+        ContextMenu menu,
+        string existingCopyHeader,
+        string translationHeader,
+        RoutedEventHandler click)
+    {
+        for (var index = 0; index < menu.Items.Count; index++)
+        {
+            if (menu.Items[index] is not MenuItem item ||
+                !string.Equals(
+                    item.Header as string,
+                    existingCopyHeader,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var translationItem = MenuItem(translationHeader, click);
+            translationItem.Tag = CopyTranslationMenuTag;
+            menu.Items.Insert(index + 1, translationItem);
+            return;
+        }
+    }
+
+    private bool TryCopySelectedTodoItemsAsMarkdown()
+    {
+        if (_selectedTodoItemIds.Count == 0)
+        {
+            return false;
+        }
+
+        if (FocusManager.GetFocusedElement(this) is TodoTextBox { SelectionLength: > 0 })
+        {
+            return false;
+        }
+
+        var selected = SelectedTodoItems();
+        return selected.Count > 0 && ClipboardHelper.TrySetText(
+            TodoClipboardFormatter.ToMarkdown(
+                selected.Select(item => (item.Text ?? string.Empty, item.Done))));
+    }
+}

--- a/src/TodoClipboardFormatter.cs
+++ b/src/TodoClipboardFormatter.cs
@@ -1,0 +1,90 @@
+using System.Text;
+
+namespace PaperTodo;
+
+internal static class TodoClipboardFormatter
+{
+    private const string AlwaysEscapedMarkdownCharacters = "\\`*_{}[]<>~|&";
+
+    internal static string ToMarkdown(IEnumerable<(string Text, bool Done)> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        var result = new StringBuilder();
+        foreach (var (text, done) in items)
+        {
+            if (result.Length > 0)
+            {
+                result.AppendLine();
+            }
+
+            result.Append(done ? "- [x] " : "- [ ] ");
+            var lines = (text ?? string.Empty)
+                .Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Replace('\r', '\n')
+                .Split('\n');
+            for (var index = 0; index < lines.Length; index++)
+            {
+                if (index > 0)
+                {
+                    result.AppendLine();
+                    result.Append("    ");
+                }
+
+                AppendEscapedLine(result, lines[index]);
+            }
+        }
+
+        return result.ToString();
+    }
+
+    private static void AppendEscapedLine(StringBuilder result, string line)
+    {
+        var firstContent = 0;
+        while (firstContent < line.Length && char.IsWhiteSpace(line[firstContent]))
+        {
+            firstContent++;
+        }
+
+        var orderedDelimiter = OrderedListDelimiterIndex(line, firstContent);
+        for (var index = 0; index < line.Length; index++)
+        {
+            var character = line[index];
+            var escapeBlockMarker =
+                index == firstContent &&
+                character is '#' or '>' or '+' or '-';
+            var escapeOrderedDelimiter = index == orderedDelimiter;
+            if (AlwaysEscapedMarkdownCharacters.Contains(character) ||
+                escapeBlockMarker ||
+                escapeOrderedDelimiter)
+            {
+                result.Append('\\');
+            }
+            result.Append(character);
+        }
+    }
+
+    private static int OrderedListDelimiterIndex(string line, int firstContent)
+    {
+        if (firstContent >= line.Length || !char.IsDigit(line[firstContent]))
+        {
+            return -1;
+        }
+
+        var index = firstContent;
+        while (index < line.Length && char.IsDigit(line[index]))
+        {
+            index++;
+        }
+
+        if (index >= line.Length || line[index] is not ('.' or ')'))
+        {
+            return -1;
+        }
+
+        var after = index + 1;
+        return after >= line.Length || char.IsWhiteSpace(line[after])
+            ? index
+            : -1;
+    }
+}

--- a/tests/PaperTodo.MarkdownSemanticChecks/CopyTranslationChecks.cs
+++ b/tests/PaperTodo.MarkdownSemanticChecks/CopyTranslationChecks.cs
@@ -1,0 +1,53 @@
+using System.Runtime.CompilerServices;
+
+namespace PaperTodo;
+
+internal static class CopyTranslationChecks
+{
+    [ModuleInitializer]
+    internal static void Run()
+    {
+        Equal(
+            "bold and italic",
+            MarkdownSemanticSnapshot.ToPlainText("**bold** and *italic*"),
+            "Markdown emphasis is removed from plain-text copy");
+        Equal(
+            "label",
+            MarkdownSemanticSnapshot.ToPlainText("[label](https://example.com)"),
+            "Markdown link destination is removed from plain-text copy");
+
+        var markdown = TodoClipboardFormatter.ToMarkdown(
+        [
+            ("buy milk", false),
+            ("submitted", true)
+        ]);
+        Equal(
+            "- [ ] buy milk" + Environment.NewLine + "- [x] submitted",
+            markdown,
+            "Todo completion state is preserved in Markdown copy");
+
+        var escaped = TodoClipboardFormatter.ToMarkdown(
+        [
+            ("literal **stars** and [brackets]", false),
+            ("first\r\n# heading-looking continuation", true)
+        ]);
+        Equal(
+            "- [ ] literal \\*\\*stars\\*\\* and \\[brackets\\]" +
+            Environment.NewLine +
+            "- [x] first" + Environment.NewLine +
+            "    \\# heading-looking continuation",
+            escaped,
+            "Todo text remains literal when translated to Markdown");
+
+        Console.WriteLine("PASS copy translation checks");
+    }
+
+    private static void Equal(string expected, string actual, string message)
+    {
+        if (!string.Equals(expected, actual, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"{message}: expected [{expected}] actual [{actual}]");
+        }
+    }
+}

--- a/tests/PaperTodo.MarkdownSemanticChecks/PaperTodo.MarkdownSemanticChecks.csproj
+++ b/tests/PaperTodo.MarkdownSemanticChecks/PaperTodo.MarkdownSemanticChecks.csproj
@@ -18,8 +18,10 @@
     <Compile Include="..\..\src\MarkdownSemanticSnapshot.Escapes.cs" Link="MarkdownSemanticSnapshot.Escapes.cs" />
     <Compile Include="..\..\src\MarkdownSemanticSnapshot.Compatibility.cs" Link="MarkdownSemanticSnapshot.Compatibility.cs" />
     <Compile Include="..\..\src\MarkdownSemanticSnapshot.Incremental.cs" Link="MarkdownSemanticSnapshot.Incremental.cs" />
+    <Compile Include="..\..\src\MarkdownSemanticSnapshot.PlainText.cs" Link="MarkdownSemanticSnapshot.PlainText.cs" />
     <Compile Include="..\..\src\MarkdownFencedCodeScanner.cs" Link="MarkdownFencedCodeScanner.cs" />
     <Compile Include="..\..\src\MarkdownListEditing.cs" Link="MarkdownListEditing.cs" />
     <Compile Include="..\..\src\MarkdownImageReferences.cs" Link="MarkdownImageReferences.cs" />
+    <Compile Include="..\..\src\TodoClipboardFormatter.cs" Link="TodoClipboardFormatter.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
只合入复制转译功能：

- 待办多选：Ctrl+C / 右键复制 = 纯文本；Ctrl+Shift+C / 右键复制为 Markdown = Markdown 任务列表。
- 笔记正文：Ctrl+C / 右键复制 = 原始 Markdown；Ctrl+Shift+C / 右键复制为纯文本 = 去 Markdown 标记后的文本。
- 复用现有 Markdig 解析语义，不混入此前预览、显隐等改动。
- Windows Release build 与 Markdown semantic checks 已通过。

当前 main 比分支多 3 个与 MCP/Todo 外部写入相关提交，文件无重叠，预期可无冲突合并。