### PR TITLE
feat: 星笺 Starpaper — 知识星图与待办插画插件

### DIFF
--- a/.github/workflows/starpaper.yml
+++ b/.github/workflows/starpaper.yml
@@ -1,0 +1,47 @@
+name: Starpaper plugin
+
+on:
+  pull_request:
+    paths:
+      - 'plugin-samples/PaperTodo.Plugin.Starpaper/**'
+      - 'plugins/com.papertodo.starpaper/**'
+      - '.github/workflows/starpaper.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'plugin-samples/PaperTodo.Plugin.Starpaper/**'
+      - 'plugins/com.papertodo.starpaper/**'
+      - '.github/workflows/starpaper.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  browser-and-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Test model and refresh policy
+        run: node --test plugin-samples/PaperTodo.Plugin.Starpaper/tests/core.test.cjs
+      - name: Install test-only browser
+        run: |
+          python -m pip install playwright==1.57.0
+          python -m playwright install --with-deps chromium
+      - name: Test UI against the public host contract
+        run: python plugin-samples/PaperTodo.Plugin.Starpaper/tests/browser_test.py --screenshots dist/screenshots
+      - name: Verify deployed files and package
+        run: python plugin-samples/PaperTodo.Plugin.Starpaper/package.py --check --output dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Starpaper-plugin
+          path: |
+            dist/Starpaper-*.zip
+            dist/Starpaper-*.sha256
+            dist/screenshots/

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/NOTICE.txt
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/NOTICE.txt
@@ -1,0 +1,8 @@
+Starpaper is distributed as part of the PaperTodo project under its existing terms.
+Full licensing terms (PolyForm Noncommercial License 1.0.0 and PaperTodo Individual Professional Use Additional Permission 1.0):
+https://github.com/snownico0722/PaperTodo/blob/75494e324c70d76ccd5aaaef20fd05c18a7d6083/LICENSE.md
+https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+Required Notice: PaperTodo Copyright © 2026 snownico0722. PaperTodo is licensed under the PolyForm Noncommercial License 1.0.0 together with the PaperTodo Individual Professional Use Additional Permission 1.0, available in the original project LICENSE file at https://github.com/snownico0722/PaperTodo/blob/main/LICENSE.md. Original project: https://github.com/snownico0722/PaperTodo
+
+Illustrations in web/art.js are original local vector artwork; no third-party image assets or web fonts are bundled.

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/README.md
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/README.md
@@ -1,0 +1,93 @@
+# 星笺 · Starpaper
+
+把知识放成星图，把待办变成有画面的行动卡片。
+
+这是一个独立的 **PaperTodo API 2.1 Web 插件**，不是新的主管理页，不修改主程序、原始待办行、Markdown 编辑器或 Edge 窗口。没有账号、云端服务、联网请求和第三方前端依赖。可创建多张独立星图。
+
+## 安装与开始
+
+退出 PaperTodo，把安装包里的 `com.papertodo.starpaper` 文件夹放入 PaperTodo 的 `plugins/`，然后重新启动。最终位置必须是：
+
+```text
+PaperTodo.exe
+plugins/
+  com.papertodo.starpaper/
+    plugin.json
+    NOTICE.txt
+    web/
+      index.html
+      ...
+```
+
+在 PaperTodo 新建一张笔记纸，在正文插件选择中选择 **星笺 · Starpaper**。首次打开是空星图；先点“新建知识”，或点“选择纸片”勾选现有待办纸、内置 Markdown 笔记纸。没有选择前，只读取纸片列表，不扫描待办或笔记正文。
+
+需要宿主支持 API **2.1**；仅凭“4.0”版本字样不能判断协议兼容。插件文件变更后需要重启，不依赖热重载。更新时替换本插件文件即可，不要删除 `plugins/data/`；卸下插件文件并不等于备份或删除插件数据。
+
+## 知识星图
+
+- 新建、编辑、删除本地知识节点，使用纯文本正文和 `[[知识标题]]` 引用。可引用已选择的 Markdown 笔记标题。同名标题不猜测目标；引用按 Unicode NFC 归一化后精确匹配。
+- 选中的待办纸生成中心节点，原始待办成为周围节点。Markdown 笔记显示为只读引用节点，正文从原纸片读取，不另外保存副本。
+- 拖动节点摆放，拖动背景平移，滚轮缩放；双击空白处新建。选中一个节点后 Shift+单击另一节点连线，或用“关联”填写关系说明。
+- 搜索标题与正文，筛选完成状态，聚焦相邻节点；“全图”定位所有匹配节点，“整理布局”恢复自动布局。
+- Ctrl+Z / Ctrl+Y 撤销、重做星图编辑，包括知识、连线、布局和封面；**不会撤销原始待办的修改**。文本输入框保留浏览器自己的文本撤销。
+
+自动布局是确定性的静态布局，不持续运行力导向动画。渲染会裁掉屏幕之外的几何，但不会截断数据；大量节点适合通过搜索、筛选和聚焦缩小浏览范围。没有未经测量的“无限节点流畅”承诺。
+
+## 待办图鉴与插图
+
+图鉴显示所选纸片的真实待办。可新建待办、编辑文字、标记完成或恢复未完成，修改全部通过宿主 Workspace API，使用原始 Paper ID + Todo ID。没有删除原始待办、删除纸片或写入笔记正文的权限。
+
+八种原创离线矢量插画：星轨、书页、代码、生长、远行、活力、创作、专注。根据文字关键词选取默认主题，可手动切换。**这是确定性的本地插画，不是 AI 绘画，也不会把待办发送给模型。** 图片显示在星笺的图鉴和详情中，不会插入原始待办行。
+
+知识、引用笔记和待办均可使用本地 PNG / JPEG / WebP / GIF，也支持粘贴或拖入单张图片。导入时转为静态 WebP 缩略图，最长边不超过 1024 像素；存储副本不依赖原文件路径。GIF 使用解码时的静态帧，不保留动画；输入 SVG / HTML、外部图片 URL 不作为封面执行或加载。为控制解码内存，输入上限为 20 MiB、3200 万像素；压缩后的每张封面不超过 512 KiB。
+
+可以导出 **960×1120 PNG 插画卡片**和 **SVG 星图**。SVG 是节点、标题和关系的矢量示意，不是包含所有照片的画布截图。界面标签和图片卡片会按可视空间省略长标题，完整标题仍在详情、SVG 的 title 和原始数据中。
+
+## 保存、同步与失败处理
+
+知识、关联、位置、封面、所选来源和视图设置属于 per-paper frontend state，通过 `papertodo.saveState` 及时提交，由 `PaperBodyPluginDataStore` 保存。没有 localStorage、IndexedDB 或第二份主数据文件。`registerStateProvider` 是边界补交，不是唯一保存机制；Web bridge 的提交返回不等于磁盘持久化 ACK。
+
+原始待办和引用笔记只存在于 Workspace 快照，不进入插件备份。原始对象被删除、自动清理或无法读取时，有关系的引用会成为“引用暂不可用”，不会自动删除关系和封面。取消选择来源也不删除原纸片或历史封面。局部编辑历史最多 30 步，并有独立内存预算；不是重启后持久化的撤销日志。
+
+读取失败会保留上次完整快照，并禁用原待办编辑。刷新队列只发布最新完整结果，过期请求不能覆盖新选择。待办写入失败或确认丢失后不自动重发，只重新读取；用户应核对原待办后决定是否重试。文字编辑提交前还会检查最新快照，发现变化就拒绝覆盖；宿主 API 没有条件写入版本号，因此这不是跨进程原子 compare-and-swap。
+
+导入备份前必须确认；只替换这张星图，可撤销，不会创建或覆盖原始待办。跨设备、重新创建的原始纸片可能具有不同 ID，备份不能自动恢复它们。损坏数据或未来版本数据会阻止写入，并提供原始数据导出，不会用空白状态覆盖。
+
+宿主 API 2.1 的每张纸状态上限为 **10 MiB UTF-8 JSON**。提交前检测实际字节数，超限拒绝本次修改，不静默截断。大型图片集合建议分成多张星图；封面是预览，不是原始照片备份。
+
+## Edge、生命周期和主题
+
+正文使用宿主绘制的标准胶囊。独立 Edge Mini 为 **只读摘要**：未完成数量、知识数量和最多三项预览。它不保存状态、不注册顶栏或占用键盘输入，不把整个页面标记为交互区。`mini.ready()` 在首个工作区结果或错误视图完成布局后发送；窗口、队列、大小和 publication 仍由宿主控制。
+
+不声明 provider Runtime、不做后台轮询。正文可见时通过 Workspace 事件更新，重新激活/显示时刷新；Mini 每次显示刷新。正文不存在时，胶囊展示的是最后一次正文发布的摘要，**不承诺常驻后台实时统计**。隐藏时停止绘制，销毁时释放订阅、刷新队列和 ResizeObserver。
+
+正文与 Mini 接收 `stateChanged`，不原样回写造成回声。跟随宿主颜色与字体设置，支持缩小窗口和系统减少动效偏好。界面提供中文、英语、日语和韩语，可在插件设置选择；默认跟随系统语言。
+
+## 开发与打包
+
+源代码在本目录；`plugins/com.papertodo.starpaper/` 是可加载副本。API 和宿主边界以仓库的 `plugin-samples/README.md`、`doc/ARCHITECTURE.md`、`PaperTodo.Plugin.Abstractions` 为准，本文件不是另一份宿主架构。
+
+在仓库根目录运行以下完整命令。Python 3.10+、Node 22+；不需要 npm install，也不编译 .NET 插件：
+
+```powershell
+node --test .\plugin-samples\PaperTodo.Plugin.Starpaper\tests\core.test.cjs
+python .\plugin-samples\PaperTodo.Plugin.Starpaper\package.py --sync --output .\dist
+```
+
+打包脚本仅更新这个插件的文件，不删除 `.runtime/` 或 `plugins/data/`，也不会启动或终止 PaperTodo。更新已加载的插件前仍须自己退出主程序。`--check` 检查源代码与部署副本一致。
+
+浏览器行为测试：
+
+```powershell
+python -m pip install playwright==1.57.0
+python -m playwright install chromium
+python .\plugin-samples\PaperTodo.Plugin.Starpaper\tests\browser_test.py --screenshots .\dist\starpaper-screenshots
+```
+
+测试用 API 2.1 mock 验证 DOM 交互、调用参数、失败与生命周期，不等于 Windows/WPF/WebView2 真机验证。默认测试直接通过本地 HTTP 加载未修改的 HTML/CSP；只有导航受限的测试环境才使用 `--inline`，该模式不验证 CSP 和资源加载。`CHROMIUM_EXECUTABLE` 可指定已有 Chromium。
+
+直接打开 `web/preview.html` 可用内存演示数据体验；刷新即重置，不会修改 PaperTodo。`index.html` 脱离宿主只显示说明，绝不自动伪造用户数据。
+
+## 许可与知识影响
+
+沿用原项目授权，见 `NOTICE.txt` 与根目录 `LICENSE.md`。没有改变现有架构、ownership、插件合同、已确立技术路线或 Agent 执行规则，因此不改动 Architecture、Decisions 或 AGENTS，也不把独立分发的插件写成主程序内置功能。

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/package.py
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/package.py
@@ -1,0 +1,63 @@
+"""Build the independent, zero-dependency Starpaper distribution using Python 3.10+."""
+from __future__ import annotations
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+import tempfile
+import zipfile
+
+ROOT = Path(__file__).resolve().parent
+REPO = ROOT.parent.parent
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', type=Path, default=REPO / 'dist')
+    parser.add_argument('--sync', action='store_true', help='Update the repository deployable copy. Exit PaperTodo first.')
+    parser.add_argument('--check', action='store_true', help='Check the committed deployable copy against source.')
+    args = parser.parse_args()
+    manifest = json.loads((ROOT / 'plugin.json').read_text(encoding='utf-8'))
+    if manifest['id'] != 'com.papertodo.starpaper' or manifest['apiVersion'] != '2.1':
+        raise ValueError('Unexpected plugin identity/protocol; review packaging before changing these.')
+    files = [ROOT / name for name in ['plugin.json', 'README.md', 'NOTICE.txt']]
+    files += sorted(path for path in (ROOT / 'web').rglob('*') if path.is_file())
+    target = REPO / 'plugins' / manifest['id']
+    if args.sync:
+        # Replace only our known files, one atomic rename at a time. Never delete user state/cache.
+        for source in files:
+            destination = target / source.relative_to(ROOT)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(dir=destination.parent, delete=False) as temporary:
+                temporary.write(source.read_bytes())
+                temp = Path(temporary.name)
+            try:
+                temp.replace(destination)
+            finally:
+                temp.unlink(missing_ok=True)
+    if args.check:
+        for source in files:
+            destination = target / source.relative_to(ROOT)
+            if not destination.is_file() or destination.read_bytes() != source.read_bytes():
+                raise ValueError(f'Deployable copy differs: {destination}')
+    args.output.mkdir(parents=True, exist_ok=True)
+    output = args.output / f'Starpaper-{manifest["version"]}.zip'
+    with zipfile.ZipFile(output, 'w', compression=zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
+        for source in files:
+            info = zipfile.ZipInfo(f'{manifest["id"]}/{source.relative_to(ROOT).as_posix()}', date_time=(2026, 9, 6, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, source.read_bytes(), compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+    digest = hashlib.sha256(output.read_bytes()).hexdigest()
+    output.with_suffix('.zip.sha256').write_text(f'{digest}  {output.name}\n', encoding='ascii')
+    print(f'{output}\nSHA256 {digest}')
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except (OSError, ValueError, KeyError) as error:
+        print(f'Packaging failed: {error}', file=sys.stderr)
+        sys.exit(1)

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/plugin.json
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/plugin.json
@@ -1,0 +1,61 @@
+{
+  "kind": "web",
+  "id": "com.papertodo.starpaper",
+  "name": "星笺 · Starpaper",
+  "description": "知识星图与待办插画。Knowledge constellations and illustrated, live-linked to-dos. Offline; no account or AI service required.",
+  "version": "1.0.0",
+  "apiVersion": "2.1",
+  "stateVersion": 1,
+  "maxPaperInstances": 0,
+  "entry": "web/index.html",
+  "miniEntry": "web/index.html",
+  "miniSize": {
+    "width": 320,
+    "height": 240
+  },
+  "miniMaxSize": {
+    "width": 320,
+    "height": 240
+  },
+  "permissions": [
+    "papers.read",
+    "papers.observe",
+    "todos.read",
+    "todos.observe",
+    "todos.append",
+    "todos.update",
+    "notes.read",
+    "notes.observe"
+  ],
+  "settings": [
+    {
+      "id": "language",
+      "type": "select",
+      "name": "语言 / Language",
+      "default": "auto",
+      "quick": true,
+      "options": [
+        {
+          "value": "auto",
+          "name": "系统 / System"
+        },
+        {
+          "value": "zh",
+          "name": "简体中文"
+        },
+        {
+          "value": "en",
+          "name": "English"
+        },
+        {
+          "value": "ja",
+          "name": "日本語"
+        },
+        {
+          "value": "ko",
+          "name": "한국어"
+        }
+      ]
+    }
+  ]
+}

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/tests/browser_test.py
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/tests/browser_test.py
@@ -1,0 +1,371 @@
+"""Behavioral Chromium tests against an API 2.1 mock, NOT Windows/WebView2 integration tests.
+
+Default mode serves the unchanged production files (including CSP) over localhost.
+--inline is for runners whose managed Chromium prohibits navigation: the same JS/CSS
+is injected into about:blank; CSP/resource loading are NOT covered in that mode.
+"""
+from __future__ import annotations
+import argparse
+import base64
+import functools
+import http.server
+import json
+import os
+from pathlib import Path
+import re
+import threading
+import unittest
+from playwright.sync_api import sync_playwright, expect
+
+ROOT = Path(__file__).resolve().parent.parent
+ARGS = argparse.Namespace(inline=False, screenshots=None)
+PNG = base64.b64decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aN3cAAAAASUVORK5CYII=')
+
+
+def blank(**kwargs):
+    return dict(schema=1, sources=[], notes=[], links=[], positions={}, covers={}, view='map', filter='all', wiki=True, **{}) | kwargs
+
+
+def board(**kwargs):
+    return blank(sources=['p1'], notes=[dict(id='n:idea', title='Idea', body='A local thought.')]) | kwargs
+
+
+class QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+
+class BrowserTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), functools.partial(QuietHandler, directory=str(ROOT / 'web')))
+        threading.Thread(target=cls.server.serve_forever, daemon=True).start()
+        cls.play = sync_playwright().start()
+        opts = dict(headless=True)
+        if executable := os.getenv('CHROMIUM_EXECUTABLE'):
+            opts['executable_path'] = executable
+        cls.browser = cls.play.chromium.launch(**opts)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.browser.close()
+        cls.play.stop()
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def setUp(self):
+        self.page = self.browser.new_page(viewport=dict(width=1100, height=760))
+        self.page.set_default_timeout(5000)
+        self.errors = []
+        self.page.on('pageerror', lambda error: self.errors.append(str(error)))
+
+    def tearDown(self):
+        self.page.close()
+        self.assertEqual(self.errors, [], 'Uncaught JavaScript errors')
+
+    def load(self, state=None, surface='body', preview=False, no_host=False):
+        name = 'preview.html' if preview else 'index.html'
+        mock = (ROOT / 'tests/host-fixture.js').read_text(encoding='utf-8')
+        if ARGS.inline:
+            html = (ROOT / 'web' / name).read_text(encoding='utf-8')
+            html = re.sub(r'<meta http-equiv="Content-Security-Policy"[^>]+>', '', html)
+            html = re.sub(r'<link rel="stylesheet" href="([^"]+)">', lambda m: '<style>' + (ROOT / 'web' / m[1]).read_text(encoding='utf-8') + '</style>', html)
+            html = re.sub(r'<script[^>]*src="[^"]+"[^>]*></script>', '', html)
+            self.page.set_content(html)
+            # about:blank has no secure-origin randomUUID; the production HTTPS host does.
+            self.page.evaluate('crypto.randomUUID ||= () => Array.from(crypto.getRandomValues(new Uint8Array(16)), b=>b.toString(16).padStart(2,"0")).join("")')
+            if not preview and not no_host:
+                self.page.evaluate(mock)
+            for script in ['core.js', 'i18n.js', 'art.js', 'app.js']:
+                self.page.add_script_tag(content=(ROOT / 'web' / script).read_text(encoding='utf-8'))
+        else:
+            if not preview and not no_host:
+                self.page.add_init_script(mock)
+            self.page.goto(f'http://127.0.0.1:{self.server.server_port}/{name}')
+        if not preview and not no_host:
+            self.page.evaluate('([state,surface]) => testHost.initialize(state,surface)', [state, surface])
+        self.page.wait_for_timeout(100)
+
+    def js(self, expression):
+        return self.page.evaluate(expression)
+
+    def saved(self):
+        return self.js('testHost.saves.at(-1)')
+
+    def click_node(self, key):
+        self.page.locator(f'[data-node="{key}"]').click()
+
+    def test_01_no_host_never_runs_fake_data(self):
+        self.load(no_host=True)
+        expect(self.page.locator('#app')).to_contain_text('PaperTodo')
+        self.assertEqual(self.page.locator('[data-node]').count(), 0)
+
+    def test_02_blank_does_not_scan_contents_or_write_defaults(self):
+        self.load()
+        self.assertEqual(self.js('testHost.saves'), [])
+        self.assertEqual([x['method'] for x in self.js('testHost.calls')], ['papers.list'])
+        self.assertEqual(self.js('testHost.providers.length'), 1)
+        self.assertEqual(self.page.locator('[data-node]').count(), 0)
+
+    def test_03_sources_are_explicit_and_exclude_other_plugin_bodies(self):
+        self.load()
+        self.page.locator('#sources').click()
+        expect(self.page.locator('#dialog')).not_to_contain_text('Starpaper')
+        self.page.get_by_label('Project', exact=True).check()
+        self.page.get_by_label('Reference', exact=True).check()
+        self.page.locator('#dialog button[type=submit]').click()
+        expect(self.page.locator('[data-node="t:p1:t1"]')).to_be_visible()
+        self.assertEqual(self.saved()['sources'], ['p1', 'p3'])
+        self.assertFalse(any(c['args'].get('paperId') == 'p2' for c in self.js('testHost.calls')))
+        self.click_node('p:p3')
+        expect(self.page.locator('#inspector')).to_contain_text('Live reference text.')
+        self.assertEqual(self.page.locator('#inspector').get_by_role('button', name='Edit', exact=True).count(), 0)
+
+    def test_04_new_idea_edit_delete_and_local_undo(self):
+        self.load()
+        self.page.locator('#add-note').click()
+        self.page.get_by_label('Title', exact=True).fill('First idea')
+        self.page.get_by_label('Text · supports [[Idea title]]', exact=True).fill('Preserve this text.')
+        self.page.locator('#dialog button[type=submit]').click()
+        expect(self.page.locator('#inspector h2')).to_have_text('First idea')
+        self.assertEqual(len(self.saved()['notes']), 1)
+        self.page.locator('#inspector').get_by_role('button', name='Edit', exact=True).click()
+        self.page.get_by_label('Title', exact=True).fill('Edited idea')
+        self.page.locator('#dialog button[type=submit]').click()
+        self.page.locator('#undo').click()
+        self.assertEqual(self.saved()['notes'][0]['title'], 'First idea')
+        self.click_node(self.saved()['notes'][0]['id'])
+        self.page.get_by_role('button', name='Delete idea', exact=True).click()
+        self.page.locator('#dialog button[type=submit]').click()
+        self.assertEqual(self.saved()['notes'], [])
+        self.page.locator('#undo').click()
+        self.assertEqual(len(self.saved()['notes']), 1)
+        self.assertTrue(all(c['method'] == 'papers.list' for c in self.js('testHost.calls')))
+
+    def test_05_drag_is_one_save_on_release_and_cancel_has_no_save(self):
+        self.load(board(sources=[]))
+        node = self.page.locator('[data-node="n:idea"]')
+        bounds = node.evaluate('(el) => el.getBoundingClientRect().toJSON()')
+        x, y = bounds['x'] + bounds['width'] / 2, bounds['y'] + 20
+        self.page.mouse.move(x, y)
+        self.page.mouse.down()
+        self.page.mouse.move(x + 100, y + 35, steps=8)
+        self.assertEqual(self.js('testHost.saves.length'), 0)
+        self.page.mouse.up()
+        self.assertEqual(self.js('testHost.saves.length'), 1)
+        self.assertIn('n:idea', self.saved()['positions'])
+        self.page.wait_for_timeout(120)
+        self.page.locator('#undo').click()
+        self.assertEqual(self.saved()['positions'], {})
+        before = self.js('testHost.saves.length')
+        expect(node).to_be_visible()
+        bounds = node.evaluate('(el) => el.getBoundingClientRect().toJSON()')
+        self.page.mouse.move(bounds['x'] + bounds['width'] / 2, bounds['y'] + 20)
+        self.page.mouse.down()
+        self.page.mouse.move(bounds['x'] + 140, bounds['y'] + 70, steps=5)
+        self.js('testHost.emit({type:"cancelInteractions"})')
+        self.page.mouse.up()
+        self.assertEqual(self.js('testHost.saves.length'), before)
+
+    def test_06_shift_click_links_and_named_link_update(self):
+        self.load(board(sources=[], notes=[dict(id='n:idea',title='Idea',body=''),dict(id='n:two',title='Second',body='')]))
+        self.click_node('n:idea')
+        self.page.locator('[data-node="n:two"]').click(modifiers=['Shift'])
+        self.assertEqual(len(self.saved()['links']), 1)
+        self.page.get_by_role('button', name='Link', exact=True).click()
+        self.page.get_by_label('Relationship (optional)', exact=True).fill('Enables')
+        self.page.locator('#dialog button[type=submit]').click()
+        self.assertEqual(self.saved()['links'][0]['label'], 'Enables')
+        self.assertEqual(len(self.saved()['links']), 1)
+
+    def test_07_task_write_waits_for_ack_and_uses_exact_ids(self):
+        self.load(board(view='cards'))
+        self.js('testHost.delayWrite=true')
+        check = self.page.get_by_role('checkbox', name='Mark done: Read a book', exact=True)
+        check.click()
+        expect(check).to_be_disabled()
+        self.assertEqual(self.js('testHost.todos[0].done'), False)
+        writes = self.js('testHost.calls.filter(c=>c.method==="todos.update")')
+        self.assertEqual(writes, [dict(method='todos.update',args=dict(paperId='p1',todoId='t1',done=True))])
+        self.js('testHost.resolveWrite()')
+        expect(self.page.get_by_role('checkbox', name='Mark open: Read a book', exact=True)).to_be_enabled()
+        self.assertEqual(self.js('testHost.saves'), [])
+
+    def test_08_failed_task_write_is_not_automatically_retried(self):
+        self.load(board(view='cards'))
+        self.js('testHost.failWrite=true')
+        self.page.get_by_role('checkbox', name='Mark done: Read a book', exact=True).click()
+        expect(self.page.locator('#toast')).to_contain_text('Operation not confirmed')
+        self.page.wait_for_timeout(150)
+        self.assertEqual(self.js('testHost.calls.filter(c=>c.method==="todos.update").length'), 1)
+        self.assertFalse(self.js('testHost.todos[0].done'))
+
+    def test_09_read_failure_preserves_snapshot_and_disables_host_edits(self):
+        self.load(board(view='cards'))
+        self.js('testHost.failRead=true; testHost.change()')
+        expect(self.page.locator('#status-banner')).to_be_visible()
+        expect(self.page.locator('#card-grid')).to_contain_text('Read a book')
+        expect(self.page.get_by_role('checkbox', name='Mark done: Read a book', exact=True)).to_be_disabled()
+        self.js('testHost.failRead=false; testHost.todos[0].text="Changed elsewhere"; testHost.change()')
+        expect(self.page.locator('#card-grid')).to_contain_text('Changed elsewhere')
+        expect(self.page.locator('#status-banner')).to_be_hidden()
+        self.assertEqual(self.js('testHost.saves'), [])
+
+    def test_10_state_changed_never_echoes_and_future_state_blocks_writes(self):
+        self.load(board())
+        next_state = board(notes=[dict(id='n:next',title='From host',body='')])
+        self.page.evaluate('(state)=>testHost.emit({type:"stateChanged",state})', next_state)
+        expect(self.page.locator('[data-node="n:next"]')).to_be_visible()
+        self.assertEqual(self.js('testHost.saves'), [])
+        self.js('testHost.emit({type:"stateChanged",state:{schema:99,original:"keep"}})')
+        expect(self.page.locator('#app')).to_contain_text('Incompatible data version')
+        self.assertEqual(self.js('testHost.saves'), [])
+        self.assertEqual(self.js('(()=>{try{testHost.providers[0]();return "bad"}catch{return "blocked"}})()'), 'blocked')
+
+    def test_11_invalid_initial_state_has_no_state_provider_or_read(self):
+        self.load(dict(schema=99, original='do not overwrite'))
+        expect(self.page.locator('#app')).to_contain_text('Incompatible data version')
+        self.assertEqual(self.js('testHost.providers'), [])
+        self.assertEqual(self.js('testHost.calls'), [])
+        self.assertEqual(self.js('testHost.saves'), [])
+
+    def test_12_image_upload_template_reset_and_png_export(self):
+        self.load(board(sources=[]))
+        self.click_node('n:idea')
+        self.page.get_by_role('button', name='Use local image', exact=True).click()
+        self.page.locator('#image-file').set_input_files(dict(name='test.png',mimeType='image/png',buffer=PNG))
+        self.page.wait_for_function('testHost.saves.at(-1)?.covers["n:idea"]?.image')
+        self.assertTrue(self.saved()['covers']['n:idea']['image'].startswith('data:image/webp;base64,'))
+        self.page.get_by_role('combobox', name='Illustration', exact=True).select_option('travel')
+        self.assertEqual(self.saved()['covers']['n:idea'], dict(scene='travel'))
+        with self.page.expect_download() as result:
+            self.page.get_by_role('button', name='Export illustrated card', exact=True).click()
+        download = result.value
+        self.assertEqual(download.suggested_filename, 'Starpaper-card.png')
+        raw = Path(download.path()).read_bytes()
+        self.assertEqual(raw[:8], b'\x89PNG\r\n\x1a\n')
+        self.assertEqual(int.from_bytes(raw[16:20], 'big'), 960)
+        self.assertEqual(int.from_bytes(raw[20:24], 'big'), 1120)
+
+    def test_13_bad_image_and_bad_backup_do_not_overwrite(self):
+        self.load(board(sources=[]))
+        self.click_node('n:idea')
+        self.page.get_by_role('button', name='Use local image', exact=True).click()
+        self.page.locator('#image-file').set_input_files(dict(name='bad.svg',mimeType='image/svg+xml',buffer=b'<svg onload="alert(1)"/>'))
+        expect(self.page.locator('#toast')).to_contain_text('Unsupported image')
+        self.assertEqual(self.js('testHost.saves'), [])
+        self.page.locator('#backup-file').set_input_files(dict(name='bad.json',mimeType='application/json',buffer=b'{"format":"papertodo.starpaper","version":1,"state":{"schema":55}}'))
+        expect(self.page.locator('#toast')).to_contain_text('Incompatible data version')
+        self.assertEqual(self.js('testHost.saves'), [])
+
+    def test_14_mini_has_layout_ready_but_no_writers_or_interactive_controls(self):
+        self.load(board(), surface='mini')
+        self.page.wait_for_function('testHost.readyCount === 1')
+        expect(self.page.locator('#app')).to_contain_text('Read a book')
+        self.assertEqual(self.js('testHost.providers'), [])
+        self.assertEqual(self.js('testHost.saves'), [])
+        self.assertEqual(self.js('testHost.capsules'), [])
+        self.assertEqual(self.js('testHost.claims'), [])
+        self.assertEqual(self.page.locator('#app button, #app input, [data-papertodo-interactive]').count(), 0)
+        self.assertGreater(self.js('testHost.readyBox.height'), 0)
+        self.page.evaluate('(state)=>testHost.emit({type:"stateChanged",state})', board(notes=[]))
+        self.page.wait_for_timeout(50)
+        self.assertEqual(self.js('testHost.readyCount'), 1)
+        self.assertEqual(self.js('testHost.saves'), [])
+
+    def test_15_theme_languages_and_narrow_viewport(self):
+        self.load(board())
+        for language in ['zh', 'en', 'ja', 'ko']:
+            self.page.evaluate('(language)=>testHost.emit({type:"settingsChanged",settings:{language}})', language)
+            self.assertEqual(self.page.locator('html').get_attribute('lang'), language)
+        self.js('testHost.emit({type:"themeChanged",theme:{paperColor:"#202825",textColor:"#edf2ef",weakTextColor:"#b1bfb5",accentColor:"#a5c8b5",borderColor:"#60726a"}})')
+        self.assertEqual(self.js('getComputedStyle(document.documentElement).getPropertyValue("--paper").trim()'), '#202825')
+        self.page.set_viewport_size(dict(width=320,height=450))
+        self.page.locator('#tab-cards').click()
+        self.assertLessEqual(self.js('document.documentElement.scrollWidth'), 320)
+        self.assertGreater(self.page.locator('#cards-pane').bounding_box()['height'], 80)
+        self.page.locator('#add-note').click()
+        bounds = self.page.locator('#dialog').bounding_box()
+        self.assertGreaterEqual(bounds['x'], 0)
+        self.assertLessEqual(bounds['x']+bounds['width'], 321)
+        self.assertLessEqual(bounds['y']+bounds['height'], 451)
+
+    def test_16_export_backup_svg_and_import_are_local(self):
+        self.load(board())
+        self.page.locator('#menu summary').click()
+        with self.page.expect_download() as result:
+            self.page.locator('#export').click()
+        data = Path(result.value.path()).read_bytes()
+        parsed = json.loads(data)
+        self.assertEqual(parsed['state'], board())
+        self.assertNotIn(b'Read a book', data)
+        self.page.locator('#menu summary').click()
+        with self.page.expect_download() as result:
+            self.page.locator('#export-svg').click()
+        self.assertIn(b'<svg', Path(result.value.path()).read_bytes())
+        replacement = dict(format='papertodo.starpaper',version=1,state=blank(notes=[dict(id='n:new',title='Imported',body='Safe text')]))
+        self.page.locator('#backup-file').set_input_files(dict(name='backup.json',mimeType='application/json',buffer=json.dumps(replacement).encode()))
+        self.page.locator('#dialog button[type=submit]').click()
+        self.assertEqual(self.saved()['notes'][0]['title'], 'Imported')
+        self.page.locator('#undo').click()
+        self.assertEqual(self.saved()['notes'][0]['title'], 'Idea')
+        self.assertFalse(any(c['method'] in ['todos.update','todos.append','notes.write'] for c in self.js('testHost.calls')))
+
+    def test_17_create_task_and_conflicting_edit(self):
+        self.load(board(view='cards'))
+        self.page.locator('#add-todo').click()
+        self.page.get_by_label('Title', exact=True).fill('A new task')
+        self.page.locator('#dialog button[type=submit]').click()
+        expect(self.page.locator('#card-grid')).to_contain_text('A new task')
+        self.assertEqual(self.js('testHost.calls.filter(c=>c.method==="todos.append").length'), 1)
+        self.page.locator('[data-card="t:p1:t1"] .card-art').click()
+        self.page.locator('#inspector').get_by_role('button', name='Edit', exact=True).click()
+        self.page.get_by_label('Title', exact=True).fill('Overwrite attempt')
+        self.js('testHost.todos[0].text="Concurrent change"')
+        self.page.locator('#dialog button[type=submit]').click()
+        expect(self.page.locator('#toast')).to_contain_text('Content changed elsewhere')
+        self.assertEqual(self.js('testHost.calls.filter(c=>c.method==="todos.update").length'), 0)
+
+    def test_18_save_failure_keeps_state_and_input(self):
+        self.load(board(sources=[]))
+        self.js('testHost.failSave=true')
+        self.page.locator('#add-note').click()
+        self.page.get_by_label('Title', exact=True).fill('Do not lose me')
+        self.page.locator('#dialog button[type=submit]').click()
+        expect(self.page.locator('#dialog')).to_be_visible()
+        expect(self.page.get_by_label('Title', exact=True)).to_have_value('Do not lose me')
+        self.assertEqual(self.js('testHost.providers[0]().notes.length'), 1)
+        self.assertEqual(self.js('testHost.saves'), [])
+
+    def test_20_keyboard_task_checkbox_is_not_intercepted_by_map_shortcuts(self):
+        self.load(board(view='cards'))
+        check = self.page.get_by_role('checkbox', name='Mark done: Read a book', exact=True)
+        check.focus()
+        self.page.keyboard.press('Space')
+        updated = self.page.get_by_role('checkbox', name='Mark open: Read a book', exact=True)
+        expect(updated).to_be_enabled()
+        expect(updated).to_be_focused()
+        self.assertEqual(self.js('testHost.calls.filter(c=>c.method==="todos.update").length'), 1)
+        self.assertEqual(self.js('testHost.saves'), [])
+
+    def test_19_explicit_preview_and_screenshots(self):
+        self.load(preview=True)
+        expect(self.page.locator('#demo-banner')).to_be_visible()
+        self.assertEqual(self.page.locator('[data-node]').count(), 11)
+        if ARGS.screenshots:
+            out = Path(ARGS.screenshots); out.mkdir(parents=True,exist_ok=True)
+            self.page.screenshot(path=str(out/'Starpaper-map.png'))
+            self.page.locator('#tab-cards').click()
+            self.page.screenshot(path=str(out/'Starpaper-cards.png'))
+            self.page.locator('[data-card="t:preview-tasks:reading"] .card-art').click()
+            self.page.screenshot(path=str(out/'Starpaper-inspector.png'))
+            self.page.set_viewport_size(dict(width=320,height=450))
+            self.page.screenshot(path=str(out/'Starpaper-narrow.png'))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--inline',action='store_true')
+    parser.add_argument('--screenshots')
+    ARGS, remaining = parser.parse_known_args()
+    unittest.main(argv=[__file__]+remaining,verbosity=2)

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/tests/core.test.cjs
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/tests/core.test.cjs
@@ -1,0 +1,150 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const C = require('../web/core.js');
+const A = require('../web/art.js');
+const I = require('../web/i18n.js');
+const paper = { id: 'p1', type: 'todo', title: 'Work' };
+const todo = { id: 't1', paperId: 'p1', paperTitle: 'Work', text: 'Read a book', done: false };
+const note = { id: 'n:one', title: 'One', body: '[[Two]]' };
+const tick = () => new Promise(resolve => setImmediate(resolve));
+const deferred = () => { let resolve, reject; const promise = new Promise((yes, no) => { resolve = yes; reject = no; }); return { promise, resolve, reject }; };
+
+test('empty host state has a complete schema; valid state is not silently rewritten', () => {
+  for (const value of [null, undefined, {}]) assert.deepEqual(C.validate(value), C.blank());
+  const state = { ...C.blank(), extension: 'preserve me' };
+  assert.equal(C.validate(state), state);
+});
+test('unknown versions and corrupt collections fail closed', () => {
+  for (const raw of [{ schema: 2 }, { schema: 0 }, [], '', { ...C.blank(), notes: null }, { ...C.blank(), view: 'secret' }]) assert.throws(() => C.validate(raw));
+});
+test('duplicate IDs, ambiguous edges, reserved properties, nonfinite geometry are rejected', () => {
+  for (const raw of [
+    { ...C.blank(), notes: [note, note] }, { ...C.blank(), sources: ['p1', 'p1'] },
+    { ...C.blank(), links: [{ from: 'a', to: 'b', label: '' }, { from: 'b', to: 'a', label: '' }] },
+    { ...C.blank(), links: [{ from: 'a', to: 'a', label: '' }] },
+    { ...C.blank(), positions: { a: { x: Infinity, y: 0 } } },
+    { ...C.blank(), positions: JSON.parse('{"__proto__":{"x":0,"y":0}}') }
+  ]) assert.throws(() => C.validate(raw));
+});
+test('JSON budget counts UTF-8 bytes, not UTF-16 character count', () => {
+  assert.equal(C.bytes('知'), 3); assert.equal(C.bytes('🌟'), 4);
+  assert.throws(() => C.validate({ ...C.blank(), notes: [{ ...note, body: '知'.repeat(4 * 1024 * 1024) }] }), /capacity/);
+});
+test('image state accepts raster data only; no SVG, external URLs or script URLs', () => {
+  assert.equal(C.safeImage('data:image/webp;base64,QUJD'), true);
+  for (const image of ['javascript:alert(1)', 'https://example.com/a.jpg', 'data:image/svg+xml;base64,PHN2Zz4=', 'data:text/html;base64,QUJD']) {
+    assert.equal(C.safeImage(image), false);
+    assert.throws(() => C.validate({ ...C.blank(), covers: { x: { scene: 'orbit', image } } }), /invalidImage/);
+  }
+});
+test('composite task identities cannot collide on delimiters', () => {
+  assert.notEqual(C.todoKey('a:b', 'c'), C.todoKey('a', 'b:c'));
+  assert.notEqual(C.todoKey('a', '%'), C.todoKey('a', '%25'));
+  assert.equal(C.pair('a:b', 'c'), C.pair('c', 'a:b'));
+});
+test('only selected papers contribute live tasks; host text/completion is never copied into state', () => {
+  const state = { ...C.blank(), sources: ['p1'] }, before = JSON.stringify(state);
+  const model = C.graph(state, [paper], [todo, { ...todo, id: 'secret', paperId: 'p2' }]);
+  assert.equal(model.nodes.filter(n => n.kind === 'todo').length, 1);
+  assert.equal(model.byId.get(C.todoKey('p1', 't1')).todo, todo);
+  assert.equal(JSON.stringify(state), before);
+});
+test('Markdown sources are read-only references and can be wiki targets', () => {
+  const state = { ...C.blank(), sources: ['p2'], notes: [{ ...note, body: '[[Reference]]' }] };
+  const model = C.graph(state, [{ id: 'p2', title: 'Reference', type: 'note' }], [], [{ paperId: 'p2', contentAvailable: true, content: 'Original text' }]);
+  assert.equal(model.byId.get(C.paperKey('p2')).kind, 'note-ref');
+  assert.equal(model.byId.get(C.paperKey('p2')).body, 'Original text');
+  assert.equal(model.edges[0].kind, 'wiki');
+  assert.equal(JSON.stringify(state).includes('Original text'), false);
+});
+test('deleted or unavailable task references remain ghosts without destructive cleanup', () => {
+  const key = C.todoKey('p1', 't1'), state = C.setLink({ ...C.blank(), notes: [note], covers: { [key]: { scene: 'read' } } }, note.id, key, 'Read');
+  const model = C.graph(state, [], []);
+  assert.equal(model.byId.get(key).kind, 'missing'); assert.equal(state.covers[key].scene, 'read');
+  assert.equal(model.edges.length, 1);
+});
+test('completion filter cannot turn a hidden completed task into a missing reference', () => {
+  const key = C.todoKey('p1', 't1'), state = C.setLink({ ...C.blank(), sources: ['p1'], notes: [note] }, note.id, key);
+  const model = C.graph(state, [paper], [{ ...todo, done: true }]);
+  const visible = C.visibleGraph(model, 'open');
+  assert.equal(model.byId.get(key).kind, 'todo');
+  assert.equal(visible.nodes.some(n => n.id === key || n.kind === 'missing'), false);
+  assert.equal(C.visibleGraph(model, 'done').nodes.some(n => n.id === key), true);
+});
+test('wiki references are exact, NFC-aware, unique and deduplicated with manual links', () => {
+  let state = { ...C.blank(), notes: [{ ...note, body: '[[Café]] [[Café]]' }, { id: 'n:two', title: 'Café', body: '' }] };
+  assert.equal(C.graph(state, [], []).edges.length, 1);
+  state = C.setLink(state, 'n:one', 'n:two', 'Named relationship');
+  assert.equal(C.graph(state, [], []).edges.length, 1);
+  state = { ...state, links: [], notes: [...state.notes, { id: 'n:three', title: 'Café', body: '' }] };
+  assert.equal(C.graph(state, [], []).edges.length, 0);
+});
+test('manual relation update is undirected, non-mutating, and refuses self-links', () => {
+  const original = C.blank(), first = C.setLink(original, 'a', 'b', ' first '), second = C.setLink(first, 'b', 'a', 'second');
+  assert.equal(original.links.length, 0); assert.equal(first.links[0].label, 'first');
+  assert.equal(second.links.length, 1); assert.equal(second.links[0].label, 'second');
+  assert.throws(() => C.setLink(second, 'a', 'a'), /selfLink/);
+});
+test('deleting a local idea cleans its own metadata but leaves host tasks/other covers alone', () => {
+  const key = C.todoKey('p1', 't1');
+  const state = C.setLink({ ...C.blank(), notes: [note], sources: ['p1'], covers: { [note.id]: { scene: 'read' }, [key]: { scene: 'code' } }, positions: { [note.id]: { x: 0, y: 0 } } }, note.id, key);
+  const next = C.removeNote(state, note.id);
+  assert.equal(next.notes.length, 0); assert.equal(next.links.length, 0); assert.deepEqual(next.sources, ['p1']);
+  assert.equal(next.covers[key].scene, 'code'); assert.equal(Object.keys(next.positions).length, 0); assert.equal(state.notes.length, 1);
+});
+test('search and one-hop focus return only edges with visible endpoints', () => {
+  const state = C.setLink({ ...C.blank(), sources: ['p1'], notes: [note] }, note.id, C.todoKey('p1', 't1'));
+  const model = C.graph(state, [paper], [todo]);
+  assert.equal(C.visibleGraph(model, 'all', 'book').nodes.length, 1);
+  assert.equal(C.visibleGraph(model, 'all', '', note.id).nodes.length, 2);
+  assert.equal(C.visibleGraph(model, 'all', 'missing').nodes.length, 0);
+});
+test('layout is deterministic, finite and never truncates 2500 nodes', () => {
+  const state = { ...C.blank(), sources: ['p1'], notes: [note] };
+  const tasks = Array.from({ length: 2500 }, (_, i) => ({ ...todo, id: 'task-' + i }));
+  const graph = C.graph(state, [paper], tasks), a = C.layout(graph), b = C.layout(graph);
+  assert.deepEqual(a, b); assert.equal(a.size, 2502);
+  for (const pos of a.values()) assert.ok(Number.isFinite(pos.x) && Number.isFinite(pos.y));
+  const stored = { [note.id]: { x: 321, y: -55 } }; assert.deepEqual(C.layout(graph, stored).get(note.id), stored[note.id]);
+  const fit = C.fit(graph.nodes, a, 320, 240); assert.ok(Object.values(fit).every(Number.isFinite));
+});
+test('zoom preserves the world coordinate underneath the pointer and clamps scale', () => {
+  const before = { x: 23, y: -51, k: .7 }, after = C.zoom(before, 1.3, 120, 200);
+  assert.ok(Math.abs((120 - before.x) / before.k - (120 - after.x) / after.k) < 1e-8);
+  assert.equal(C.zoom(before, 1e9, 120, 200).k, 4); assert.equal(C.zoom(before, 1e-9, 120, 200).k, .01);
+});
+test('history has a bounded depth; undo and redo do not own host data', () => {
+  const h = new C.History(3, 100000), states = Array.from({ length: 6 }, (_, i) => ({ ...C.blank(), wiki: i % 2 === 0 }));
+  states.slice(0, 5).forEach(s => h.push(s)); assert.equal(h.past.length, 3);
+  const previous = h.undo(states[5]); assert.equal(previous, states[4]); assert.equal(h.redo(previous), states[5]);
+  h.push(states[0]); assert.equal(h.future.length, 0); h.clear(); assert.equal(h.past.length, 0);
+});
+test('refresh queue rejects obsolete responses and publishes only the latest complete snapshot', async () => {
+  const loads = [], published = [], errors = [];
+  const q = new C.RefreshQueue(() => { const job = deferred(); loads.push(job); return job.promise; }, v => published.push(v), e => errors.push(e));
+  const idle = q.request(); q.request(); q.request(); assert.equal(loads.length, 1);
+  loads[0].resolve('old'); await tick(); assert.equal(loads.length, 2); assert.deepEqual(published, []);
+  loads[1].resolve('new'); await idle; assert.deepEqual(published, ['new']); assert.deepEqual(errors, []);
+});
+test('read failure keeps the last snapshot; refresh is explicit, not an infinite retry', async () => {
+  let count = 0; const published = [], errors = [];
+  const q = new C.RefreshQueue(async () => { if (++count === 2) throw new Error('offline'); return count; }, v => published.push(v), e => errors.push(e.message));
+  await q.request(); await q.request(); await tick(); assert.equal(count, 2); assert.deepEqual(published, [1]); assert.deepEqual(errors, ['offline']);
+  await q.request(); assert.deepEqual(published, [1, 3]);
+});
+test('disposing a refresh queue prevents late publication and further reads', async () => {
+  const job = deferred(), published = []; let calls = 0;
+  const q = new C.RefreshQueue(() => { calls++; return job.promise; }, v => published.push(v), () => assert.fail('disposed error'));
+  const idle = q.request(); q.dispose(); job.resolve('late'); await idle; await q.request();
+  assert.equal(calls, 1); assert.deepEqual(published, []);
+});
+test('every UI string has four translations and each art scene is deterministic and local', () => {
+  for (const [key, row] of Object.entries(I.rows)) assert.ok(row.length === 4 && row.every(s => typeof s === 'string' && s.length), key);
+  assert.equal(I.language('auto', 'ja-JP'), 'ja'); assert.equal(I.language('auto', 'fr-FR'), 'en');
+  for (const scene of C.SCENES) {
+    assert.equal(A.svg(scene, 42), A.svg(scene, 42)); assert.ok(A.data(scene, 42).startsWith('data:image/svg+xml'));
+    assert.equal(/<script|<foreignObject|https:\/\//.test(A.svg(scene, 42)), false);
+  }
+  assert.equal(C.sceneFor('Read a book'), 'read'); assert.equal(C.sceneFor('插件测试'), 'code');
+});

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/tests/host-fixture.js
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/tests/host-fixture.js
@@ -1,0 +1,59 @@
+// Test-only implementation of the public API 2.1 contract. Never shipped as the real bridge.
+(() => {
+  const clone = value => structuredClone(value);
+  const fixture = window.testHost = {
+    calls: [], saves: [], capsules: [], claims: [], providers: [], errors: [], readyCount: 0,
+    failRead: false, failWrite: false, failSave: false, delayWrite: false,
+    papers: [
+      { id: 'p1', title: 'Project', type: 'todo', bodyProviderId: '' },
+      { id: 'p2', title: 'Private', type: 'todo', bodyProviderId: '' },
+      { id: 'p3', title: 'Reference', type: 'note', bodyProviderId: 'builtin.markdown' },
+      { id: 'self', title: 'Starpaper', type: 'note', bodyProviderId: 'com.papertodo.starpaper' }
+    ],
+    todos: [
+      { id: 't1', paperId: 'p1', paperTitle: 'Project', text: 'Read a book', done: false, order: 0 },
+      { id: 't2', paperId: 'p1', paperTitle: 'Project', text: 'Write code', done: true, order: 1 },
+      { id: 'private', paperId: 'p2', paperTitle: 'Private', text: 'Do not read without selection', done: false, order: 0 }
+    ],
+    notes: [{ paperId: 'p3', paperTitle: 'Reference', bodyProviderId: 'builtin.markdown', contentAvailable: true, content: 'Live reference text. [[Idea]]' }],
+    emit(message) { window.dispatchEvent(new CustomEvent('papertodo', { detail: clone(message) })); },
+    change() { fixture.eventHandler?.({ type: 'todo.changed' }); },
+    initialize(state = null, surface = 'body') {
+      papertodo.surface = surface;
+      fixture.emit({ type: 'initialize', state, surface, visible: true, stateVersion: 1, targetStateVersion: 1, settings: { language: 'en' } });
+    }
+  };
+  window.papertodo = {
+    surface: 'body',
+    saveState(state) { if (fixture.failSave) throw new Error('disk unavailable'); fixture.saves.push(clone(state)); },
+    registerStateProvider(fn) { fixture.providers.push(fn); },
+    paper: { setHeaderText() {}, setCapsulePresentation(value) { fixture.capsules.push(clone(value)); } },
+    body: { setInputClaims(value) { fixture.claims.push(clone(value)); } },
+    mini: { ready() { fixture.readyCount++; fixture.readyBox = document.getElementById('app').getBoundingClientRect().toJSON(); } },
+    onHostEvent(types, handler, options) { fixture.subscription = { types, options }; fixture.eventHandler = handler; return () => { fixture.eventHandler = null; }; },
+    workspace: { async request(method, args = {}) {
+      fixture.calls.push({ method, args: clone(args) });
+      if (/\.list$|\.get$/.test(method) && fixture.failRead) throw new Error('read failed');
+      if (method === 'papers.list') return clone(fixture.papers);
+      if (method === 'todos.list') return clone(fixture.todos.filter(t => t.paperId === args.paperId));
+      if (method === 'notes.get') return clone(fixture.notes.find(n => n.paperId === args.paperId) || null);
+      if (fixture.delayWrite) await new Promise(resolve => { fixture.resolveWrite = resolve; });
+      if (fixture.failWrite) throw new Error('write failed');
+      if (method === 'todos.update') {
+        const item = fixture.todos.find(t => t.id === args.todoId && t.paperId === args.paperId);
+        if (!item) throw new Error('not found');
+        if (typeof args.text === 'string') item.text = args.text;
+        if (typeof args.done === 'boolean') item.done = args.done;
+        fixture.change(); return { paperId: args.paperId, todoId: args.todoId };
+      }
+      if (method === 'todos.append') {
+        const todoIds = args.todos.map((item, i) => {
+          const id = 'new-' + fixture.todos.length + '-' + i;
+          fixture.todos.push({ ...item, id, done: false, order: fixture.todos.length, paperId: args.paperId, paperTitle: 'Project' }); return id;
+        });
+        fixture.change(); return { paperId: args.paperId, todoIds };
+      }
+      throw new Error('Unexpected fixture call: ' + method);
+    } }
+  };
+})();

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/web/app.js
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/web/app.js
@@ -1,0 +1,791 @@
+(function () {
+  'use strict';
+  const C = window.StarCore, A = window.StarArt, I = window.StarI18n;
+  const $ = id => document.getElementById(id);
+  const app = $('app'), dialog = $('dialog');
+  const NS = 'http://www.w3.org/2000/svg';
+  const demo = document.body.dataset.preview === 'true' && !window.papertodo && !location.hostname.endsWith('.papertodo.local');
+  let host = window.papertodo;
+  let state = C.blank(), original = null, ready = false, blocked = false, mini = false, visible = true;
+  let locale = I.language('auto', navigator.language), t = I.translator(locale);
+  let papers = [], todos = [], sourceNotes = [], model = C.graph(state, [], []), positions = new Map();
+  let selection = null, focusId = null, query = '', camera = { x: 0, y: 0, k: 1 }, fitNeeded = true;
+  let size = { width: 600, height: 400 }, drag = null, suppressClick = false, frame = 0, toastTimer = 0;
+  let queue = null, unsubscribe = null, resize = null, stale = false, mounted = false, miniReady = false, workspaceLoaded = false;
+  let imageTarget = null, imageJob = 0, generation = 0, lastFocused = null;
+  const pending = new Set(), history = new C.History();
+  function el(tag, text, className) {
+    const node = document.createElement(tag);
+    if (text !== undefined) node.textContent = text;
+    if (className) node.className = className;
+    return node;
+  }
+  function svgEl(tag, attrs = {}, text) {
+    const node = document.createElementNS(NS, tag);
+    for (const [key, value] of Object.entries(attrs)) node.setAttribute(key, value);
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+  function button(text, action, className = '') {
+    const node = el('button', text, className); node.type = 'button';
+    node.addEventListener('click', action); return node;
+  }
+  function short(text, length = 23) {
+    const chars = [...String(text)]; return chars.length > length ? chars.slice(0, length - 1).join('') + '…' : chars.join('');
+  }
+  function nodeTitle(node) { return node.title || t(node.missing ? 'unavailable' : 'untitled'); }
+  function scene(node) { return state.covers[node.id]?.scene || node.scene || C.sceneFor(node.title); }
+  function image(node) { return state.covers[node.id]?.image || A.data(scene(node), C.hash(node.id)); }
+  function toast(key, detail = '') {
+    const message = I.rows[key] ? t(key) : key;
+    $('toast').textContent = message + (detail ? ` (${short(detail, 140)})` : '');
+    $('toast').hidden = false; clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => { $('toast').hidden = true; }, 6500);
+  }
+  function problem(error) { toast(I.rows[error?.message] ? error.message : 'invalidState', I.rows[error?.message] ? '' : error?.message || ''); }
+  function translate() {
+    document.documentElement.lang = locale;
+    document.querySelectorAll('[data-i18n]').forEach(node => { node.textContent = t(node.dataset.i18n); });
+    document.querySelectorAll('[data-title]').forEach(node => { node.title = t(node.dataset.title); node.setAttribute('aria-label', t(node.dataset.title)); });
+    if ($('search')) $('search').placeholder = t('search');
+  }
+  function theme(value) {
+    if (!value) return;
+    const style = document.documentElement.style;
+    const mapping = { paperColor: '--paper', textColor: '--text', weakTextColor: '--weak', accentColor: '--accent', borderColor: '--border' };
+    for (const [key, name] of Object.entries(mapping)) if (typeof value[key] === 'string' && CSS.supports('color', value[key])) style.setProperty(name, value[key]);
+    if (value.fontFamily) style.setProperty('--font', `${JSON.stringify(value.fontFamily)}, system-ui, sans-serif`);
+    if (Number.isFinite(value.fontScale)) style.setProperty('--host-scale', String(Math.max(.5, Math.min(3, value.fontScale))));
+    const color = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+    if (/^#[\da-f]{6}$/i.test(color)) {
+      const n = parseInt(color.slice(1), 16), light = ((n >> 16) * .2126 + ((n >> 8) & 255) * .7152 + (n & 255) * .0722) > 140;
+      style.colorScheme = light ? 'light' : 'dark';
+    }
+  }
+  function claims() {
+    if (!mini && ready && host?.body?.setInputClaims) host.body.setInputClaims(dialog.open || selection || focusId ? ['escapeKey'] : []);
+  }
+  function commit(next, remember = true) {
+    if (!ready || blocked || mini) return false;
+    try {
+      C.validate(next);
+      const previous = state;
+      // saveState is transport submission, not a durable disk-write acknowledgement.
+      host.saveState(next);
+      if (remember) history.push(previous);
+      state = next; original = state;
+      render();
+      return true;
+    } catch (error) { problem(error); return false; }
+  }
+  function undo(redo = false) {
+    const stack = redo ? history.future : history.past;
+    if (!stack.length) return;
+    const previous = state, entry = stack[stack.length - 1];
+    const next = { ...entry.state, view: state.view, filter: state.filter };
+    if (commit(next, false)) {
+      imageJob++;
+      if (redo) history.redo(previous); else history.undo(previous);
+      queue.request(); render();
+    }
+  }
+  function mount() {
+    if (mounted) return;
+    mounted = true;
+    app.innerHTML = `<div class="shell">
+      <div class="demo-banner" id="demo-banner" hidden data-i18n="demo"></div>
+      <header class="top">
+        <div class="brand-row"><div class="brand"><span class="brand-mark" aria-hidden="true">✦</span><span data-i18n="name"></span><span class="local-badge" data-i18n="local"></span></div>
+          <div class="actions"><button type="button" class="icon" id="undo" data-title="undo">↶</button><button type="button" class="icon" id="redo" data-title="redo">↷</button>
+            <details class="menu" id="menu"><summary data-title="more">⋯</summary><div class="menu-items">
+              <button type="button" id="export" data-i18n="export"></button><button type="button" id="import" data-i18n="import"></button><button type="button" id="export-svg" data-i18n="exportSvg"></button>
+              <label><input type="checkbox" id="wiki"><span data-i18n="wiki"></span></label><button type="button" id="help" data-i18n="help"></button>
+            </div></details></div></div>
+        <div class="intro"><h1 data-i18n="tagline"></h1><p data-i18n="savedByHost"></p></div>
+        <div class="tools"><div class="tabs" role="tablist"><button type="button" id="tab-map" role="tab" aria-controls="map-pane" data-i18n="map"></button><button type="button" id="tab-cards" role="tab" aria-controls="cards-pane" data-i18n="cards"></button></div>
+          <div class="actions"><button type="button" id="add-note" class="primary">＋ <span data-i18n="newNote"></span></button><button type="button" id="add-todo" class="secondary">＋ <span data-i18n="newTodo"></span></button></div></div>
+        <div class="search-row"><input id="search" type="search" autocomplete="off" data-title="search"><select id="filter" data-title="all"><option value="all" data-i18n="all"></option><option value="open" data-i18n="open"></option><option value="done" data-i18n="done"></option></select><button type="button" id="sources" class="source-button secondary" data-i18n="sources"></button><button type="button" id="refresh" class="icon" data-title="refresh">↻</button></div>
+      </header>
+      <div class="status-banner" id="status-banner" hidden data-i18n="stale"></div>
+      <main class="stage" id="stage">
+        <div class="map-pane" id="map-pane" role="tabpanel" aria-labelledby="tab-map"><svg id="canvas" role="region" tabindex="0" data-title="hint"><g id="world"></g></svg><div id="map-empty" class="empty" hidden></div>
+          <span class="map-hint" data-i18n="hint"></span><div class="map-controls"><button type="button" id="unfocus" hidden data-i18n="unfocus"></button><button type="button" id="zoom-out" data-title="zoomOut">−</button><button type="button" id="fit" data-i18n="fit"></button><button type="button" id="zoom-in" data-title="zoomIn">＋</button><button type="button" id="arrange" data-i18n="arrange"></button></div></div>
+        <div class="cards-pane" id="cards-pane" role="tabpanel" aria-labelledby="tab-cards" hidden><div class="card-grid" id="card-grid"></div><div class="empty" id="cards-empty" hidden></div></div>
+        <aside class="inspector" id="inspector" hidden></aside>
+      </main>
+      <footer class="bottom"><span id="stats"></span><span class="legend"><span data-i18n="knowledge"></span><span data-i18n="tasks"></span></span></footer>
+    </div>`;
+    $('demo-banner').hidden = !demo;
+    $('undo').onclick = () => undo(); $('redo').onclick = () => undo(true);
+    $('add-note').onclick = () => editNote(); $('add-todo').onclick = () => newTodo();
+    $('sources').onclick = chooseSources; $('refresh').onclick = () => queue.request();
+    $('search').addEventListener('input', e => { query = e.target.value; fitNeeded = true; render(); });
+    $('filter').onchange = e => { fitNeeded = true; commit({ ...state, filter: e.target.value }, false); };
+    for (const view of ['map', 'cards']) $(`tab-${view}`).onclick = () => { commit({ ...state, view }, false); schedulePaint(); };
+    $('fit').onclick = fitAll;
+    $('zoom-in').onclick = () => { camera = C.zoom(camera, 1.25, size.width / 2, size.height / 2); schedulePaint(); };
+    $('zoom-out').onclick = () => { camera = C.zoom(camera, .8, size.width / 2, size.height / 2); schedulePaint(); };
+    $('arrange').onclick = () => confirmDialog('arrange', 'arrangeHint', () => { fitNeeded = true; return commit({ ...state, positions: {} }); });
+    $('unfocus').onclick = () => { focusId = null; fitNeeded = true; render(); };
+    $('export').onclick = () => downloadJson(state);
+    $('import').onclick = () => { $('backup-file').value = ''; $('backup-file').click(); };
+    $('export-svg').onclick = exportMap;
+    $('wiki').onchange = e => commit({ ...state, wiki: e.target.checked });
+    $('help').onclick = () => openForm('help', area => { area.append(el('p', t('helpText')), el('p', t('savedByHost'), 'small')); if (demo) area.append(el('p', t('previewOnly'), 'small')); }, () => true, 'close');
+    $('menu').querySelectorAll('button').forEach(node => node.addEventListener('click', () => { $('menu').open = false; }));
+    bindCanvas();
+    resize = new ResizeObserver(() => {
+      if (state.view !== 'map' || !visible) return;
+      const rect = $('map-pane').getBoundingClientRect();
+      if (!rect.width || !rect.height) return;
+      camera.x += (rect.width - size.width) / 2; camera.y += (rect.height - size.height) / 2;
+      size = { width: rect.width, height: rect.height }; schedulePaint();
+    });
+    resize.observe($('map-pane'));
+    translate();
+  }
+  function rebuild() {
+    model = C.graph(state, papers, todos, sourceNotes); positions = C.layout(model, state.positions);
+    if (selection && !model.byId.has(selection)) selection = null;
+    if (focusId && !model.byId.has(focusId)) focusId = null;
+  }
+  function render() {
+    if (!ready || blocked) return;
+    app.setAttribute('aria-busy', 'false');
+    rebuild();
+    if (mini) { renderMini(); return; }
+    mount();
+    $('tab-map').setAttribute('aria-selected', state.view === 'map');
+    $('tab-cards').setAttribute('aria-selected', state.view === 'cards');
+    $('map-pane').hidden = state.view !== 'map'; $('cards-pane').hidden = state.view !== 'cards';
+    $('filter').value = state.filter; $('wiki').checked = state.wiki;
+    $('undo').disabled = !history.past.length; $('redo').disabled = !history.future.length;
+    $('add-todo').disabled = stale || pending.has('append');
+    $('status-banner').hidden = !stale; $('unfocus').hidden = !focusId;
+    const taskNodes = model.nodes.filter(n => n.kind === 'todo'), done = taskNodes.filter(n => n.done).length;
+    const ideas = model.nodes.filter(n => n.kind === 'note' || n.kind === 'note-ref').length;
+    $('stats').textContent = `${ideas} ${t('knowledge')} · ${done}/${taskNodes.length} ${t('tasks')} · ${state.sources.length} ${t('papers')}`;
+    if (visible) { if (state.view === 'cards') renderCards(); renderInspector(); schedulePaint(); }
+    const caption = `${t('name')} · ${taskNodes.length - done} ${t('open')} · ${ideas} ${t('knowledge')}`;
+    host.paper.setHeaderText(caption);
+    host.paper.setCapsulePresentation({ preferredWidth: 0, plainText: caption, components: [{ kind: 'text', text: `✦ ${taskNodes.length - done} · ${ideas}`, fill: true }] });
+    claims();
+  }
+  function emptyContent(container, filtered = false, cards = false) {
+    container.replaceChildren(el('div', '✦', 'empty-mark'), el('h2', t(filtered ? 'noMatch' : cards ? 'noTasks' : 'emptyTitle')), el('p', t('emptyText')));
+    const actions = el('div', undefined, 'actions');
+    if (filtered) actions.append(button(t('clearFilter'), () => { query = ''; $('search').value = ''; focusId = null; fitNeeded = true; commit({ ...state, filter: 'all' }, false); }, 'secondary'));
+    else actions.append(button(t(cards ? 'newTodo' : 'newNote'), () => cards ? newTodo() : editNote(), 'primary'), button(t('sources'), chooseSources, 'secondary'));
+    container.append(actions);
+  }
+  function renderCards() {
+    const nodes = C.visibleGraph(model, state.filter, query).nodes.filter(n => n.kind === 'todo');
+    const focused = document.activeElement, focusedId = focused?.closest('[data-card]')?.dataset.card;
+    const focusedAction = focused?.dataset.action;
+    const grid = $('card-grid'); grid.replaceChildren();
+    $('cards-empty').hidden = nodes.length !== 0;
+    if (!nodes.length) emptyContent($('cards-empty'), !!query || state.filter !== 'all', true);
+    for (const node of nodes) {
+      const card = el('article', undefined, `task-card${node.done ? ' done' : ''}${selection === node.id ? ' selected' : ''}`);
+      const cover = button('', () => select(node.id), 'card-art'); cover.setAttribute('aria-label', nodeTitle(node));
+      const img = el('img'); img.src = image(node); img.alt = ''; img.loading = 'lazy'; img.width = 320; img.height = 210; cover.append(img);
+      const content = el('div', undefined, 'card-content');
+      content.append(el('div', node.todo.paperTitle || t('untitled'), 'card-meta'), button(node.title, () => select(node.id), 'card-title'), completion(node));
+      card.dataset.card = node.id; card.append(cover, content); grid.append(card);
+      if (focusedId === node.id && focusedAction === 'completion') card.querySelector('[data-action=completion]').focus({ preventScroll: true });
+    }
+  }
+  function completion(node) {
+    const control = button('', () => mutate(node.id, 'todos.update', { paperId: node.todo.paperId, todoId: node.todo.id, done: !node.done }), 'completion');
+    control.dataset.action = 'completion';
+    control.setAttribute('role', 'checkbox'); control.setAttribute('aria-checked', String(node.done));
+    control.setAttribute('aria-label', `${t(node.done ? 'reopen' : 'complete')}: ${node.title}`);
+    control.disabled = stale || pending.has(node.id);
+    if (pending.has(node.id)) control.setAttribute('aria-busy', 'true');
+    control.append(el('span', pending.has(node.id) ? '·' : node.done ? '✓' : '', 'checkmark'), el('span', t(node.done ? 'done' : 'open')));
+    return control;
+  }
+  function select(id) { selection = id; render(); }
+  function renderInspector() {
+    const area = $('inspector'), node = model.byId.get(selection);
+    area.hidden = !node; area.replaceChildren(); if (!node) return;
+    const heading = el('div', undefined, 'inspector-head');
+    heading.append(el('span', t(['note', 'note-ref'].includes(node.kind) ? 'knowledge' : node.kind === 'todo' ? 'tasks' : node.kind === 'paper' ? 'papers' : 'unavailable')), button('×', () => { selection = null; render(); }, 'icon'));
+    heading.lastChild.setAttribute('aria-label', t('close')); area.append(heading);
+    if (['note', 'note-ref', 'todo'].includes(node.kind)) {
+      const img = el('img', undefined, 'inspector-art'); img.src = image(node); img.alt = ''; area.append(img);
+    }
+    area.append(el('h2', nodeTitle(node)));
+    if (node.kind === 'todo') area.append(el('p', node.todo.paperTitle || t('untitled'), 'small'), completion(node));
+    if (node.missing) area.append(el('p', t('missingHint'), 'small'));
+    if (node.kind === 'note-ref') area.append(el('p', t('readOnlyNote'), 'small'));
+    if (node.unavailable) area.append(el('p', t('unavailable'), 'small'));
+    if (['note', 'note-ref'].includes(node.kind) && node.body) area.append(el('div', node.body, 'inspector-text'));
+    const actions = el('div', undefined, 'actions');
+    if (node.kind === 'note' || node.kind === 'todo') {
+      const edit = button(t('edit'), () => node.kind === 'note' ? editNote(node) : editTodo(node), 'secondary');
+      edit.disabled = node.kind === 'todo' && (stale || pending.has(node.id)); actions.append(edit);
+    }
+    actions.append(button(t('link'), () => editLink(node.id), 'secondary'));
+    actions.append(button(t(focusId === node.id ? 'unfocus' : 'focus'), () => { focusId = focusId === node.id ? null : node.id; fitNeeded = true; render(); }, 'secondary'));
+    area.append(actions);
+    if (['note', 'note-ref', 'todo'].includes(node.kind)) {
+      const section = el('section'); section.append(el('h3', t('illustration')));
+      const picker = el('select'); picker.setAttribute('aria-label', t('illustration'));
+      C.SCENES.forEach(value => { const option = el('option', t(value === 'focus' ? 'focusScene' : value)); option.value = value; picker.append(option); });
+      picker.value = scene(node);
+      picker.onchange = () => { imageJob++; commit({ ...state, covers: { ...state.covers, [node.id]: { scene: picker.value } } }); };
+      section.append(picker, button(t('image'), () => { imageTarget = node.id; $('image-file').value = ''; $('image-file').click(); }, 'secondary wide'), el('p', t('imageHint'), 'small'));
+      section.append(button(t('resetCover'), () => { imageJob++; const covers = { ...state.covers }; delete covers[node.id]; commit({ ...state, covers }); }, 'wide'));
+      section.append(button(t('exportCard'), () => exportCard(node).catch(problem), 'wide'));
+      area.append(section);
+    }
+    const links = model.edges.filter(e => e.from === node.id || e.to === node.id);
+    if (links.length) {
+      const section = el('section'); section.append(el('h3', t('related')));
+      links.forEach(edge => {
+        const target = model.byId.get(edge.from === node.id ? edge.to : edge.from), row = el('div', undefined, 'connection');
+        const targetButton = button(nodeTitle(target), () => select(target.id), 'link-target');
+        targetButton.title = nodeTitle(target); targetButton.append(el('small', edge.label || t(edge.kind === 'contains' ? 'contains' : edge.kind === 'wiki' ? 'reference' : 'manual')));
+        row.append(targetButton);
+        if (edge.kind === 'manual') {
+          const remove = button('×', () => commit({ ...state, links: state.links.filter(e => C.pair(e.from, e.to) !== C.pair(edge.from, edge.to)) }), 'icon');
+          remove.setAttribute('aria-label', t('unlink')); row.append(remove);
+        }
+        section.append(row);
+      });
+      area.append(section);
+    }
+    if (node.kind === 'note') {
+      const section = el('section'); section.append(button(t('remove'), () => confirmDialog('remove', 'removeHint', () => commit(C.removeNote(state, node.id)), true), 'danger wide')); area.append(section);
+    }
+  }
+  function schedulePaint() {
+    if (frame || !visible || mini || !mounted || state.view !== 'map') return;
+    frame = requestAnimationFrame(() => { frame = 0; paint(); });
+  }
+  function fitAll() { fitNeeded = true; schedulePaint(); }
+  function paint() {
+    if (!visible || state.view !== 'map' || !mounted) return;
+    const rect = $('map-pane').getBoundingClientRect(); if (!rect.width || !rect.height) return;
+    size = { width: rect.width, height: rect.height };
+    const filtered = C.visibleGraph(model, state.filter, query, focusId);
+    if (fitNeeded) { camera = C.fit(filtered.nodes, positions, size.width, size.height); fitNeeded = false; }
+    $('map-empty').hidden = filtered.nodes.length !== 0;
+    if (!filtered.nodes.length) emptyContent($('map-empty'), !!query || state.filter !== 'all' || !!focusId);
+    const world = $('world');
+    const activeId = document.activeElement?.dataset?.node;
+    world.replaceChildren(); world.setAttribute('transform', `translate(${camera.x} ${camera.y}) scale(${camera.k})`);
+    const visibleIds = new Set(filtered.nodes.filter(node => {
+      const p = positions.get(node.id), x = p.x * camera.k + camera.x, y = p.y * camera.k + camera.y;
+      return x > -150 && y > -100 && x < size.width + 150 && y < size.height + 100;
+    }).map(n => n.id));
+    for (const edge of filtered.edges) {
+      const a = positions.get(edge.from), b = positions.get(edge.to);
+      // Cull only offscreen geometry, never truncate the graph's data.
+      if (!visibleIds.has(edge.from) && !visibleIds.has(edge.to)) {
+        const left = Math.min(a.x, b.x) * camera.k + camera.x, right = Math.max(a.x, b.x) * camera.k + camera.x;
+        const top = Math.min(a.y, b.y) * camera.k + camera.y, bottom = Math.max(a.y, b.y) * camera.k + camera.y;
+        if (right < 0 || left > size.width || bottom < 0 || top > size.height) continue;
+      }
+      const highlight = selection === edge.from || selection === edge.to;
+      world.append(svgEl('line', { x1: a.x, y1: a.y, x2: b.x, y2: b.y, class: `edge ${edge.kind}${highlight ? ' highlight' : ''}` }));
+      if (edge.label && highlight && camera.k > .35) world.append(svgEl('text', { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 - 7, class: 'edge-label' }, short(edge.label, 24)));
+    }
+    let index = 0;
+    for (const node of filtered.nodes) {
+      if (!visibleIds.has(node.id)) continue;
+      const p = positions.get(node.id), colors = A.palette(scene(node)), radius = node.kind === 'paper' ? 30 : ['note', 'note-ref'].includes(node.kind) ? 26 : 22;
+      const g = svgEl('g', { transform: `translate(${p.x} ${p.y})`, class: `node ${node.kind}${node.done ? ' done' : ''}${selection === node.id ? ' selected' : ''}`, role: 'button', tabindex: '0', 'data-node': node.id, 'aria-label': nodeTitle(node) });
+      g.append(svgEl('title', {}, nodeTitle(node)), svgEl('circle', { r: radius + 8, class: 'halo' }));
+      g.append(svgEl('circle', { r: radius, fill: node.kind === 'paper' ? 'var(--wash)' : colors[0], stroke: node.kind === 'paper' ? 'var(--accent)' : colors[2], 'stroke-width': 1.6 }));
+      if (node.kind === 'todo' && camera.k > .3) {
+        const clipId = `star-clip-${index++}`, clip = svgEl('clipPath', { id: clipId }); clip.append(svgEl('circle', { r: radius - 1 })); g.append(clip);
+        g.append(svgEl('image', { href: image(node), x: -radius, y: -radius, width: radius * 2, height: radius * 2, preserveAspectRatio: 'xMidYMid slice', 'clip-path': `url(#${clipId})` }));
+        if (node.done) g.append(svgEl('text', { y: 1, class: 'node-symbol', fill: colors[1] }, '✓'));
+      } else g.append(svgEl('text', { y: 1, class: 'node-symbol', fill: colors[1] }, ['note', 'note-ref'].includes(node.kind) ? '✦' : node.kind === 'paper' ? '▤' : node.kind === 'missing' ? '?' : node.done ? '✓' : '·'));
+      if (camera.k > .22 || selection === node.id) g.append(svgEl('text', { y: radius + 21, class: 'node-label', style: `font-size:${Math.max(12, 10 / camera.k)}px` }, short(nodeTitle(node))));
+      world.append(g);
+      if (activeId === node.id) g.focus({ preventScroll: true });
+    }
+  }
+  function localPoint(event) { const r = $('canvas').getBoundingClientRect(); return { x: event.clientX - r.left, y: event.clientY - r.top }; }
+  function cancelDrag() {
+    if (!drag) return;
+    const pointer = drag.pointer; drag = null; rebuild();
+    if ($('canvas')) { $('canvas').classList.remove('dragging'); if ($('canvas').hasPointerCapture(pointer)) $('canvas').releasePointerCapture(pointer); }
+    schedulePaint();
+  }
+  function bindCanvas() {
+    const canvas = $('canvas');
+    canvas.addEventListener('pointerdown', e => {
+      if (e.button !== 0 || drag) return;
+      const node = e.target.closest('[data-node]');
+      if (node) node.focus({ preventScroll: true }); else canvas.focus({ preventScroll: true });
+      drag = { pointer: e.pointerId, x: e.clientX, y: e.clientY, key: node?.dataset.node, camera: { ...camera }, pos: node ? { ...positions.get(node.dataset.node) } : null, moved: false, generation };
+
+    });
+    canvas.addEventListener('pointermove', e => {
+      if (!drag || drag.pointer !== e.pointerId) return;
+      const dx = e.clientX - drag.x, dy = e.clientY - drag.y;
+      if (!drag.moved && Math.hypot(dx, dy) < 4) return;
+      if (!canvas.hasPointerCapture(e.pointerId)) canvas.setPointerCapture(e.pointerId);
+      drag.moved = true; canvas.classList.add('dragging');
+      if (drag.key) positions.set(drag.key, { x: drag.pos.x + dx / camera.k, y: drag.pos.y + dy / camera.k });
+      else camera = { ...drag.camera, x: drag.camera.x + dx, y: drag.camera.y + dy };
+      schedulePaint();
+    });
+    canvas.addEventListener('pointerup', e => {
+      if (!drag || drag.pointer !== e.pointerId) return;
+      const completed = drag, position = completed.key ? positions.get(completed.key) : null;
+      drag = null; canvas.classList.remove('dragging');
+      if (canvas.hasPointerCapture(e.pointerId)) canvas.releasePointerCapture(e.pointerId);
+      if (completed.moved) {
+        suppressClick = true; setTimeout(() => { suppressClick = false; }, 80);
+        if (completed.key && completed.generation === generation) {
+          if (!commit({ ...state, positions: { ...state.positions, [completed.key]: position } })) { rebuild(); schedulePaint(); }
+        }
+      }
+    });
+    canvas.addEventListener('pointercancel', cancelDrag);
+    canvas.addEventListener('pointerleave', () => { if (drag && !canvas.hasPointerCapture(drag.pointer)) cancelDrag(); });
+    canvas.addEventListener('lostpointercapture', cancelDrag);
+    canvas.addEventListener('click', e => {
+      if (suppressClick) return;
+      const node = e.target.closest('[data-node]');
+      if (!node) { selection = null; render(); return; }
+      const key = node.dataset.node;
+      if (e.shiftKey && selection && selection !== key) commit(C.setLink(state, selection, key));
+      else select(key);
+    });
+    canvas.addEventListener('dblclick', e => {
+      if (e.target.closest('[data-node]')) return;
+      const p = localPoint(e); editNote(null, { x: (p.x - camera.x) / camera.k, y: (p.y - camera.y) / camera.k });
+    });
+    canvas.addEventListener('wheel', e => {
+      e.preventDefault(); const p = localPoint(e);
+      camera = C.zoom(camera, Math.exp(-e.deltaY * (e.deltaMode === 1 ? .04 : .0015)), p.x, p.y); schedulePaint();
+    }, { passive: false });
+  }
+  function closeDialog() {
+    if (dialog.open) dialog.close(); claims();
+    if (lastFocused?.isConnected) lastFocused.focus({ preventScroll: true });
+  }
+  function openForm(titleKey, build, submit, submitKey = 'save', danger = false) {
+    if (mini || blocked) return;
+    if (dialog.open) dialog.close();
+    lastFocused = document.activeElement;
+    dialog.replaceChildren();
+    const form = el('form'), head = el('div', undefined, 'dialog-head'), area = el('div'), actions = el('div', undefined, 'dialog-actions');
+    head.append(el('h2', t(titleKey)), button('×', closeDialog, 'icon')); head.lastChild.setAttribute('aria-label', t('close'));
+    const submitButton = el('button', t(submitKey), danger ? 'danger' : 'primary'); submitButton.type = 'submit';
+    actions.append(button(t('cancel'), closeDialog, 'secondary'), submitButton);
+    form.append(head, area, actions); dialog.append(form); build(area);
+    form.addEventListener('submit', async e => {
+      e.preventDefault(); if (submitButton.disabled || !form.reportValidity()) return;
+      submitButton.disabled = true;
+      try { if (await submit(area)) { if (dialog.contains(form)) closeDialog(); } }
+      catch (error) { problem(error); }
+      finally { submitButton.disabled = false; }
+    });
+    dialog.showModal(); claims();
+  }
+  function confirmDialog(title, body, action, danger = false) {
+    openForm(title, area => area.append(el('p', t(body))), action, 'save', danger);
+  }
+  function field(area, caption, tag = 'input', value = '') {
+    const label = el('label', undefined, 'field'); label.append(el('span', t(caption)));
+    const input = el(tag); input.value = value; label.append(input); area.append(label); return input;
+  }
+  async function chooseSources() {
+    await queue.request();
+    if (stale) { toast('stale'); return; }
+    const choices = new Map();
+    openForm('sources', area => {
+      area.append(el('p', t('sourceHint'), 'small'));
+      if (!papers.length) area.append(el('p', t('noPaper')));
+      const list = el('div', undefined, 'source-list');
+      const available = papers.map(p => ({ id: p.id, title: p.title || t('untitled') }));
+      state.sources.filter(id => !papers.some(p => p.id === id)).forEach(id => available.push({ id, title: `${t('unavailable')} · ${short(id, 12)}` }));
+      available.forEach(paper => {
+        const label = el('label', undefined, 'source-option'), input = el('input'); input.type = 'checkbox'; input.checked = state.sources.includes(paper.id);
+        choices.set(paper.id, input); label.append(input, el('span', paper.title)); list.append(label);
+      });
+      area.append(list);
+    }, () => {
+      const sources = [...choices].filter(([, input]) => input.checked).map(([key]) => key);
+      if (!commit({ ...state, sources })) return false;
+      fitNeeded = true; queue.request(); return true;
+    });
+  }
+  function editNote(node = null, point = null) {
+    let title, body;
+    const baseline = node ? JSON.stringify(state.notes.find(n => n.id === node.id)) : null;
+    openForm(node ? 'edit' : 'newNote', area => {
+      title = field(area, 'title', 'input', node?.title || ''); title.required = true;
+      body = field(area, 'body', 'textarea', node?.body || '');
+    }, () => {
+      if (!title.value.trim()) { title.focus(); return false; }
+      if (node && baseline !== JSON.stringify(state.notes.find(n => n.id === node.id))) { toast('conflict'); return false; }
+      const id = node?.id || `n:${crypto.randomUUID()}`;
+      const note = { id, title: title.value.trim(), body: body.value };
+      const next = { ...state, notes: node ? state.notes.map(n => n.id === id ? note : n) : [...state.notes, note] };
+      if (point) next.positions = { ...state.positions, [id]: point };
+      if (!commit(next)) return false;
+      selection = id; if (!point && !node) fitNeeded = true; render(); return true;
+    });
+  }
+  function newTodo() {
+    if (stale) { toast('stale'); return; }
+    const targets = papers.filter(p => p.type === 'todo' && state.sources.includes(p.id));
+    if (!targets.length) { chooseSources(); return; }
+    let paper, text;
+    openForm('newTodo', area => {
+      paper = field(area, 'papers', 'select');
+      targets.forEach(p => { const option = el('option', p.title || t('untitled')); option.value = p.id; paper.append(option); });
+      text = field(area, 'title'); text.required = true;
+    }, async () => {
+      if (!text.value.trim()) { text.focus(); return false; }
+      return mutate('append', 'todos.append', { paperId: paper.value, todos: [{ text: text.value.trim() }] });
+    });
+  }
+  function editTodo(node) {
+    let text;
+    const baseline = node.todo.text;
+    openForm('edit', area => { text = field(area, 'title', 'textarea', baseline); text.required = true; }, async () => {
+      if (!text.value.trim()) { text.focus(); return false; }
+      await queue.request();
+      const latest = model.byId.get(node.id);
+      if (stale || latest?.kind !== 'todo' || latest.todo.text !== baseline) { toast('conflict'); return false; }
+      return mutate(node.id, 'todos.update', { paperId: node.todo.paperId, todoId: node.todo.id, text: text.value });
+    });
+  }
+  function editLink(from) {
+    const candidates = model.nodes.filter(n => n.id !== from);
+    if (!candidates.length) { toast('noTarget'); return; }
+    let target, label;
+    openForm('link', area => {
+      target = field(area, 'target', 'select');
+      candidates.forEach(node => { const option = el('option', nodeTitle(node)); option.value = node.id; target.append(option); });
+      label = field(area, 'relation');
+    }, () => {
+      if (!model.byId.has(from) || !model.byId.has(target.value)) { toast('conflict'); return false; }
+      return commit(C.setLink(state, from, target.value, label.value));
+    });
+  }
+  async function mutate(key, method, params) {
+    if (!ready || blocked || mini || stale || pending.has(key)) return false;
+    const restoreTaskFocus = document.activeElement?.dataset.action === 'completion' && document.activeElement?.closest('[data-card]')?.dataset.card === key;
+    pending.add(key); render();
+    try {
+      await host.workspace.request(method, params);
+      await queue.request();
+      return true;
+    } catch (error) {
+      stale = true;
+      toast('operationFailed', error?.code || error?.message || '');
+      // A timeout can mean "committed, acknowledgement lost". Read only; never replay a mutation.
+      await queue.request();
+      return false;
+    } finally {
+      pending.delete(key); render();
+      if (restoreTaskFocus && document.activeElement === document.body) {
+        const card = [...document.querySelectorAll('[data-card]')].find(card => card.dataset.card === key);
+        card?.querySelector('[data-action=completion]')?.focus({ preventScroll: true });
+      }
+    }
+  }
+  function loadImage(source) {
+    return new Promise((resolve, reject) => {
+      const img = new Image(); img.onload = () => resolve(img); img.onerror = () => reject(new Error('invalidImage')); img.src = source;
+    });
+  }
+  async function compressImage(file) {
+    if (!file || !/^image\/(png|jpeg|webp|gif)$/.test(file.type)) throw new Error('invalidImage');
+    if (file.size > 20 * 1024 * 1024) throw new Error('imageTooLarge');
+    const url = URL.createObjectURL(file);
+    try {
+      const img = await loadImage(url);
+      if (!img.naturalWidth || img.naturalWidth * img.naturalHeight > 32e6) throw new Error('imageTooLarge');
+      const canvas = document.createElement('canvas');
+      let ratio = Math.min(1, 1024 / Math.max(img.naturalWidth, img.naturalHeight));
+      // Covers need thumbnail quality, not a second full-resolution photo library.
+      for (let attempt = 0; attempt < 5; attempt++) {
+        canvas.width = Math.max(1, Math.round(img.naturalWidth * ratio)); canvas.height = Math.max(1, Math.round(img.naturalHeight * ratio));
+        canvas.getContext('2d').drawImage(img, 0, 0, canvas.width, canvas.height);
+        const data = canvas.toDataURL('image/webp', .82);
+        if (C.bytes(data) <= 512 * 1024) return data;
+        ratio *= .7;
+      }
+      throw new Error('imageTooLarge');
+    } finally { URL.revokeObjectURL(url); }
+  }
+  async function attachImage(file, target) {
+    const node = model.byId.get(target);
+    if (!node || !['note', 'todo', 'note-ref'].includes(node.kind)) { toast('selectedImage'); return; }
+    const job = ++imageJob, version = generation;
+    try {
+      const data = await compressImage(file);
+      if (job !== imageJob || version !== generation || !model.byId.has(target)) return;
+      commit({ ...state, covers: { ...state.covers, [target]: { scene: scene(model.byId.get(target)), image: data } } });
+    } catch (error) { problem(error); }
+  }
+  function download(content, type, name) {
+    const blob = content instanceof Blob ? content : new Blob([content], { type });
+    const url = URL.createObjectURL(blob), link = el('a'); link.href = url; link.download = name;
+    document.body.append(link); link.click(); link.remove(); setTimeout(() => URL.revokeObjectURL(url), 60000);
+  }
+  function downloadJson(value) {
+    download(JSON.stringify({ format: 'papertodo.starpaper', version: 1, state: value }), 'application/json', 'Starpaper-backup.json');
+  }
+  async function importBackup(file) {
+    if (!file) return;
+    try {
+      if (file.size > C.MAX_BYTES * 2) throw new Error('capacity'); // pretty-printed export can exceed compact JSON size
+      const value = JSON.parse(await file.text());
+      if (value.format !== 'papertodo.starpaper' || value.version !== 1) throw new Error('stateVersion');
+      const imported = C.validate(value.state);
+      confirmDialog('import', 'importHint', () => {
+        if (!commit(imported)) return false;
+        imageJob++; selection = null; focusId = null; query = ''; $('search').value = ''; fitNeeded = true;
+        queue.request(); render(); return true;
+      });
+    } catch (error) { problem(error); }
+  }
+  function exportMap() {
+    const filtered = C.visibleGraph(model, state.filter, query, focusId);
+    if (!filtered.nodes.length) { toast('noMatch'); return; }
+    const xs = filtered.nodes.map(n => positions.get(n.id).x), ys = filtered.nodes.map(n => positions.get(n.id).y);
+    const x = xs.reduce((a, b) => Math.min(a, b), Infinity) - 140, y = ys.reduce((a, b) => Math.min(a, b), Infinity) - 100;
+    const width = xs.reduce((a, b) => Math.max(a, b), -Infinity) - x + 140, height = ys.reduce((a, b) => Math.max(a, b), -Infinity) - y + 130;
+    const svg = svgEl('svg', { xmlns: NS, viewBox: `${x} ${y} ${width} ${height}`, width: Math.ceil(width), height: Math.ceil(height) });
+    const style = getComputedStyle(document.documentElement), paper = style.getPropertyValue('--paper').trim(), text = style.getPropertyValue('--text').trim(), accent = style.getPropertyValue('--accent').trim();
+    svg.append(svgEl('title', {}, t('map')), svgEl('rect', { x, y, width, height, fill: paper }));
+    filtered.edges.forEach(edge => {
+      const a = positions.get(edge.from), b = positions.get(edge.to);
+      const line = svgEl('line', { x1: a.x, y1: a.y, x2: b.x, y2: b.y, stroke: accent, 'stroke-opacity': '.45', 'stroke-width': 1.5 });
+      if (edge.kind !== 'manual') line.setAttribute('stroke-dasharray', '4 5');
+      svg.append(line);
+      if (edge.label) svg.append(svgEl('text', { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 - 5, fill: text, 'font-size': 11, 'text-anchor': 'middle' }, edge.label));
+    });
+    filtered.nodes.forEach(node => {
+      const p = positions.get(node.id), group = svgEl('g'); group.append(svgEl('title', {}, nodeTitle(node)));
+      group.append(svgEl('circle', { cx: p.x, cy: p.y, r: 23, fill: A.palette(scene(node))[0], stroke: accent, 'stroke-width': 1.5 }));
+      group.append(svgEl('text', { x: p.x, y: p.y + 6, 'text-anchor': 'middle', 'font-size': 18, fill: accent }, node.done ? '✓' : node.kind === 'paper' ? '▤' : '✦'));
+      group.append(svgEl('text', { x: p.x, y: p.y + 47, 'text-anchor': 'middle', 'font-family': 'sans-serif', 'font-size': 13, fill: text }, short(nodeTitle(node), 34)));
+      svg.append(group);
+    });
+    download(new XMLSerializer().serializeToString(svg), 'image/svg+xml', 'Starpaper-map.svg');
+  }
+  async function exportCard(node) {
+    const source = image(node), title = nodeTitle(node), subtitle = node.todo?.paperTitle || t('knowledge');
+    const img = await loadImage(source), canvas = document.createElement('canvas'); canvas.width = 960; canvas.height = 1120;
+    const ctx = canvas.getContext('2d'), colors = A.palette(scene(node));
+    ctx.fillStyle = '#fcfaf5'; ctx.fillRect(0, 0, 960, 1120);
+    const ratio = Math.max(960 / img.width, 630 / img.height), w = img.width * ratio, h = img.height * ratio;
+    ctx.save(); ctx.beginPath(); ctx.rect(0, 0, 960, 630); ctx.clip(); ctx.drawImage(img, (960 - w) / 2, (630 - h) / 2, w, h); ctx.restore();
+    ctx.fillStyle = colors[1]; ctx.font = '24px sans-serif'; ctx.fillText(short(subtitle, 38), 70, 698);
+    ctx.fillStyle = '#343c38'; ctx.font = '38px sans-serif';
+    const words = typeof Intl.Segmenter === 'function' ? [...new Intl.Segmenter(locale, { granularity: 'grapheme' }).segment(title)].map(s => s.segment) : [...title];
+    const lines = []; let line = '';
+    words.forEach(char => {
+      if (char === '\n' || ctx.measureText(line + char).width > 820) { lines.push(line); line = char === '\n' ? '' : char; }
+      else line += char;
+    });
+    if (line) lines.push(line);
+    lines.slice(0, 5).forEach((value, i) => ctx.fillText(i === 4 && lines.length > 5 ? short(value, Math.max(1, [...value].length - 1)) + '…' : value, 70, 764 + i * 52));
+    ctx.fillStyle = colors[1]; ctx.font = '23px sans-serif'; ctx.fillText(node.done ? `✓ ${t('done')}` : '✦ Starpaper', 70, 1054);
+    const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+    if (!blob) throw new Error('invalidImage');
+    download(blob, 'image/png', 'Starpaper-card.png');
+  }
+
+  async function loadWorkspace() {
+    // Only paper metadata is read before the user chooses sources. No all-workspace todo scan.
+    const sources = [...state.sources];
+    const all = await host.workspace.request('papers.list');
+    if (!Array.isArray(all) || all.some(p => typeof p.id !== 'string' || typeof p.type !== 'string' || typeof p.title !== 'string')) throw new Error('protocolData');
+    const nextPapers = all.filter(p => p.type === 'todo' || (p.type === 'note' && p.bodyProviderId === 'builtin.markdown'));
+    const nextTodos = [], nextNotes = [];
+    for (const paper of nextPapers.filter(p => sources.includes(p.id))) {
+      if (paper.type === 'todo') {
+        const items = await host.workspace.request('todos.list', { paperId: paper.id, includeBlank: false });
+        if (!Array.isArray(items) || items.some(item => item.paperId !== paper.id || typeof item.id !== 'string' || typeof item.text !== 'string' || typeof item.done !== 'boolean')) throw new Error('protocolData');
+        nextTodos.push(...items);
+      } else {
+        const note = await host.workspace.request('notes.get', { paperId: paper.id });
+        if (note && (note.paperId !== paper.id || typeof note.contentAvailable !== 'boolean' || typeof note.content !== 'string')) throw new Error('protocolData');
+        if (note) nextNotes.push(note);
+      }
+    }
+    return { papers: nextPapers, todos: nextTodos, sourceNotes: nextNotes };
+  }
+  function renderMini() {
+    const box = el('main', undefined, 'mini'), head = el('div', undefined, 'mini-head');
+    head.append(el('strong', '✦ ' + t('name')), el('span', t('local'))); box.append(head);
+    const tasks = model.nodes.filter(n => n.kind === 'todo'), open = tasks.filter(n => !n.done);
+    const ideas = model.nodes.filter(n => n.kind === 'note' || n.kind === 'note-ref');
+    const counts = el('div'); counts.append(el('span', String(open.length), 'mini-count'), el('span', t('open') + ' · ' + ideas.length + ' ' + t('knowledge'), 'small')); box.append(counts);
+    const list = (open.length ? open : ideas).slice(0, 3);
+    list.forEach(node => { const row = el('div', undefined, 'mini-row'), img = el('img'); img.src = image(node); img.alt = ''; row.append(img, el('span', nodeTitle(node))); box.append(row); });
+    if (!list.length) box.append(el('p', t('emptyTitle'), 'small'));
+    if (stale) box.append(el('p', t('stale'), 'small'));
+    app.replaceChildren(box);
+    publishMiniReady();
+  }
+  function publishMiniReady() {
+    if (!mini || miniReady || (!workspaceLoaded && !blocked)) return;
+    miniReady = true;
+    // The host owns publication/visibility. Signal only after our own first real layout.
+    requestAnimationFrame(() => { if (ready) { app.getBoundingClientRect(); host.mini.ready(); } });
+  }
+  function blockState(error) {
+    blocked = true; imageJob++; generation++; cancelDrag();
+    queue?.dispose(); unsubscribe?.(); unsubscribe = null; resize?.disconnect();
+    cancelAnimationFrame(frame); frame = 0; closeDialog();
+    const panel = el('main', undefined, 'empty'); panel.append(el('h2', t('invalidState')), el('p', t(I.rows[error?.message] ? error.message : 'invalidState')));
+    if (!mini) panel.append(button(t('export'), () => downloadJson(original), 'primary'));
+    app.replaceChildren(panel); mounted = false; publishMiniReady();
+  }
+  function initialize(message) {
+    host = window.papertodo || host;
+    if (!host) return;
+    queue?.dispose(); unsubscribe?.(); unsubscribe = null; resize?.disconnect();
+    generation++; imageJob++; pending.clear(); history.clear();
+    ready = true; blocked = false; workspaceLoaded = false; mini = message.surface === 'mini' || host.surface === 'mini';
+    visible = message.visible !== false; original = message.state;
+    locale = I.language(message.settings?.language, navigator.language); t = I.translator(locale); theme(message.theme);
+    try { state = C.validate(message.state); } catch (error) { blockState(error); return; }
+    if (!mini) {
+      // A provider is only registered after validation. It must never flush a guessed empty state.
+      host.registerStateProvider(() => { if (blocked) throw new Error('invalidState'); return state; });
+    }
+    queue = new C.RefreshQueue(loadWorkspace, snapshot => {
+      papers = snapshot.papers; todos = snapshot.todos; sourceNotes = snapshot.sourceNotes; stale = false; workspaceLoaded = true; render();
+    }, () => { stale = true; workspaceLoaded = true; render(); });
+    if (!mini && host.onHostEvent) {
+      unsubscribe = host.onHostEvent(['paper.created', 'paper.changed', 'paper.deleted', 'todo.created', 'todo.changed', 'todo.deleted', 'note.changed'], () => { if (visible && !blocked) queue.request(); }, { excludeOwnOperations: false });
+    }
+    mounted = false; fitNeeded = true; selection = null; focusId = null; render(); queue.request();
+  }
+  function onMessage(message) {
+    if (!message || typeof message.type !== 'string') return;
+    if (message.type === 'initialize') { initialize(message); return; }
+    if (!ready) return;
+    if (message.type === 'stateChanged') {
+      original = message.state;
+      if (blocked) return; // Recovery requires reopening the document, not an automatic overwrite.
+      try {
+        const next = C.validate(message.state);
+        if (JSON.stringify(next) === JSON.stringify(state)) return;
+        cancelDrag(); state = next; generation++; imageJob++; history.clear(); fitNeeded = true;
+        render(); queue.request(); // Never echo a received state back to the host.
+      } catch (error) { blockState(error); }
+    } else if (message.type === 'settingsChanged') {
+      locale = I.language(message.settings?.language, navigator.language); t = I.translator(locale); translate(); render();
+    } else if (message.type === 'themeChanged' || message.type === 'typographyChanged') {
+      theme(message.theme); render();
+    } else if (message.type === 'visibilityChanged') {
+      visible = message.visible !== false;
+      if (!visible) { cancelDrag(); cancelAnimationFrame(frame); frame = 0; }
+      else { render(); if (!blocked) queue.request(); }
+    } else if (message.type === 'activated') {
+      if (!blocked) queue.request();
+    } else if (message.type === 'cancelInteractions' || message.type === 'deactivated') {
+      cancelDrag();
+    } else if (message.type === 'hostSubscriptionError') {
+      stale = true; render(); toast('stale');
+    }
+  }
+  window.addEventListener('papertodo', event => onMessage(event.detail));
+  dialog.addEventListener('close', claims);
+  dialog.addEventListener('cancel', event => { event.preventDefault(); closeDialog(); });
+  function isEditing(target) { return !!target?.closest('input, textarea, select, [contenteditable="true"]'); }
+  document.addEventListener('keydown', event => {
+    if (!ready || blocked || mini || event.isComposing) return;
+    if (event.key === 'Escape') {
+      if (dialog.open) { event.preventDefault(); closeDialog(); }
+      else if (selection || focusId || drag) { event.preventDefault(); cancelDrag(); selection = null; focusId = null; render(); }
+      return;
+    }
+    if (dialog.open || isEditing(event.target)) return;
+    if ((event.ctrlKey || event.metaKey) && ['z', 'y'].includes(event.key.toLowerCase())) {
+      event.preventDefault(); undo(event.key.toLowerCase() === 'y' || event.shiftKey); return;
+    }
+    const node = event.target.closest('#canvas [data-node]');
+    if (node && (event.key === 'Enter' || event.key === ' ')) { event.preventDefault(); select(node.dataset.node); return; }
+    if (event.target.id === 'canvas' || node) {
+      const delta = { ArrowLeft: [45, 0], ArrowRight: [-45, 0], ArrowUp: [0, 45], ArrowDown: [0, -45] }[event.key];
+      if (delta) { event.preventDefault(); camera.x += delta[0]; camera.y += delta[1]; schedulePaint(); }
+      else if (event.key.toLowerCase() === 'f') { event.preventDefault(); fitAll(); }
+      else if (['+', '=', '-'].includes(event.key)) { event.preventDefault(); camera = C.zoom(camera, event.key === '-' ? .8 : 1.25, size.width / 2, size.height / 2); schedulePaint(); }
+    }
+  });
+  $('image-file').onchange = event => { const file = event.target.files[0]; if (file) attachImage(file, imageTarget); };
+  $('backup-file').onchange = event => { const file = event.target.files[0]; if (file) importBackup(file).catch(problem); };
+  document.addEventListener('paste', event => {
+    if (!ready || blocked || mini || dialog.open || isEditing(event.target)) return;
+    const file = [...(event.clipboardData?.items || [])].find(item => item.kind === 'file' && item.type.startsWith('image/'))?.getAsFile();
+    if (file) { event.preventDefault(); attachImage(file, selection); }
+  });
+  document.addEventListener('dragover', event => { if (!mini && event.dataTransfer?.types.includes('Files')) event.preventDefault(); });
+  document.addEventListener('drop', event => {
+    if (!ready || blocked || mini || dialog.open || !event.dataTransfer?.files.length) return;
+    event.preventDefault(); const file = event.dataTransfer.files[0];
+    const target = event.target.closest('[data-node]')?.dataset.node || event.target.closest('[data-card]')?.dataset.card || selection;
+    attachImage(file, target);
+  });
+  window.addEventListener('pagehide', () => {
+    ready = false; generation++; imageJob++; queue?.dispose(); unsubscribe?.(); resize?.disconnect();
+    cancelAnimationFrame(frame); clearTimeout(toastTimer);
+  });
+
+  // Explicit, memory-only preview. Production index.html never substitutes fake host data.
+  function previewHost() {
+    const samplePapers = [
+      { id: 'preview-tasks', type: 'todo', title: '让想法落地', bodyProviderId: '' },
+      { id: 'preview-notes', type: 'note', title: '设计原则', bodyProviderId: 'builtin.markdown' }
+    ];
+    const sampleTasks = [
+      ['reading', '读完《设计中的设计》', false], ['drawing', '画一张自己的星图', false],
+      ['code', '完成插件的第一轮测试', true], ['health', '傍晚去公园散步', false],
+      ['travel', '安排一场周末短途旅行', false], ['grow', '给阳台的植物浇水', true]
+    ].map(([id, text, done], order) => ({ id, text, done, order, paperId: 'preview-tasks', paperTitle: '让想法落地' }));
+    const sampleNote = { paperId: 'preview-notes', paperTitle: '设计原则', contentAvailable: true, content: '纸片优先，即时使用。\n\n从 [[微小行动]] 开始，把想法放进日常，而不是放进另一个管理系统。' };
+    let listener = () => {};
+    const preview = {
+      surface: 'body', saveState() {}, registerStateProvider() {},
+      paper: { setHeaderText() {}, setCapsulePresentation() {} }, body: { setInputClaims() {} },
+      onHostEvent(types, handler) { listener = handler; return () => { listener = () => {}; }; },
+      workspace: { async request(method, args = {}) {
+        if (method === 'papers.list') return structuredClone(samplePapers);
+        if (method === 'todos.list') return structuredClone(sampleTasks.filter(item => item.paperId === args.paperId));
+        if (method === 'notes.get') return structuredClone(sampleNote);
+        if (method === 'todos.update') {
+          const item = sampleTasks.find(item => item.id === args.todoId && item.paperId === args.paperId);
+          if (!item) throw new Error('unavailable');
+          if (typeof args.done === 'boolean') item.done = args.done;
+          if (typeof args.text === 'string') item.text = args.text;
+          listener({ type: 'todo.changed' }); return { paperId: args.paperId, todoId: args.todoId };
+        }
+        if (method === 'todos.append') {
+          const ids = args.todos.map(item => { const id = crypto.randomUUID(); sampleTasks.push({ ...item, id, done: false, order: sampleTasks.length, paperId: args.paperId, paperTitle: '让想法落地' }); return id; });
+          listener({ type: 'todo.created' }); return { paperId: args.paperId, todoIds: ids };
+        }
+        throw new Error('protocolData');
+      } }
+    };
+    const sample = { ...C.blank(), sources: ['preview-tasks', 'preview-notes'], notes: [
+      { id: 'n:curiosity', title: '保持好奇', body: '把看到的、想到的，留成一颗星。\n\n通过 [[微小行动]]，让好奇心有一个落点。' },
+      { id: 'n:action', title: '微小行动', body: '不等待一个完整计划。\n先做一件今天可以完成的小事。\n\n关联：[[设计原则]]' },
+      { id: 'n:garden', title: '想法花园', body: '知识不必排成一列。\n让想法像植物一样，自由生长。' }
+    ], links: [
+      { from: 'n:curiosity', to: C.todoKey('preview-tasks', 'reading'), label: '输入' },
+      { from: 'n:garden', to: C.todoKey('preview-tasks', 'drawing'), label: '创作' },
+      { from: 'n:action', to: C.todoKey('preview-tasks', 'health'), label: '今天就做' }
+    ] };
+    host = preview; initialize({ type: 'initialize', surface: 'body', state: sample, settings: { language: 'zh' } });
+  }
+  if (demo) previewHost();
+  else { app.replaceChildren(el('main', t('waiting'), 'empty')); }
+})();

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/web/art.js
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/web/art.js
@@ -1,0 +1,36 @@
+/* Original, deterministic SVG illustrations. No remote images, fonts, AI calls or dependencies. */
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.StarArt = api;
+})(globalThis, function () {
+  'use strict';
+  const palettes = {
+    orbit: ['#f0eaf8', '#756091', '#b09cc9', '#f8f5fc'],
+    read: ['#e9eee8', '#547161', '#9bb49c', '#fcfaf3'],
+    code: ['#e7eef5', '#4f718d', '#99b8cb', '#f5f9fc'],
+    grow: ['#e9f0df', '#627c49', '#a6ba78', '#faf8ee'],
+    travel: ['#f6eadb', '#ac7850', '#d6b38a', '#fff9eb'],
+    health: ['#f6e5e1', '#ac6d66', '#d7a29a', '#fff5ed'],
+    create: ['#f5e9ef', '#976780', '#c7a0b6', '#fff6f3'],
+    focus: ['#e5eeed', '#537978', '#99b9b2', '#f6faf4']
+  };
+  function palette(scene) { return palettes[scene] || palettes.orbit; }
+  function svg(scene, seed = 0) {
+    const [bg, ink, soft, paper] = palette(scene);
+    const shapes = {
+      orbit: `<ellipse cx="160" cy="102" rx="99" ry="31" transform="rotate(-24 160 102)"/><circle cx="160" cy="99" r="44" fill="${soft}" stroke="none"/><path d="M72 142q104-9 161-79"/><circle cx="231" cy="65" r="9" fill="${paper}"/><path d="M104 43v16m-8-8h16M231 135v12m-6-6h12"/>`,
+      read: `<path d="M69 60q47-17 89 5v91q-41-26-89-8z" fill="${paper}"/><path d="M158 65q47-22 92-5v88q-47-9-92 8z" fill="${paper}"/><path d="M158 68v83M85 81q28-5 54 4m-54 12q28-5 54 4m-54 12q28-5 42 1m57-28q25-12 48-7m-48 23q25-12 48-7m-48 23q25-12 36-9" stroke="${soft}"/><path d="M206 44v56l9-8 9 3V42" fill="${soft}" stroke="none"/>`,
+      code: `<rect x="63" y="46" width="192" height="116" rx="11" fill="${paper}"/><path d="M63 70h192" stroke="${soft}"/><circle cx="79" cy="58" r="3" fill="${soft}" stroke="none"/><circle cx="92" cy="58" r="3" fill="${soft}" stroke="none"/><path d="m127 91-24 21 24 20m65-41 24 21-24 20m-19-46-20 54"/><path d="M108 177h108m-81-15-5 15m49-15 5 15"/>`,
+      grow: `<path d="M133 124h56l-9 48h-38z" fill="${paper}"/><path d="M160 125V56"/><path d="M161 109q-49 0-49-34 46-1 49 34M161 90q0-36 39-40 1 38-39 40M160 70q-29-8-24-35 28 5 24 35" fill="${soft}"/><path d="M100 173h123" stroke="${soft}"/><circle cx="221" cy="93" r="17" stroke-dasharray="2 8"/>`,
+      travel: `<path d="M37 158 111 71l51 58 35-45 88 74z" fill="${paper}"/><path d="m88 98 23-27 23 26-22-8z" fill="${soft}" stroke="none"/><circle cx="219" cy="53" r="22" fill="${soft}" stroke="none"/><path d="M43 169h238M62 180h154" stroke="${soft}"/><path d="m170 50 42-22-17 43-7-20z" fill="${paper}"/>`,
+      health: `<path d="M112 113c-68-40-21-93 14-48l34 38 34-38c35-45 82 8 14 48l-48 44z" fill="${paper}"/><path d="M87 105h40l14-25 20 52 18-34 12 7h47"/><path d="M121 174h78" stroke="${soft}"/>`,
+      create: `<path d="M92 166q-31-83 36-111 66-24 93 36 12 37-25 24-25-10-22 18 4 35-38 36z" fill="${paper}"/><circle cx="118" cy="88" r="10" fill="${soft}" stroke="none"/><circle cx="151" cy="72" r="9" fill="${ink}" stroke="none"/><circle cx="186" cy="87" r="9" fill="${soft}" stroke="none"/><path d="m173 164 43-92 11 5-42 93z" fill="${soft}"/><path d="M173 164q-17 5-13 18 16 7 25-12" fill="${ink}"/>`,
+      focus: `<path d="M113 41h96m-96 128h96M124 43c0 36 0 42 36 61-36 19-36 27-36 63m73-124c0 36 0 42-36 61 36 19 36 27 36 63"/><path d="m131 65 30 33 29-33zM130 160l31-37 31 37z" fill="${soft}" stroke="none"/><path d="M82 76v15m-7-7h14m145 44v15m-7-7h14" stroke="${soft}"/>`
+    };
+    const dot = 20 + (Number(seed) >>> 0) % 22;
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 210"><rect width="320" height="210" fill="${bg}"/><circle cx="160" cy="104" r="85" fill="${paper}" opacity=".28"/><g fill="none" stroke="${ink}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">${shapes[scene] || shapes.orbit}</g><g fill="${soft}" opacity=".8"><circle cx="${dot}" cy="53" r="2"/><circle cx="281" cy="118" r="2.5"/><circle cx="59" cy="182" r="1.5"/></g></svg>`;
+  }
+  function data(scene, seed) { return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg(scene, seed))}`; }
+  return Object.freeze({ palette, svg, data });
+});

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/web/core.js
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/web/core.js
@@ -1,0 +1,227 @@
+/* Starpaper's data model is independent of the DOM and the PaperTodo transport. */
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.StarCore = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+  const SCHEMA = 1;
+  const MAX_BYTES = 10 * 1024 * 1024; // PaperTodo API 2.1 per-paper JSON limit.
+  const SCENES = Object.freeze(['orbit', 'read', 'code', 'grow', 'travel', 'health', 'create', 'focus']);
+  const bytes = value => new TextEncoder().encode(typeof value === 'string' ? value : JSON.stringify(value)).length;
+  const own = (object, key) => Object.prototype.hasOwnProperty.call(object, key);
+  const record = value => value !== null && typeof value === 'object' && !Array.isArray(value);
+  const fail = code => { throw new Error(code); };
+  const id = value => typeof value === 'string' && value.length > 0 && value.length <= 512 &&
+    !['__proto__', 'constructor', 'prototype'].includes(value);
+  function blank() {
+    return { schema: SCHEMA, sources: [], notes: [], links: [], positions: {}, covers: {},
+      view: 'map', filter: 'all', wiki: true };
+  }
+  function safeImage(value) {
+    return typeof value === 'string' && /^data:image\/(?:png|jpeg|webp);base64,[A-Za-z0-9+/]+={0,2}$/.test(value);
+  }
+  // Fail closed: invalid/future state is never normalized into an empty writable document.
+  function validate(raw) {
+    if (raw == null || (record(raw) && Object.keys(raw).length === 0)) return blank();
+    if (!record(raw) || raw.schema !== SCHEMA) fail('stateVersion');
+    for (const key of ['sources', 'notes', 'links']) if (!Array.isArray(raw[key])) fail('invalidState');
+    if (!record(raw.positions) || !record(raw.covers)) fail('invalidState');
+    if (!['map', 'cards'].includes(raw.view) || !['all', 'open', 'done'].includes(raw.filter) || typeof raw.wiki !== 'boolean') fail('invalidState');
+    const seen = new Set();
+    for (const source of raw.sources) {
+      if (!id(source) || seen.has(source)) fail('invalidState');
+      seen.add(source);
+    }
+    seen.clear();
+    for (const note of raw.notes) {
+      if (!record(note) || !id(note.id) || !note.id.startsWith('n:') || seen.has(note.id) ||
+          typeof note.title !== 'string' || !note.title.trim() || typeof note.body !== 'string') fail('invalidState');
+      seen.add(note.id);
+    }
+    seen.clear();
+    for (const link of raw.links) {
+      if (!record(link) || !id(link.from) || !id(link.to) || link.from === link.to || typeof link.label !== 'string') fail('invalidState');
+      const key = pair(link.from, link.to);
+      if (seen.has(key)) fail('invalidState');
+      seen.add(key);
+    }
+    for (const [key, pos] of Object.entries(raw.positions)) {
+      if (!id(key) || !record(pos) || !Number.isFinite(pos.x) || !Number.isFinite(pos.y) ||
+          Math.abs(pos.x) > 1e7 || Math.abs(pos.y) > 1e7) fail('invalidState');
+    }
+    for (const [key, cover] of Object.entries(raw.covers)) {
+      if (!id(key) || !record(cover) || !SCENES.includes(cover.scene) ||
+          (cover.image !== undefined && cover.image !== null && !safeImage(cover.image))) fail('invalidImage');
+    }
+    if (bytes(raw) > MAX_BYTES) fail('capacity');
+    // A versioned file is a complete document. Return it unchanged: no silent field loss.
+    return raw;
+  }
+  function pair(a, b) { return JSON.stringify(a < b ? [a, b] : [b, a]); }
+  const todoKey = (paperId, todoId) => `t:${encodeURIComponent(paperId)}:${encodeURIComponent(todoId)}`;
+  const paperKey = paperId => `p:${encodeURIComponent(paperId)}`;
+  function hash(text) {
+    let h = 2166136261;
+    for (const c of String(text)) { h ^= c.codePointAt(0); h = Math.imul(h, 16777619); }
+    return h >>> 0;
+  }
+  function sceneFor(text) {
+    const groups = [
+      ['read', /读|阅读|书|学习|论文|read|book|learn|study|読|勉強|독서|공부/i],
+      ['code', /代码|编程|修复|测试|插件|code|bug|test|develop|プログラム|코드|개발/i],
+      ['grow', /植物|花|园|种植|grow|plant|garden|花|植物|식물|정원/i],
+      ['travel', /旅行|出游|机票|游览|出发|travel|trip|flight|旅|여행/i],
+      ['health', /运动|健身|跑|训练|散步|workout|health|gym|run|運動|운동/i],
+      ['create', /画|设计|创作|写作|音乐|拍摄|draw|design|write|music|写真|그림|디자인/i],
+      ['focus', /专注|整理|规划|计划|focus|plan|organize|計画|집중|계획/i]
+    ];
+    return groups.find(([, re]) => re.test(text))?.[0] || 'orbit';
+  }
+  function setLink(state, from, to, label = '') {
+    if (!id(from) || !id(to) || from === to) fail('selfLink');
+    const links = state.links.filter(link => pair(link.from, link.to) !== pair(from, to));
+    return { ...state, links: [...links, { from, to, label: String(label).trim() }] };
+  }
+  function removeNote(state, noteId) {
+    const positions = { ...state.positions }, covers = { ...state.covers };
+    delete positions[noteId]; delete covers[noteId];
+    return { ...state, notes: state.notes.filter(n => n.id !== noteId), positions, covers,
+      links: state.links.filter(e => e.from !== noteId && e.to !== noteId) };
+  }
+  function wikiTargets(text) {
+    return [...String(text).matchAll(/\[\[([^\[\]\n]+)\]\]/g)].map(match => match[1].trim()).filter(Boolean);
+  }
+  function graph(state, papers, todos, sourceNotes = []) {
+    const nodes = [], edges = [], byId = new Map();
+    function add(node) { if (!byId.has(node.id)) { nodes.push(node); byId.set(node.id, node); } }
+    for (const source of state.sources) {
+      const paper = papers.find(p => p.id === source);
+      const note = sourceNotes.find(n => n.paperId === source);
+      add({ id: paperKey(source), kind: paper?.type === 'note' ? 'note-ref' : 'paper',
+        title: paper?.title || '', body: note?.contentAvailable ? note.content : '',
+        paperId: source, missing: !paper, unavailable: paper?.type === 'note' && !note?.contentAvailable });
+    }
+    for (const todo of todos) {
+      if (!state.sources.includes(todo.paperId)) continue;
+      const key = todoKey(todo.paperId, todo.id);
+      add({ id: key, kind: 'todo', title: todo.text, body: todo.text, done: !!todo.done, todo,
+        scene: state.covers[key]?.scene || sceneFor(todo.text) });
+      edges.push({ from: paperKey(todo.paperId), to: key, kind: 'contains', label: '' });
+    }
+    for (const note of state.notes) add({ ...note, kind: 'note', scene: state.covers[note.id]?.scene || sceneFor(note.title) });
+    // A missing external reference is not proof of deletion. Keep it visible, never prune its data.
+    for (const link of state.links) {
+      for (const key of [link.from, link.to]) if (!byId.has(key)) add({ id: key, kind: 'missing', title: '', missing: true });
+      edges.push({ ...link, kind: 'manual' });
+    }
+    if (state.wiki) {
+      const titles = new Map(), used = new Set(edges.map(e => pair(e.from, e.to)));
+      for (const node of nodes.filter(n => n.kind === 'note' || n.kind === 'note-ref')) {
+        const key = node.title.trim().normalize('NFC');
+        titles.set(key, titles.has(key) ? null : node.id); // Ambiguous names never create guessed facts.
+      }
+      for (const node of nodes) for (const target of wikiTargets(node.body || '')) {
+        const to = titles.get(target.normalize('NFC'));
+        if (!to || to === node.id || used.has(pair(node.id, to))) continue;
+        used.add(pair(node.id, to)); edges.push({ from: node.id, to, kind: 'wiki', label: '' });
+      }
+    }
+    return { nodes, edges, byId };
+  }
+  function visibleGraph(model, filter, query = '', focusId = null) {
+    const queryText = query.trim().toLocaleLowerCase();
+    let allowed = new Set(model.nodes.filter(n =>
+      (n.kind !== 'todo' || filter === 'all' || (filter === 'done') === n.done) &&
+      (!queryText || `${n.title}\n${n.body || ''}`.toLocaleLowerCase().includes(queryText))).map(n => n.id));
+    if (focusId && model.byId.has(focusId)) {
+      const neighborhood = new Set([focusId]);
+      model.edges.forEach(e => { if (e.from === focusId) neighborhood.add(e.to); if (e.to === focusId) neighborhood.add(e.from); });
+      allowed = new Set([...allowed].filter(key => neighborhood.has(key)));
+    }
+    return { nodes: model.nodes.filter(n => allowed.has(n.id)), edges: model.edges.filter(e => allowed.has(e.from) && allowed.has(e.to)) };
+  }
+  function layout(model, positions = {}) {
+    const result = new Map(), papers = model.nodes.filter(n => n.kind === 'paper');
+    const counts = papers.map(p => model.nodes.filter(n => n.todo?.paperId === p.paperId).length);
+    const gap = 430 + Math.sqrt(Math.max(0, ...counts)) * 110;
+    const cols = Math.max(1, Math.ceil(Math.sqrt(papers.length + 1)));
+    papers.forEach((paper, i) => {
+      const center = { x: (i % cols + 1) * gap, y: Math.floor(i / cols) * gap };
+      result.set(paper.id, center);
+      const tasks = model.nodes.filter(n => n.todo?.paperId === paper.paperId).sort((a, b) => a.id.localeCompare(b.id));
+      tasks.forEach((node, j) => {
+        const angle = j * 2.3999632297 + (hash(paper.id) % 100) / 100;
+        const radius = 130 + Math.sqrt(j) * 74;
+        result.set(node.id, { x: center.x + Math.cos(angle) * radius, y: center.y + Math.sin(angle) * radius });
+      });
+    });
+    const others = model.nodes.filter(n => !result.has(n.id)).sort((a, b) => a.id.localeCompare(b.id));
+    others.forEach((node, i) => {
+      const angle = i * 2.3999632297 - Math.PI / 2, radius = others.length === 1 ? 0 : 125 + Math.sqrt(i) * 80;
+      result.set(node.id, { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius });
+    });
+    for (const [key, pos] of Object.entries(positions)) if (result.has(key)) result.set(key, { ...pos });
+    return result;
+  }
+  function fit(nodes, positions, width, height) {
+    if (!nodes.length) return { x: width / 2, y: height / 2, k: 1 };
+    let x1 = Infinity, y1 = Infinity, x2 = -Infinity, y2 = -Infinity;
+    for (const n of nodes) {
+      const p = positions.get(n.id); if (!p) continue;
+      x1 = Math.min(x1, p.x - 95); y1 = Math.min(y1, p.y - 58);
+      x2 = Math.max(x2, p.x + 95); y2 = Math.max(y2, p.y + 74);
+    }
+    const k = Math.min(1.25, Math.max(.01, Math.min(Math.max(40, width - 64) / (x2 - x1), Math.max(40, height - 64) / (y2 - y1))));
+    return { x: width / 2 - (x1 + x2) / 2 * k, y: height / 2 - (y1 + y2) / 2 * k, k };
+  }
+  function zoom(camera, factor, x, y) {
+    const k = Math.max(.01, Math.min(4, camera.k * factor)), ratio = k / camera.k;
+    return { k, x: x - (x - camera.x) * ratio, y: y - (y - camera.y) * ratio };
+  }
+  class History {
+    constructor(limit = 30, budget = 24 * 1024 * 1024) { this.limit = limit; this.budget = budget; this.clear(); }
+    clear() { this.past = []; this.future = []; }
+    push(state) {
+      this.past.push({ state, size: bytes(state) }); this.future = [];
+      let size = this.past.reduce((sum, entry) => sum + entry.size, 0);
+      while (this.past.length > 1 && (this.past.length > this.limit || size > this.budget)) size -= this.past.shift().size;
+    }
+    undo(current) {
+      if (!this.past.length) return current;
+      this.future.push({ state: current, size: bytes(current) }); return this.past.pop().state;
+    }
+    redo(current) {
+      if (!this.future.length) return current;
+      this.past.push({ state: current, size: bytes(current) }); return this.future.pop().state;
+    }
+  }
+  // Coalesce refreshes, but never publish an obsolete response after a newer event/source selection.
+  class RefreshQueue {
+    constructor(load, publish, onError) { this.load = load; this.publish = publish; this.onError = onError; this.revision = 0; this.running = false; this.disposed = false; }
+    request() {
+      if (this.disposed) return Promise.resolve();
+      this.revision++;
+      if (!this.running) this.idle = this.drain();
+      return this.idle;
+    }
+    async drain() {
+      if (this.running || this.disposed) return;
+      this.running = true;
+      try {
+        let done;
+        do {
+          const revision = this.revision;
+          try {
+            const value = await this.load();
+            if (!this.disposed && revision === this.revision) this.publish(value);
+          } catch (error) { if (!this.disposed && revision === this.revision) this.onError(error); }
+          done = revision === this.revision;
+        } while (!done && !this.disposed);
+      } finally { this.running = false; }
+    }
+    dispose() { this.disposed = true; }
+  }
+  return Object.freeze({ SCHEMA, MAX_BYTES, SCENES, blank, validate, bytes, safeImage, pair, todoKey, paperKey,
+    hash, sceneFor, setLink, removeNote, wikiTargets, graph, visibleGraph, layout, fit, zoom, History, RefreshQueue, own });
+});

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/web/i18n.js
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/web/i18n.js
@@ -1,0 +1,94 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.StarI18n = api;
+})(globalThis, function () {
+  'use strict';
+  // Each row is zh / en / ja / ko. Keep all four variants together when adding UI copy.
+  const rows = {
+    name: ['星笺', 'Starpaper', '星のノート', '별빛 노트'],
+    tagline: ['让灵感相连，让行动生长。', 'Connect ideas. Give plans a little life.', 'ひらめきをつなぎ、行動を育てる。', '생각을 잇고, 계획을 키워요.'],
+    map: ['知识星图', 'Constellation', '知識の星図', '지식 별자리'],
+    cards: ['待办图鉴', 'Illustrated tasks', 'タスク図鑑', '할 일 도감'],
+    local: ['离线 · 本地', 'Offline · local', 'オフライン · ローカル', '오프라인 · 로컬'],
+    demo: ['演示数据 · 不会修改 PaperTodo', 'Demo · no PaperTodo data is changed', 'デモ · PaperTodo のデータは変更されません', '데모 · PaperTodo 데이터는 변경되지 않습니다'],
+    sources: ['选择纸片', 'Choose papers', '用紙を選択', '용지 선택'],
+    sourceHint: ['只读取选中纸片的正文；标记完成会修改原待办。取消来源选择不会删除原始数据。', 'Only selected papers are read. Completing a task changes the original. Deselecting never deletes it.', '選択した用紙だけを読み取ります。完了操作は元のタスクに反映されます。選択を外しても削除されません。', '선택한 용지만 읽습니다. 완료 상태는 원본에 반영됩니다. 선택을 해제해도 삭제되지 않습니다.'],
+    newNote: ['新建知识', 'New idea', '知識を追加', '지식 추가'],
+    newTodo: ['新建待办', 'New task', 'タスクを追加', '할 일 추가'],
+    search: ['搜索标题与内容…', 'Search titles and text…', 'タイトル・内容を検索…', '제목과 내용 검색…'],
+    all: ['全部', 'All', 'すべて', '전체'], open: ['未完成', 'Open', '未完了', '미완료'], done: ['已完成', 'Done', '完了', '완료'],
+    undo: ['撤销星图编辑（不撤销原待办）', 'Undo board edit (not host tasks)', '星図の編集を元に戻す（元のタスクは対象外）', '별자리 편집 실행 취소 (원본 할 일 제외)'],
+    redo: ['重做星图编辑', 'Redo board edit', '星図の編集をやり直す', '별자리 편집 다시 실행'],
+    more: ['更多', 'More', 'その他', '더 보기'], fit: ['全图', 'Fit all', '全体表示', '전체 보기'],
+    arrange: ['整理布局', 'Arrange', '整列', '정렬'],
+    arrangeHint: ['恢复自动布局？知识和连线都会保留，布局可撤销。', 'Restore the automatic layout? Ideas and links stay intact. You can undo this.', '自動配置に戻しますか？知識と関連は残り、操作を元に戻せます。', '자동 배치로 되돌릴까요? 지식과 연결은 유지되며 실행 취소할 수 있습니다.'],
+    export: ['导出备份', 'Export backup', 'バックアップを保存', '백업 내보내기'],
+    import: ['导入备份', 'Import backup', 'バックアップを読み込む', '백업 가져오기'],
+    exportSvg: ['导出星图 SVG', 'Export map as SVG', '星図を SVG で保存', '별자리를 SVG로 저장'],
+    exportCard: ['导出插画卡片', 'Export illustrated card', 'イラストカードを保存', '일러스트 카드 저장'],
+    help: ['使用说明', 'Guide', '使い方', '사용 안내'],
+    helpText: ['拖动节点摆放，拖动画布平移，滚轮缩放。选中节点后 Shift+单击另一节点可快速连线，也可用“关联”填写关系。正文中的 [[知识标题]] 会生成虚线链接；同名知识不自动猜测。双击空白处新建知识。Ctrl+Z / Ctrl+Y 只处理星图本地编辑。插画显示在本插件，不改变原待办行。', 'Drag nodes to arrange; drag the canvas to pan; use the wheel to zoom. Shift-click another node to connect, or use Link to name the relationship. [[Idea title]] creates a dashed reference; duplicate titles are not guessed. Double-click the canvas to add an idea. Ctrl+Z / Ctrl+Y only affect local board edits. Illustrations live here, not in the original task rows.', 'ノードのドラッグで配置、余白のドラッグで移動、ホイールで拡大縮小。別のノードを Shift+クリックすると関連を追加できます。「関連」で名前も付けられます。[[知識のタイトル]] は点線の参照になります。同名の場合は推測しません。余白をダブルクリックで知識を追加。Ctrl+Z / Ctrl+Y は星図のみが対象です。イラストはこのプラグイン内に表示されます。', '노드를 끌어 배치하고, 배경을 끌어 이동하며, 휠로 확대합니다. 다른 노드를 Shift+클릭하면 연결할 수 있고, 연결 메뉴에서 관계 이름을 지정합니다. [[지식 제목]]은 점선 참조를 만듭니다. 중복 제목은 추측하지 않습니다. 배경을 두 번 클릭하면 지식을 추가합니다. Ctrl+Z / Ctrl+Y는 별자리 편집만 되돌립니다. 일러스트는 이 플러그인 안에만 표시됩니다.'],
+    knowledge: ['知识', 'Ideas', '知識', '지식'], tasks: ['待办', 'Tasks', 'タスク', '할 일'], papers: ['纸片', 'Papers', '用紙', '용지'],
+    link: ['关联', 'Link', '関連', '연결'], relation: ['关系说明（可选）', 'Relationship (optional)', '関連の説明（任意）', '관계 설명 (선택)'],
+    target: ['目标节点', 'Target node', '関連先', '연결 대상'], noTarget: ['先再创建一个知识节点或选择待办纸。', 'Add another idea or choose a task paper first.', '別の知識を追加するか、タスクの用紙を選択してください。', '다른 지식을 추가하거나 할 일 용지를 먼저 선택하세요.'],
+    related: ['相邻节点', 'Connections', '関連するノード', '연결된 노드'],
+    focus: ['只看相邻节点', 'Focus on connections', '関連ノードに絞る', '연결된 노드만 보기'],
+    unfocus: ['退出聚焦', 'Show all nodes', '絞り込みを解除', '모든 노드 보기'],
+    wiki: ['[[标题]] 自动关联', 'Link [[titles]] automatically', '[[タイトル]] を自動参照', '[[제목]] 자동 연결'],
+    manual: ['手动关联', 'Manual link', '手動の関連', '수동 연결'], reference: ['正文引用', 'Text reference', '本文の参照', '본문 참조'],
+    contains: ['所属纸片', 'Paper membership', '所属する用紙', '소속 용지'],
+    unlink: ['移除连线', 'Remove link', '関連を解除', '연결 제거'],
+    title: ['标题', 'Title', 'タイトル', '제목'], body: ['内容 · 支持 [[知识标题]]', 'Text · supports [[Idea title]]', '内容 · [[知識のタイトル]] に対応', '내용 · [[지식 제목]] 지원'],
+    edit: ['编辑', 'Edit', '編集', '편집'], save: ['保存', 'Save', '保存', '저장'], cancel: ['取消', 'Cancel', 'キャンセル', '취소'], close: ['关闭', 'Close', '閉じる', '닫기'],
+    remove: ['删除知识', 'Delete idea', '知識を削除', '지식 삭제'],
+    removeHint: ['仅删除这个知识节点及其连线，不删除任何原始待办。可以撤销。', 'Delete this idea and its links only. Original tasks are not deleted. You can undo this.', 'この知識と関連のみ削除します。元のタスクは削除されず、操作を元に戻せます。', '이 지식과 연결만 삭제합니다. 원본 할 일은 삭제하지 않으며 실행 취소할 수 있습니다.'],
+    complete: ['标记完成', 'Mark done', '完了にする', '완료로 표시'], reopen: ['恢复未完成', 'Mark open', '未完了に戻す', '미완료로 표시'],
+    illustration: ['插画', 'Illustration', 'イラスト', '일러스트'],
+    image: ['使用本地图片', 'Use local image', 'ローカル画像を使う', '로컬 이미지 사용'],
+    imageHint: ['支持 PNG / JPEG / WebP / GIF。也可粘贴或拖入图片；自动缩小并保存副本，不依赖原文件。', 'PNG / JPEG / WebP / GIF. You can also paste or drop an image. A resized copy is stored, independent of the original file.', 'PNG / JPEG / WebP / GIF に対応。貼り付け・ドロップも可能。縮小したコピーを保存するため元ファイルは不要です。', 'PNG / JPEG / WebP / GIF 지원. 붙여넣기나 끌어넣기도 가능합니다. 축소한 사본을 저장하므로 원본 파일이 필요하지 않습니다.'],
+    resetCover: ['恢复自动插画', 'Restore automatic art', '自動イラストに戻す', '자동 일러스트 복원'],
+    orbit: ['星轨', 'Orbit', '星の軌道', '별의 궤도'], read: ['书页', 'Reading', '読書', '독서'], code: ['代码', 'Code', 'コード', '코드'],
+    grow: ['生长', 'Growth', '成長', '성장'], travel: ['远行', 'Travel', '旅', '여행'], health: ['活力', 'Wellbeing', '健康', '활력'], create: ['创作', 'Create', '創作', '창작'], focusScene: ['专注', 'Focus', '集中', '집중'],
+    emptyTitle: ['一颗想法，就能点亮星图。', 'One idea starts a constellation.', 'ひとつの知識から、星図が始まる。', '생각 하나가 별자리의 시작입니다.'],
+    emptyText: ['创建一个知识节点，或选取现有待办、笔记纸。没有数据会被自动导入或修改。', 'Add an idea or choose existing task or note papers. Nothing is imported or changed automatically.', '知識を追加するか、既存の用紙を選択してください。自動で読み込んだり変更したりしません。', '지식을 추가하거나 기존 할 일 용지를 선택하세요. 자동으로 가져오거나 수정하지 않습니다.'],
+    noTasks: ['这里还没有待办', 'No tasks here yet', 'タスクはまだありません', '아직 할 일이 없습니다'],
+    noMatch: ['没有匹配的节点', 'No matching nodes', '一致するノードがありません', '일치하는 노드가 없습니다'],
+    noPaper: ['请先在 PaperTodo 创建一张待办纸，再点刷新。', 'Create a task paper in PaperTodo, then refresh.', 'PaperTodo でタスク用紙を作成してから更新してください。', 'PaperTodo에서 할 일 용지를 만든 후 새로고침하세요.'],
+    refresh: ['刷新', 'Refresh', '更新', '새로고침'], loading: ['正在读取…', 'Loading…', '読み込み中…', '불러오는 중…'],
+    stale: ['读取失败；保留上次成功读取的内容。请刷新后再操作。', 'Read failed; the last successful snapshot is kept. Refresh before editing host tasks.', '読み込み失敗。前回の内容を保持しています。更新してから元のタスクを操作してください。', '읽기 실패. 마지막으로 읽은 내용을 유지합니다. 새로고침 후 원본 할 일을 수정하세요.'],
+    unavailable: ['引用暂不可用', 'Reference unavailable', '参照を利用できません', '참조를 사용할 수 없음'],
+    missingHint: ['原始对象可能已删除、自动清理或不再可读取。连线与插图不会被自动抹掉；这不是一条可编辑的原始待办。', 'The original may be deleted, auto-cleared, or unreadable. Links and art are kept. This is not an editable original task.', '元の項目が削除・自動整理されたか、読み取れない可能性があります。関連と画像は保持されます。この参照から元のタスクは編集できません。', '원본이 삭제·자동 정리되었거나 읽을 수 없을 수 있습니다. 연결과 그림은 유지됩니다. 이 참조는 편집 가능한 원본 할 일이 아닙니다.'],
+    waiting: ['请在 PaperTodo 中加载插件；浏览器预览请打开 preview.html。', 'Load this plugin in PaperTodo. For a browser demo, open preview.html.', 'PaperTodo で読み込んでください。ブラウザーのデモは preview.html を開きます。', 'PaperTodo에서 플러그인을 불러오세요. 브라우저 데모는 preview.html을 여세요.'],
+    stateVersion: ['数据版本不兼容，已停止写入。请先导出原始数据。', 'Incompatible data version; writes are blocked. Export the original data first.', 'データのバージョンが非対応のため書き込みを停止しました。まず元データを保存してください。', '호환되지 않는 데이터 버전으로 쓰기를 중단했습니다. 원본 데이터를 먼저 내보내세요.'],
+    invalidState: ['数据格式异常，未覆盖原始数据。', 'Invalid document; the original has not been overwritten.', 'データ形式が不正です。元データは上書きしていません。', '데이터 형식이 잘못되었습니다. 원본은 덮어쓰지 않았습니다.'],
+    invalidImage: ['不支持这份图片数据。请选择可解码的本地位图。', 'Unsupported image data. Choose a decodable local raster image.', 'この画像には対応していません。読み込めるローカル画像を選択してください。', '지원하지 않는 이미지입니다. 읽을 수 있는 로컬 비트맵을 선택하세요.'],
+    capacity: ['超出宿主每张纸 10 MiB 的状态容量，未提交这次修改。可导出备份后移除部分图片。', 'This exceeds the host’s 10 MiB per-paper state limit. The change was not submitted. Back up, then remove some images.', '宿主の用紙あたり 10 MiB 制限を超えるため変更していません。バックアップ後、画像を減らしてください。', '호스트의 용지당 10 MiB 제한을 초과하여 변경하지 않았습니다. 백업한 뒤 일부 이미지를 제거하세요.'],
+    importHint: ['将替换这张星图的知识、连线和插图；不会创建、删除或覆盖原始待办。其他设备上的原始待办 ID 可能无法对应。可撤销。', 'Replace this board’s ideas, links and art. Original tasks are not created, deleted or overwritten. Task IDs may not resolve on another installation. Undo is available.', 'この星図の知識・関連・画像を置き換えます。元のタスクを作成・削除・上書きしません。別の環境ではタスク ID が一致しない場合があります。元に戻せます。', '이 별자리의 지식·연결·그림을 교체합니다. 원본 할 일은 생성·삭제·덮어쓰지 않습니다. 다른 환경에서는 할 일 ID가 일치하지 않을 수 있습니다. 실행 취소가 가능합니다.'],
+    operationFailed: ['操作未确认。请先刷新核对原待办，再决定是否重试；不会自动重发。', 'Operation not confirmed. Refresh and check the original before retrying. It will not be resent automatically.', '操作を確認できませんでした。更新して元のタスクを確認してから再試行してください。自動再送はしません。', '작업 결과를 확인하지 못했습니다. 새로고침하여 원본을 확인한 뒤 재시도하세요. 자동으로 재전송하지 않습니다.'],
+    conflict: ['内容已在其他位置变化。请重新打开编辑器，避免覆盖更新。', 'Content changed elsewhere. Reopen the editor to avoid overwriting it.', '他の場所で内容が変更されました。上書きを避けるため編集画面を開き直してください。', '다른 위치에서 내용이 변경되었습니다. 덮어쓰지 않도록 편집기를 다시 여세요.'],
+    selfLink: ['请选择另一个节点。', 'Choose a different node.', '別のノードを選択してください。', '다른 노드를 선택하세요.'],
+    selectedImage: ['先选中一个待办或知识节点，再放入图片。', 'Select a task or idea before adding an image.', 'タスクまたは知識を選択してから画像を追加してください。', '이미지를 추가하기 전에 할 일이나 지식을 선택하세요.'],
+    imageTooLarge: ['图片过大，请先缩小到 20 MiB / 3200 万像素以内。', 'Resize the image below 20 MiB / 32 megapixels first.', '画像を 20 MiB / 3200 万画素以下に縮小してください。', '먼저 이미지를 20 MiB / 3200만 화소 이하로 줄이세요.'],
+    savedByHost: ['编辑会立即提交宿主保存；备份不包含原始待办或引用笔记正文。', 'Edits are submitted to the host immediately. Backups do not contain original task or referenced note text.', '編集はすぐに宿主へ保存要求します。バックアップに元のタスクや参照メモの本文は含まれません。', '편집은 즉시 호스트에 저장 요청됩니다. 백업에는 원본 할 일이나 참조 메모 본문이 포함되지 않습니다.'],
+    previewOnly: ['演示只在当前页面内存中运行，刷新会重置。', 'The demo is memory-only and resets when reloaded.', 'デモはメモリ内のみで動作し、再読み込みすると初期化されます。', '데모는 메모리에서만 동작하며 새로고침하면 초기화됩니다.'],
+    hint: ['拖动 · 滚轮缩放 · Shift+单击连线', 'Drag · wheel to zoom · Shift-click to link', 'ドラッグ · ホイールで拡大 · Shift+クリックで関連', '끌기 · 휠로 확대 · Shift+클릭으로 연결'],
+    selected: ['已选', 'Selected', '選択済み', '선택됨'],
+    untitled: ['未命名纸片', 'Untitled paper', '無題の用紙', '제목 없는 용지'],
+    clearFilter: ['清除筛选', 'Clear filters', '絞り込みを解除', '필터 해제'],
+    readOnlyNote: ['实时引用的笔记正文。请在原笔记纸编辑；这里可配图和连线。', 'Live note reference. Edit the original note; add art and links here.', '元のメモの参照です。本文は元の用紙で編集し、ここでは画像や関連を追加します。', '실시간 메모 참조입니다. 원본 메모에서 편집하고 여기에서는 그림과 연결을 추가하세요.'],
+    zoomIn: ['放大', 'Zoom in', '拡大', '확대'], zoomOut: ['缩小', 'Zoom out', '縮小', '축소'],
+    protocolData: ['宿主返回的数据格式不符合 API 2.1。', 'The host response does not match API 2.1.', '宿主の応答が API 2.1 の形式と一致しません。', '호스트 응답이 API 2.1 형식과 다릅니다.']
+  };
+  const languages = ['zh', 'en', 'ja', 'ko'];
+  function language(value, system = 'zh') {
+    const requested = !value || value === 'auto' ? system : value;
+    const prefix = String(requested).slice(0, 2).toLowerCase();
+    return languages.includes(prefix) ? prefix : 'en';
+  }
+  function translator(locale) {
+    const index = languages.indexOf(language(locale));
+    return key => rows[key]?.[index] ?? key;
+  }
+  return Object.freeze({ rows, languages, language, translator });
+});

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/web/index.html
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/web/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'">
+  <title>星笺 · Starpaper</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="core.js" defer></script>
+  <script src="i18n.js" defer></script>
+  <script src="art.js" defer></script>
+  <script src="app.js" defer></script>
+</head>
+<body>
+  <div id="app" aria-busy="true"></div>
+  <div id="toast" role="status" aria-live="polite" hidden></div>
+  <dialog id="dialog"></dialog>
+  <input id="image-file" type="file" accept="image/png,image/jpeg,image/webp,image/gif" hidden>
+  <input id="backup-file" type="file" accept=".json,application/json" hidden>
+</body>
+</html>

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/web/preview.html
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/web/preview.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'">
+  <title>星笺 · Starpaper</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="core.js" defer></script>
+  <script src="i18n.js" defer></script>
+  <script src="art.js" defer></script>
+  <script src="app.js" defer></script>
+</head>
+<body data-preview="true">
+  <div id="app" aria-busy="true"></div>
+  <div id="toast" role="status" aria-live="polite" hidden></div>
+  <dialog id="dialog"></dialog>
+  <input id="image-file" type="file" accept="image/png,image/jpeg,image/webp,image/gif" hidden>
+  <input id="backup-file" type="file" accept=".json,application/json" hidden>
+</body>
+</html>

--- a/plugin-samples/PaperTodo.Plugin.Starpaper/web/style.css
+++ b/plugin-samples/PaperTodo.Plugin.Starpaper/web/style.css
@@ -1,0 +1,146 @@
+:root {
+  color-scheme: light;
+  --paper: #f8f6f0; --text: #343c38; --weak: #798078; --accent: #637d6c;
+  --border: #d8dcd2; --font: 'Segoe UI', 'Microsoft YaHei UI', system-ui, sans-serif;
+  --host-scale: 1; --panel: color-mix(in srgb, var(--paper), var(--text) 3%);
+  --wash: color-mix(in srgb, var(--paper), var(--accent) 9%);
+  font: calc(13px * var(--host-scale))/1.55 var(--font);
+  color: var(--text); background: var(--paper);
+}
+* { box-sizing: border-box; }
+html, body, #app { margin: 0; width: 100%; height: 100%; overflow: hidden; }
+[hidden] { display: none !important; }
+button, input, select, textarea { font: inherit; color: inherit; }
+button, summary, select, input[type=checkbox] { cursor: pointer; }
+button { border: 1px solid transparent; border-radius: 9px; background: transparent; padding: 6px 10px; line-height: 1.5; }
+button:hover:not(:disabled), summary:hover { background: var(--wash); }
+button:disabled { opacity: .42; cursor: default; }
+button:focus-visible, summary:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible, svg:focus-visible, [role=button]:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 3px;
+}
+button.primary { background: var(--accent); color: var(--paper); }
+button.primary:hover:not(:disabled) { background: color-mix(in srgb, var(--accent), var(--text) 14%); }
+button.secondary { border-color: var(--border); }
+button.danger { color: #bd5c53; border-color: color-mix(in srgb, var(--paper), #bd5c53 30%); }
+button.icon { min-width: 32px; font-size: 18px; padding: 3px 7px; }
+button.wide { width: 100%; }
+input:not([type=checkbox]), textarea, select { background: var(--paper); border: 1px solid var(--border); border-radius: 8px; padding: 7px 9px; min-width: 0; }
+input[type=checkbox] { accent-color: var(--accent); width: 17px; height: 17px; flex: 0 0 auto; }
+textarea { resize: vertical; min-height: 140px; width: 100%; }
+label.field { display: grid; gap: 5px; margin-bottom: 15px; }
+.small, small { font-size: .85rem; color: var(--weak); }
+p { margin: 0 0 12px; }
+h1, h2, h3 { margin: 0; font-weight: 600; }
+.shell { display: flex; flex-direction: column; height: 100%; }
+.top { padding: 16px 22px 0; }
+.brand-row, .actions, .tools, .search-row, .bottom, .inspector-head, .dialog-head { display: flex; align-items: center; gap: 9px; }
+.brand-row { justify-content: space-between; }
+.brand { display: flex; align-items: center; gap: 9px; font-size: 16px; font-weight: 600; letter-spacing: .07em; }
+.brand-mark { color: var(--accent); font-size: 25px; font-weight: 400; }
+.local-badge { font-size: 10px; padding: 3px 7px; border: 1px solid var(--border); border-radius: 20px; color: var(--weak); font-weight: 400; letter-spacing: 0; white-space: nowrap; }
+.intro { padding: 17px 0 13px; }
+.intro h1 { font-size: 23px; font-family: Georgia, 'Noto Serif CJK SC', 'Microsoft YaHei', serif; font-weight: 500; letter-spacing: .02em; }
+.intro p { color: var(--weak); font-size: 12px; margin: 5px 0 0; }
+.tools { flex-wrap: wrap; justify-content: space-between; padding: 8px 0 10px; }
+.tabs { display: inline-flex; border-radius: 10px; padding: 3px; background: var(--panel); border: 1px solid var(--border); }
+.tabs button { padding: 5px 12px; border-radius: 7px; font-size: .92rem; }
+.tabs button[aria-selected=true] { background: var(--paper); box-shadow: 0 1px 4px #0000000c; color: var(--accent); }
+.search-row { padding-bottom: 13px; }
+.search-row input { flex: 1; width: 70px; background: transparent; }
+.search-row select { max-width: 115px; background: transparent; }
+.source-button { white-space: nowrap; font-size: .9rem; }
+.menu { position: relative; }
+.menu summary { list-style: none; font-size: 19px; border-radius: 8px; text-align: center; padding: 0 9px; }
+.menu summary::-webkit-details-marker { display: none; }
+.menu-items { position: absolute; top: 32px; right: 0; width: 210px; padding: 7px; background: var(--paper); border: 1px solid var(--border); box-shadow: 0 10px 35px #0002; border-radius: 12px; z-index: 6; }
+.menu-items button { display: block; width: 100%; text-align: left; }
+.menu-items label { display: flex; gap: 6px; padding: 8px 4px; font-size: .88rem; }
+.status-banner, .demo-banner { padding: 7px 18px; border-block: 1px solid var(--border); font-size: .86rem; background: var(--wash); }
+.status-banner { color: #aa6455; }
+.stage { flex: 1; min-height: 130px; display: flex; position: relative; overflow: hidden; border-block: 1px solid var(--border); }
+.map-pane { flex: 1; min-width: 0; position: relative; overflow: hidden; background-image: radial-gradient(color-mix(in srgb, var(--border), transparent 20%) .75px, transparent .75px); background-size: 22px 22px; }
+#canvas { width: 100%; height: 100%; display: block; touch-action: none; user-select: none; cursor: grab; }
+#canvas.dragging { cursor: grabbing; }
+.node { cursor: pointer; outline: none; }
+.node circle { transition: opacity 120ms; }
+.node:hover .halo, .node:focus .halo { opacity: .7; }
+.node .halo { fill: none; stroke: var(--accent); stroke-width: 1.5px; opacity: 0; }
+.node.selected .halo { opacity: 1; stroke-width: 2px; }
+.node.done { opacity: .52; }
+.node.missing { opacity: .65; }
+.node-symbol { font-size: 19px; font-family: var(--font); text-anchor: middle; dominant-baseline: middle; pointer-events: none; }
+.node-label, .edge-label { text-anchor: middle; font-family: var(--font); fill: var(--text); paint-order: stroke; stroke: var(--paper); stroke-width: 4px; stroke-linejoin: round; pointer-events: none; }
+.node-label { font-size: 12px; }
+.node.paper .node-label { font-weight: 600; font-size: 13px; }
+.edge { stroke: color-mix(in srgb, var(--border), var(--accent) 25%); stroke-width: 1.3px; fill: none; vector-effect: non-scaling-stroke; }
+.edge.contains { stroke-dasharray: 2 6; opacity: .65; }
+.edge.wiki { stroke-dasharray: 5 5; }
+.edge.highlight { stroke: var(--accent); stroke-width: 1.8px; opacity: .95; }
+.edge-label { font-size: 11px; fill: var(--accent); }
+.map-controls { position: absolute; right: 13px; bottom: 12px; display: flex; gap: 2px; padding: 4px; background: var(--paper); border: 1px solid var(--border); border-radius: 11px; box-shadow: 0 2px 8px #00000008; }
+.map-controls button { padding: 3px 8px; font-size: 12px; }
+.map-hint { position: absolute; left: 16px; bottom: 19px; max-width: 52%; font-size: 10px; color: var(--weak); pointer-events: none; }
+.empty { position: absolute; inset: 20% 16px auto; text-align: center; max-width: 450px; margin: auto; }
+.empty-mark { font-size: 65px; color: var(--accent); opacity: .45; line-height: 1.1; margin-bottom: 18px; }
+.empty h2 { font-size: 18px; margin-bottom: 10px; font-weight: 500; }
+.empty p { color: var(--weak); font-size: 12px; }
+.empty .actions { justify-content: center; flex-wrap: wrap; }
+.cards-pane { flex: 1; min-width: 0; overflow-y: auto; padding: 21px; position: relative; scrollbar-width: thin; scrollbar-color: var(--border) transparent; }
+.card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 195px), 1fr)); gap: 18px; }
+.task-card { border: 1px solid var(--border); border-radius: 13px; overflow: hidden; background: var(--paper); content-visibility: auto; contain-intrinsic-size: auto 290px; }
+.task-card.selected { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+.card-art { padding: 0; display: block; width: 100%; border-radius: 0; overflow: hidden; }
+.card-art img { width: 100%; height: 155px; display: block; object-fit: cover; }
+.card-content { padding: 12px 14px 14px; }
+.card-meta { font-size: 10px; color: var(--weak); letter-spacing: .03em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.card-title { padding: 4px 0 7px; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; font-size: 14px; line-height: 1.6; text-align: left; width: 100%; border-radius: 0; }
+.task-card.done .card-title { text-decoration: line-through; color: var(--weak); }
+.task-card.done img { opacity: .65; }
+.completion { display: flex; align-items: center; gap: 7px; padding: 3px 0; font-size: 11px; color: var(--weak); }
+.checkmark { width: 20px; height: 20px; border-radius: 50%; border: 1px solid var(--border); display: inline-grid; place-items: center; color: var(--accent); font-size: 12px; }
+[aria-checked=true] .checkmark { background: var(--wash); border-color: var(--accent); }
+.inspector { width: 275px; flex-shrink: 0; padding: 15px; border-left: 1px solid var(--border); overflow-y: auto; background: var(--paper); z-index: 3; scrollbar-width: thin; }
+.inspector-head { justify-content: space-between; margin-bottom: 10px; color: var(--weak); font-size: 11px; }
+.inspector-art { height: 146px; width: 100%; border-radius: 10px; object-fit: cover; display: block; margin-bottom: 13px; }
+.inspector h2 { font-size: 17px; overflow-wrap: anywhere; margin-bottom: 7px; }
+.inspector-text { white-space: pre-wrap; overflow-wrap: anywhere; font-size: 12px; margin: 12px 0; max-height: 230px; overflow-y: auto; }
+.inspector .actions { gap: 4px; flex-wrap: wrap; margin: 10px 0; }
+.inspector section { border-top: 1px solid var(--border); margin-top: 16px; padding-top: 12px; }
+.inspector h3 { font-size: 11px; letter-spacing: .04em; color: var(--weak); margin-bottom: 9px; font-weight: 500; }
+.inspector select { width: 100%; margin: 6px 0 10px; }
+.inspector .small { font-size: 10px; }
+.connection { display: flex; align-items: center; gap: 2px; }
+.connection .link-target { flex: 1; min-width: 0; text-align: left; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-size: 11px; }
+.connection small { font-size: 9px; display: block; }
+.bottom { justify-content: space-between; padding: 9px 20px; color: var(--weak); font-size: 10px; min-height: 34px; }
+.legend { display: inline-flex; gap: 12px; }
+.legend span::before { content: '●'; color: var(--accent); font-size: 7px; margin-right: 5px; }
+dialog { color: var(--text); background: var(--paper); border: 1px solid var(--border); border-radius: 16px; padding: 21px; width: min(460px, calc(100vw - 24px)); max-height: calc(100vh - 28px); overflow-y: auto; box-shadow: 0 16px 60px #0003; }
+dialog::backdrop { background: #1b27284d; }
+.dialog-head { justify-content: space-between; margin-bottom: 15px; }
+.dialog-head h2 { font-size: 18px; }
+.dialog-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 19px; }
+.source-option { display: flex; align-items: center; gap: 9px; padding: 8px 2px; border-bottom: 1px solid var(--border); overflow-wrap: anywhere; }
+.source-list { max-height: 260px; overflow-y: auto; }
+#toast { position: fixed; bottom: 43px; left: 50%; transform: translateX(-50%); max-width: min(540px, 92vw); width: max-content; border: 1px solid var(--border); background: var(--text); color: var(--paper); border-radius: 11px; padding: 11px 15px; font-size: 12px; box-shadow: 0 4px 20px #0002; z-index: 20; }
+.fault { padding: 25px; height: 100%; overflow-y: auto; }
+.fault h2 { font-size: 18px; margin-bottom: 15px; }
+.mini { padding: 14px 17px; height: 100%; overflow: hidden; }
+.mini-head { display: flex; justify-content: space-between; align-items: center; color: var(--weak); font-size: 11px; margin-bottom: 13px; }
+.mini-head strong { color: var(--accent); font-size: 15px; font-weight: 500; }
+.mini-count { font-size: 23px; color: var(--accent); margin-right: 5px; }
+.mini-row { display: flex; align-items: center; gap: 9px; margin-top: 10px; }
+.mini-row img { width: 39px; height: 34px; object-fit: cover; border-radius: 6px; }
+.mini-row span { font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+@media (max-width: 760px) { .inspector { position: absolute; right: 12px; bottom: 12px; width: min(320px, calc(100% - 24px)); max-height: calc(100% - 24px); border: 1px solid var(--border); border-radius: 13px; box-shadow: 0 8px 35px #0002; } }
+@media (max-width: 520px) {
+  .top { padding: 10px 12px 0; } .intro { display: none; } .tools { padding-top: 12px; gap: 6px; }
+  .tabs button { padding-inline: 7px; } .source-button { font-size: 11px; padding-inline: 4px; }
+  .search-row { gap: 5px; } .map-hint { display: none; } .cards-pane { padding: 12px; } .card-grid { gap: 12px; }
+  .card-art img { height: 135px; } .local-badge { display: none; } .bottom { padding: 7px 12px; } .legend { gap: 7px; }
+}
+@media (max-width: 330px) { .tools .actions { width: 100%; } .search-row { flex-wrap: wrap; } .source-button { margin-left: auto; } .brand { font-size: 14px; } }
+@media (max-height: 490px) { .intro { display: none; } .top { padding-top: 7px; } .brand-row { min-height: 25px; } .tools { padding-block: 5px; } .search-row { padding-bottom: 7px; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { transition: none !important; animation: none !important; scroll-behavior: auto !important; } }
+
+@media (max-width: 520px) and (max-height: 550px) { .inspector-art { height: 86px; } }

--- a/plugins/com.papertodo.starpaper/NOTICE.txt
+++ b/plugins/com.papertodo.starpaper/NOTICE.txt
@@ -1,0 +1,8 @@
+Starpaper is distributed as part of the PaperTodo project under its existing terms.
+Full licensing terms (PolyForm Noncommercial License 1.0.0 and PaperTodo Individual Professional Use Additional Permission 1.0):
+https://github.com/snownico0722/PaperTodo/blob/75494e324c70d76ccd5aaaef20fd05c18a7d6083/LICENSE.md
+https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+Required Notice: PaperTodo Copyright © 2026 snownico0722. PaperTodo is licensed under the PolyForm Noncommercial License 1.0.0 together with the PaperTodo Individual Professional Use Additional Permission 1.0, available in the original project LICENSE file at https://github.com/snownico0722/PaperTodo/blob/main/LICENSE.md. Original project: https://github.com/snownico0722/PaperTodo
+
+Illustrations in web/art.js are original local vector artwork; no third-party image assets or web fonts are bundled.

--- a/plugins/com.papertodo.starpaper/README.md
+++ b/plugins/com.papertodo.starpaper/README.md
@@ -1,0 +1,93 @@
+# 星笺 · Starpaper
+
+把知识放成星图，把待办变成有画面的行动卡片。
+
+这是一个独立的 **PaperTodo API 2.1 Web 插件**，不是新的主管理页，不修改主程序、原始待办行、Markdown 编辑器或 Edge 窗口。没有账号、云端服务、联网请求和第三方前端依赖。可创建多张独立星图。
+
+## 安装与开始
+
+退出 PaperTodo，把安装包里的 `com.papertodo.starpaper` 文件夹放入 PaperTodo 的 `plugins/`，然后重新启动。最终位置必须是：
+
+```text
+PaperTodo.exe
+plugins/
+  com.papertodo.starpaper/
+    plugin.json
+    NOTICE.txt
+    web/
+      index.html
+      ...
+```
+
+在 PaperTodo 新建一张笔记纸，在正文插件选择中选择 **星笺 · Starpaper**。首次打开是空星图；先点“新建知识”，或点“选择纸片”勾选现有待办纸、内置 Markdown 笔记纸。没有选择前，只读取纸片列表，不扫描待办或笔记正文。
+
+需要宿主支持 API **2.1**；仅凭“4.0”版本字样不能判断协议兼容。插件文件变更后需要重启，不依赖热重载。更新时替换本插件文件即可，不要删除 `plugins/data/`；卸下插件文件并不等于备份或删除插件数据。
+
+## 知识星图
+
+- 新建、编辑、删除本地知识节点，使用纯文本正文和 `[[知识标题]]` 引用。可引用已选择的 Markdown 笔记标题。同名标题不猜测目标；引用按 Unicode NFC 归一化后精确匹配。
+- 选中的待办纸生成中心节点，原始待办成为周围节点。Markdown 笔记显示为只读引用节点，正文从原纸片读取，不另外保存副本。
+- 拖动节点摆放，拖动背景平移，滚轮缩放；双击空白处新建。选中一个节点后 Shift+单击另一节点连线，或用“关联”填写关系说明。
+- 搜索标题与正文，筛选完成状态，聚焦相邻节点；“全图”定位所有匹配节点，“整理布局”恢复自动布局。
+- Ctrl+Z / Ctrl+Y 撤销、重做星图编辑，包括知识、连线、布局和封面；**不会撤销原始待办的修改**。文本输入框保留浏览器自己的文本撤销。
+
+自动布局是确定性的静态布局，不持续运行力导向动画。渲染会裁掉屏幕之外的几何，但不会截断数据；大量节点适合通过搜索、筛选和聚焦缩小浏览范围。没有未经测量的“无限节点流畅”承诺。
+
+## 待办图鉴与插图
+
+图鉴显示所选纸片的真实待办。可新建待办、编辑文字、标记完成或恢复未完成，修改全部通过宿主 Workspace API，使用原始 Paper ID + Todo ID。没有删除原始待办、删除纸片或写入笔记正文的权限。
+
+八种原创离线矢量插画：星轨、书页、代码、生长、远行、活力、创作、专注。根据文字关键词选取默认主题，可手动切换。**这是确定性的本地插画，不是 AI 绘画，也不会把待办发送给模型。** 图片显示在星笺的图鉴和详情中，不会插入原始待办行。
+
+知识、引用笔记和待办均可使用本地 PNG / JPEG / WebP / GIF，也支持粘贴或拖入单张图片。导入时转为静态 WebP 缩略图，最长边不超过 1024 像素；存储副本不依赖原文件路径。GIF 使用解码时的静态帧，不保留动画；输入 SVG / HTML、外部图片 URL 不作为封面执行或加载。为控制解码内存，输入上限为 20 MiB、3200 万像素；压缩后的每张封面不超过 512 KiB。
+
+可以导出 **960×1120 PNG 插画卡片**和 **SVG 星图**。SVG 是节点、标题和关系的矢量示意，不是包含所有照片的画布截图。界面标签和图片卡片会按可视空间省略长标题，完整标题仍在详情、SVG 的 title 和原始数据中。
+
+## 保存、同步与失败处理
+
+知识、关联、位置、封面、所选来源和视图设置属于 per-paper frontend state，通过 `papertodo.saveState` 及时提交，由 `PaperBodyPluginDataStore` 保存。没有 localStorage、IndexedDB 或第二份主数据文件。`registerStateProvider` 是边界补交，不是唯一保存机制；Web bridge 的提交返回不等于磁盘持久化 ACK。
+
+原始待办和引用笔记只存在于 Workspace 快照，不进入插件备份。原始对象被删除、自动清理或无法读取时，有关系的引用会成为“引用暂不可用”，不会自动删除关系和封面。取消选择来源也不删除原纸片或历史封面。局部编辑历史最多 30 步，并有独立内存预算；不是重启后持久化的撤销日志。
+
+读取失败会保留上次完整快照，并禁用原待办编辑。刷新队列只发布最新完整结果，过期请求不能覆盖新选择。待办写入失败或确认丢失后不自动重发，只重新读取；用户应核对原待办后决定是否重试。文字编辑提交前还会检查最新快照，发现变化就拒绝覆盖；宿主 API 没有条件写入版本号，因此这不是跨进程原子 compare-and-swap。
+
+导入备份前必须确认；只替换这张星图，可撤销，不会创建或覆盖原始待办。跨设备、重新创建的原始纸片可能具有不同 ID，备份不能自动恢复它们。损坏数据或未来版本数据会阻止写入，并提供原始数据导出，不会用空白状态覆盖。
+
+宿主 API 2.1 的每张纸状态上限为 **10 MiB UTF-8 JSON**。提交前检测实际字节数，超限拒绝本次修改，不静默截断。大型图片集合建议分成多张星图；封面是预览，不是原始照片备份。
+
+## Edge、生命周期和主题
+
+正文使用宿主绘制的标准胶囊。独立 Edge Mini 为 **只读摘要**：未完成数量、知识数量和最多三项预览。它不保存状态、不注册顶栏或占用键盘输入，不把整个页面标记为交互区。`mini.ready()` 在首个工作区结果或错误视图完成布局后发送；窗口、队列、大小和 publication 仍由宿主控制。
+
+不声明 provider Runtime、不做后台轮询。正文可见时通过 Workspace 事件更新，重新激活/显示时刷新；Mini 每次显示刷新。正文不存在时，胶囊展示的是最后一次正文发布的摘要，**不承诺常驻后台实时统计**。隐藏时停止绘制，销毁时释放订阅、刷新队列和 ResizeObserver。
+
+正文与 Mini 接收 `stateChanged`，不原样回写造成回声。跟随宿主颜色与字体设置，支持缩小窗口和系统减少动效偏好。界面提供中文、英语、日语和韩语，可在插件设置选择；默认跟随系统语言。
+
+## 开发与打包
+
+源代码在本目录；`plugins/com.papertodo.starpaper/` 是可加载副本。API 和宿主边界以仓库的 `plugin-samples/README.md`、`doc/ARCHITECTURE.md`、`PaperTodo.Plugin.Abstractions` 为准，本文件不是另一份宿主架构。
+
+在仓库根目录运行以下完整命令。Python 3.10+、Node 22+；不需要 npm install，也不编译 .NET 插件：
+
+```powershell
+node --test .\plugin-samples\PaperTodo.Plugin.Starpaper\tests\core.test.cjs
+python .\plugin-samples\PaperTodo.Plugin.Starpaper\package.py --sync --output .\dist
+```
+
+打包脚本仅更新这个插件的文件，不删除 `.runtime/` 或 `plugins/data/`，也不会启动或终止 PaperTodo。更新已加载的插件前仍须自己退出主程序。`--check` 检查源代码与部署副本一致。
+
+浏览器行为测试：
+
+```powershell
+python -m pip install playwright==1.57.0
+python -m playwright install chromium
+python .\plugin-samples\PaperTodo.Plugin.Starpaper\tests\browser_test.py --screenshots .\dist\starpaper-screenshots
+```
+
+测试用 API 2.1 mock 验证 DOM 交互、调用参数、失败与生命周期，不等于 Windows/WPF/WebView2 真机验证。默认测试直接通过本地 HTTP 加载未修改的 HTML/CSP；只有导航受限的测试环境才使用 `--inline`，该模式不验证 CSP 和资源加载。`CHROMIUM_EXECUTABLE` 可指定已有 Chromium。
+
+直接打开 `web/preview.html` 可用内存演示数据体验；刷新即重置，不会修改 PaperTodo。`index.html` 脱离宿主只显示说明，绝不自动伪造用户数据。
+
+## 许可与知识影响
+
+沿用原项目授权，见 `NOTICE.txt` 与根目录 `LICENSE.md`。没有改变现有架构、ownership、插件合同、已确立技术路线或 Agent 执行规则，因此不改动 Architecture、Decisions 或 AGENTS，也不把独立分发的插件写成主程序内置功能。

--- a/plugins/com.papertodo.starpaper/plugin.json
+++ b/plugins/com.papertodo.starpaper/plugin.json
@@ -1,0 +1,61 @@
+{
+  "kind": "web",
+  "id": "com.papertodo.starpaper",
+  "name": "星笺 · Starpaper",
+  "description": "知识星图与待办插画。Knowledge constellations and illustrated, live-linked to-dos. Offline; no account or AI service required.",
+  "version": "1.0.0",
+  "apiVersion": "2.1",
+  "stateVersion": 1,
+  "maxPaperInstances": 0,
+  "entry": "web/index.html",
+  "miniEntry": "web/index.html",
+  "miniSize": {
+    "width": 320,
+    "height": 240
+  },
+  "miniMaxSize": {
+    "width": 320,
+    "height": 240
+  },
+  "permissions": [
+    "papers.read",
+    "papers.observe",
+    "todos.read",
+    "todos.observe",
+    "todos.append",
+    "todos.update",
+    "notes.read",
+    "notes.observe"
+  ],
+  "settings": [
+    {
+      "id": "language",
+      "type": "select",
+      "name": "语言 / Language",
+      "default": "auto",
+      "quick": true,
+      "options": [
+        {
+          "value": "auto",
+          "name": "系统 / System"
+        },
+        {
+          "value": "zh",
+          "name": "简体中文"
+        },
+        {
+          "value": "en",
+          "name": "English"
+        },
+        {
+          "value": "ja",
+          "name": "日本語"
+        },
+        {
+          "value": "ko",
+          "name": "한국어"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/com.papertodo.starpaper/web/app.js
+++ b/plugins/com.papertodo.starpaper/web/app.js
@@ -1,0 +1,791 @@
+(function () {
+  'use strict';
+  const C = window.StarCore, A = window.StarArt, I = window.StarI18n;
+  const $ = id => document.getElementById(id);
+  const app = $('app'), dialog = $('dialog');
+  const NS = 'http://www.w3.org/2000/svg';
+  const demo = document.body.dataset.preview === 'true' && !window.papertodo && !location.hostname.endsWith('.papertodo.local');
+  let host = window.papertodo;
+  let state = C.blank(), original = null, ready = false, blocked = false, mini = false, visible = true;
+  let locale = I.language('auto', navigator.language), t = I.translator(locale);
+  let papers = [], todos = [], sourceNotes = [], model = C.graph(state, [], []), positions = new Map();
+  let selection = null, focusId = null, query = '', camera = { x: 0, y: 0, k: 1 }, fitNeeded = true;
+  let size = { width: 600, height: 400 }, drag = null, suppressClick = false, frame = 0, toastTimer = 0;
+  let queue = null, unsubscribe = null, resize = null, stale = false, mounted = false, miniReady = false, workspaceLoaded = false;
+  let imageTarget = null, imageJob = 0, generation = 0, lastFocused = null;
+  const pending = new Set(), history = new C.History();
+  function el(tag, text, className) {
+    const node = document.createElement(tag);
+    if (text !== undefined) node.textContent = text;
+    if (className) node.className = className;
+    return node;
+  }
+  function svgEl(tag, attrs = {}, text) {
+    const node = document.createElementNS(NS, tag);
+    for (const [key, value] of Object.entries(attrs)) node.setAttribute(key, value);
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+  function button(text, action, className = '') {
+    const node = el('button', text, className); node.type = 'button';
+    node.addEventListener('click', action); return node;
+  }
+  function short(text, length = 23) {
+    const chars = [...String(text)]; return chars.length > length ? chars.slice(0, length - 1).join('') + '…' : chars.join('');
+  }
+  function nodeTitle(node) { return node.title || t(node.missing ? 'unavailable' : 'untitled'); }
+  function scene(node) { return state.covers[node.id]?.scene || node.scene || C.sceneFor(node.title); }
+  function image(node) { return state.covers[node.id]?.image || A.data(scene(node), C.hash(node.id)); }
+  function toast(key, detail = '') {
+    const message = I.rows[key] ? t(key) : key;
+    $('toast').textContent = message + (detail ? ` (${short(detail, 140)})` : '');
+    $('toast').hidden = false; clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => { $('toast').hidden = true; }, 6500);
+  }
+  function problem(error) { toast(I.rows[error?.message] ? error.message : 'invalidState', I.rows[error?.message] ? '' : error?.message || ''); }
+  function translate() {
+    document.documentElement.lang = locale;
+    document.querySelectorAll('[data-i18n]').forEach(node => { node.textContent = t(node.dataset.i18n); });
+    document.querySelectorAll('[data-title]').forEach(node => { node.title = t(node.dataset.title); node.setAttribute('aria-label', t(node.dataset.title)); });
+    if ($('search')) $('search').placeholder = t('search');
+  }
+  function theme(value) {
+    if (!value) return;
+    const style = document.documentElement.style;
+    const mapping = { paperColor: '--paper', textColor: '--text', weakTextColor: '--weak', accentColor: '--accent', borderColor: '--border' };
+    for (const [key, name] of Object.entries(mapping)) if (typeof value[key] === 'string' && CSS.supports('color', value[key])) style.setProperty(name, value[key]);
+    if (value.fontFamily) style.setProperty('--font', `${JSON.stringify(value.fontFamily)}, system-ui, sans-serif`);
+    if (Number.isFinite(value.fontScale)) style.setProperty('--host-scale', String(Math.max(.5, Math.min(3, value.fontScale))));
+    const color = getComputedStyle(document.documentElement).getPropertyValue('--paper').trim();
+    if (/^#[\da-f]{6}$/i.test(color)) {
+      const n = parseInt(color.slice(1), 16), light = ((n >> 16) * .2126 + ((n >> 8) & 255) * .7152 + (n & 255) * .0722) > 140;
+      style.colorScheme = light ? 'light' : 'dark';
+    }
+  }
+  function claims() {
+    if (!mini && ready && host?.body?.setInputClaims) host.body.setInputClaims(dialog.open || selection || focusId ? ['escapeKey'] : []);
+  }
+  function commit(next, remember = true) {
+    if (!ready || blocked || mini) return false;
+    try {
+      C.validate(next);
+      const previous = state;
+      // saveState is transport submission, not a durable disk-write acknowledgement.
+      host.saveState(next);
+      if (remember) history.push(previous);
+      state = next; original = state;
+      render();
+      return true;
+    } catch (error) { problem(error); return false; }
+  }
+  function undo(redo = false) {
+    const stack = redo ? history.future : history.past;
+    if (!stack.length) return;
+    const previous = state, entry = stack[stack.length - 1];
+    const next = { ...entry.state, view: state.view, filter: state.filter };
+    if (commit(next, false)) {
+      imageJob++;
+      if (redo) history.redo(previous); else history.undo(previous);
+      queue.request(); render();
+    }
+  }
+  function mount() {
+    if (mounted) return;
+    mounted = true;
+    app.innerHTML = `<div class="shell">
+      <div class="demo-banner" id="demo-banner" hidden data-i18n="demo"></div>
+      <header class="top">
+        <div class="brand-row"><div class="brand"><span class="brand-mark" aria-hidden="true">✦</span><span data-i18n="name"></span><span class="local-badge" data-i18n="local"></span></div>
+          <div class="actions"><button type="button" class="icon" id="undo" data-title="undo">↶</button><button type="button" class="icon" id="redo" data-title="redo">↷</button>
+            <details class="menu" id="menu"><summary data-title="more">⋯</summary><div class="menu-items">
+              <button type="button" id="export" data-i18n="export"></button><button type="button" id="import" data-i18n="import"></button><button type="button" id="export-svg" data-i18n="exportSvg"></button>
+              <label><input type="checkbox" id="wiki"><span data-i18n="wiki"></span></label><button type="button" id="help" data-i18n="help"></button>
+            </div></details></div></div>
+        <div class="intro"><h1 data-i18n="tagline"></h1><p data-i18n="savedByHost"></p></div>
+        <div class="tools"><div class="tabs" role="tablist"><button type="button" id="tab-map" role="tab" aria-controls="map-pane" data-i18n="map"></button><button type="button" id="tab-cards" role="tab" aria-controls="cards-pane" data-i18n="cards"></button></div>
+          <div class="actions"><button type="button" id="add-note" class="primary">＋ <span data-i18n="newNote"></span></button><button type="button" id="add-todo" class="secondary">＋ <span data-i18n="newTodo"></span></button></div></div>
+        <div class="search-row"><input id="search" type="search" autocomplete="off" data-title="search"><select id="filter" data-title="all"><option value="all" data-i18n="all"></option><option value="open" data-i18n="open"></option><option value="done" data-i18n="done"></option></select><button type="button" id="sources" class="source-button secondary" data-i18n="sources"></button><button type="button" id="refresh" class="icon" data-title="refresh">↻</button></div>
+      </header>
+      <div class="status-banner" id="status-banner" hidden data-i18n="stale"></div>
+      <main class="stage" id="stage">
+        <div class="map-pane" id="map-pane" role="tabpanel" aria-labelledby="tab-map"><svg id="canvas" role="region" tabindex="0" data-title="hint"><g id="world"></g></svg><div id="map-empty" class="empty" hidden></div>
+          <span class="map-hint" data-i18n="hint"></span><div class="map-controls"><button type="button" id="unfocus" hidden data-i18n="unfocus"></button><button type="button" id="zoom-out" data-title="zoomOut">−</button><button type="button" id="fit" data-i18n="fit"></button><button type="button" id="zoom-in" data-title="zoomIn">＋</button><button type="button" id="arrange" data-i18n="arrange"></button></div></div>
+        <div class="cards-pane" id="cards-pane" role="tabpanel" aria-labelledby="tab-cards" hidden><div class="card-grid" id="card-grid"></div><div class="empty" id="cards-empty" hidden></div></div>
+        <aside class="inspector" id="inspector" hidden></aside>
+      </main>
+      <footer class="bottom"><span id="stats"></span><span class="legend"><span data-i18n="knowledge"></span><span data-i18n="tasks"></span></span></footer>
+    </div>`;
+    $('demo-banner').hidden = !demo;
+    $('undo').onclick = () => undo(); $('redo').onclick = () => undo(true);
+    $('add-note').onclick = () => editNote(); $('add-todo').onclick = () => newTodo();
+    $('sources').onclick = chooseSources; $('refresh').onclick = () => queue.request();
+    $('search').addEventListener('input', e => { query = e.target.value; fitNeeded = true; render(); });
+    $('filter').onchange = e => { fitNeeded = true; commit({ ...state, filter: e.target.value }, false); };
+    for (const view of ['map', 'cards']) $(`tab-${view}`).onclick = () => { commit({ ...state, view }, false); schedulePaint(); };
+    $('fit').onclick = fitAll;
+    $('zoom-in').onclick = () => { camera = C.zoom(camera, 1.25, size.width / 2, size.height / 2); schedulePaint(); };
+    $('zoom-out').onclick = () => { camera = C.zoom(camera, .8, size.width / 2, size.height / 2); schedulePaint(); };
+    $('arrange').onclick = () => confirmDialog('arrange', 'arrangeHint', () => { fitNeeded = true; return commit({ ...state, positions: {} }); });
+    $('unfocus').onclick = () => { focusId = null; fitNeeded = true; render(); };
+    $('export').onclick = () => downloadJson(state);
+    $('import').onclick = () => { $('backup-file').value = ''; $('backup-file').click(); };
+    $('export-svg').onclick = exportMap;
+    $('wiki').onchange = e => commit({ ...state, wiki: e.target.checked });
+    $('help').onclick = () => openForm('help', area => { area.append(el('p', t('helpText')), el('p', t('savedByHost'), 'small')); if (demo) area.append(el('p', t('previewOnly'), 'small')); }, () => true, 'close');
+    $('menu').querySelectorAll('button').forEach(node => node.addEventListener('click', () => { $('menu').open = false; }));
+    bindCanvas();
+    resize = new ResizeObserver(() => {
+      if (state.view !== 'map' || !visible) return;
+      const rect = $('map-pane').getBoundingClientRect();
+      if (!rect.width || !rect.height) return;
+      camera.x += (rect.width - size.width) / 2; camera.y += (rect.height - size.height) / 2;
+      size = { width: rect.width, height: rect.height }; schedulePaint();
+    });
+    resize.observe($('map-pane'));
+    translate();
+  }
+  function rebuild() {
+    model = C.graph(state, papers, todos, sourceNotes); positions = C.layout(model, state.positions);
+    if (selection && !model.byId.has(selection)) selection = null;
+    if (focusId && !model.byId.has(focusId)) focusId = null;
+  }
+  function render() {
+    if (!ready || blocked) return;
+    app.setAttribute('aria-busy', 'false');
+    rebuild();
+    if (mini) { renderMini(); return; }
+    mount();
+    $('tab-map').setAttribute('aria-selected', state.view === 'map');
+    $('tab-cards').setAttribute('aria-selected', state.view === 'cards');
+    $('map-pane').hidden = state.view !== 'map'; $('cards-pane').hidden = state.view !== 'cards';
+    $('filter').value = state.filter; $('wiki').checked = state.wiki;
+    $('undo').disabled = !history.past.length; $('redo').disabled = !history.future.length;
+    $('add-todo').disabled = stale || pending.has('append');
+    $('status-banner').hidden = !stale; $('unfocus').hidden = !focusId;
+    const taskNodes = model.nodes.filter(n => n.kind === 'todo'), done = taskNodes.filter(n => n.done).length;
+    const ideas = model.nodes.filter(n => n.kind === 'note' || n.kind === 'note-ref').length;
+    $('stats').textContent = `${ideas} ${t('knowledge')} · ${done}/${taskNodes.length} ${t('tasks')} · ${state.sources.length} ${t('papers')}`;
+    if (visible) { if (state.view === 'cards') renderCards(); renderInspector(); schedulePaint(); }
+    const caption = `${t('name')} · ${taskNodes.length - done} ${t('open')} · ${ideas} ${t('knowledge')}`;
+    host.paper.setHeaderText(caption);
+    host.paper.setCapsulePresentation({ preferredWidth: 0, plainText: caption, components: [{ kind: 'text', text: `✦ ${taskNodes.length - done} · ${ideas}`, fill: true }] });
+    claims();
+  }
+  function emptyContent(container, filtered = false, cards = false) {
+    container.replaceChildren(el('div', '✦', 'empty-mark'), el('h2', t(filtered ? 'noMatch' : cards ? 'noTasks' : 'emptyTitle')), el('p', t('emptyText')));
+    const actions = el('div', undefined, 'actions');
+    if (filtered) actions.append(button(t('clearFilter'), () => { query = ''; $('search').value = ''; focusId = null; fitNeeded = true; commit({ ...state, filter: 'all' }, false); }, 'secondary'));
+    else actions.append(button(t(cards ? 'newTodo' : 'newNote'), () => cards ? newTodo() : editNote(), 'primary'), button(t('sources'), chooseSources, 'secondary'));
+    container.append(actions);
+  }
+  function renderCards() {
+    const nodes = C.visibleGraph(model, state.filter, query).nodes.filter(n => n.kind === 'todo');
+    const focused = document.activeElement, focusedId = focused?.closest('[data-card]')?.dataset.card;
+    const focusedAction = focused?.dataset.action;
+    const grid = $('card-grid'); grid.replaceChildren();
+    $('cards-empty').hidden = nodes.length !== 0;
+    if (!nodes.length) emptyContent($('cards-empty'), !!query || state.filter !== 'all', true);
+    for (const node of nodes) {
+      const card = el('article', undefined, `task-card${node.done ? ' done' : ''}${selection === node.id ? ' selected' : ''}`);
+      const cover = button('', () => select(node.id), 'card-art'); cover.setAttribute('aria-label', nodeTitle(node));
+      const img = el('img'); img.src = image(node); img.alt = ''; img.loading = 'lazy'; img.width = 320; img.height = 210; cover.append(img);
+      const content = el('div', undefined, 'card-content');
+      content.append(el('div', node.todo.paperTitle || t('untitled'), 'card-meta'), button(node.title, () => select(node.id), 'card-title'), completion(node));
+      card.dataset.card = node.id; card.append(cover, content); grid.append(card);
+      if (focusedId === node.id && focusedAction === 'completion') card.querySelector('[data-action=completion]').focus({ preventScroll: true });
+    }
+  }
+  function completion(node) {
+    const control = button('', () => mutate(node.id, 'todos.update', { paperId: node.todo.paperId, todoId: node.todo.id, done: !node.done }), 'completion');
+    control.dataset.action = 'completion';
+    control.setAttribute('role', 'checkbox'); control.setAttribute('aria-checked', String(node.done));
+    control.setAttribute('aria-label', `${t(node.done ? 'reopen' : 'complete')}: ${node.title}`);
+    control.disabled = stale || pending.has(node.id);
+    if (pending.has(node.id)) control.setAttribute('aria-busy', 'true');
+    control.append(el('span', pending.has(node.id) ? '·' : node.done ? '✓' : '', 'checkmark'), el('span', t(node.done ? 'done' : 'open')));
+    return control;
+  }
+  function select(id) { selection = id; render(); }
+  function renderInspector() {
+    const area = $('inspector'), node = model.byId.get(selection);
+    area.hidden = !node; area.replaceChildren(); if (!node) return;
+    const heading = el('div', undefined, 'inspector-head');
+    heading.append(el('span', t(['note', 'note-ref'].includes(node.kind) ? 'knowledge' : node.kind === 'todo' ? 'tasks' : node.kind === 'paper' ? 'papers' : 'unavailable')), button('×', () => { selection = null; render(); }, 'icon'));
+    heading.lastChild.setAttribute('aria-label', t('close')); area.append(heading);
+    if (['note', 'note-ref', 'todo'].includes(node.kind)) {
+      const img = el('img', undefined, 'inspector-art'); img.src = image(node); img.alt = ''; area.append(img);
+    }
+    area.append(el('h2', nodeTitle(node)));
+    if (node.kind === 'todo') area.append(el('p', node.todo.paperTitle || t('untitled'), 'small'), completion(node));
+    if (node.missing) area.append(el('p', t('missingHint'), 'small'));
+    if (node.kind === 'note-ref') area.append(el('p', t('readOnlyNote'), 'small'));
+    if (node.unavailable) area.append(el('p', t('unavailable'), 'small'));
+    if (['note', 'note-ref'].includes(node.kind) && node.body) area.append(el('div', node.body, 'inspector-text'));
+    const actions = el('div', undefined, 'actions');
+    if (node.kind === 'note' || node.kind === 'todo') {
+      const edit = button(t('edit'), () => node.kind === 'note' ? editNote(node) : editTodo(node), 'secondary');
+      edit.disabled = node.kind === 'todo' && (stale || pending.has(node.id)); actions.append(edit);
+    }
+    actions.append(button(t('link'), () => editLink(node.id), 'secondary'));
+    actions.append(button(t(focusId === node.id ? 'unfocus' : 'focus'), () => { focusId = focusId === node.id ? null : node.id; fitNeeded = true; render(); }, 'secondary'));
+    area.append(actions);
+    if (['note', 'note-ref', 'todo'].includes(node.kind)) {
+      const section = el('section'); section.append(el('h3', t('illustration')));
+      const picker = el('select'); picker.setAttribute('aria-label', t('illustration'));
+      C.SCENES.forEach(value => { const option = el('option', t(value === 'focus' ? 'focusScene' : value)); option.value = value; picker.append(option); });
+      picker.value = scene(node);
+      picker.onchange = () => { imageJob++; commit({ ...state, covers: { ...state.covers, [node.id]: { scene: picker.value } } }); };
+      section.append(picker, button(t('image'), () => { imageTarget = node.id; $('image-file').value = ''; $('image-file').click(); }, 'secondary wide'), el('p', t('imageHint'), 'small'));
+      section.append(button(t('resetCover'), () => { imageJob++; const covers = { ...state.covers }; delete covers[node.id]; commit({ ...state, covers }); }, 'wide'));
+      section.append(button(t('exportCard'), () => exportCard(node).catch(problem), 'wide'));
+      area.append(section);
+    }
+    const links = model.edges.filter(e => e.from === node.id || e.to === node.id);
+    if (links.length) {
+      const section = el('section'); section.append(el('h3', t('related')));
+      links.forEach(edge => {
+        const target = model.byId.get(edge.from === node.id ? edge.to : edge.from), row = el('div', undefined, 'connection');
+        const targetButton = button(nodeTitle(target), () => select(target.id), 'link-target');
+        targetButton.title = nodeTitle(target); targetButton.append(el('small', edge.label || t(edge.kind === 'contains' ? 'contains' : edge.kind === 'wiki' ? 'reference' : 'manual')));
+        row.append(targetButton);
+        if (edge.kind === 'manual') {
+          const remove = button('×', () => commit({ ...state, links: state.links.filter(e => C.pair(e.from, e.to) !== C.pair(edge.from, edge.to)) }), 'icon');
+          remove.setAttribute('aria-label', t('unlink')); row.append(remove);
+        }
+        section.append(row);
+      });
+      area.append(section);
+    }
+    if (node.kind === 'note') {
+      const section = el('section'); section.append(button(t('remove'), () => confirmDialog('remove', 'removeHint', () => commit(C.removeNote(state, node.id)), true), 'danger wide')); area.append(section);
+    }
+  }
+  function schedulePaint() {
+    if (frame || !visible || mini || !mounted || state.view !== 'map') return;
+    frame = requestAnimationFrame(() => { frame = 0; paint(); });
+  }
+  function fitAll() { fitNeeded = true; schedulePaint(); }
+  function paint() {
+    if (!visible || state.view !== 'map' || !mounted) return;
+    const rect = $('map-pane').getBoundingClientRect(); if (!rect.width || !rect.height) return;
+    size = { width: rect.width, height: rect.height };
+    const filtered = C.visibleGraph(model, state.filter, query, focusId);
+    if (fitNeeded) { camera = C.fit(filtered.nodes, positions, size.width, size.height); fitNeeded = false; }
+    $('map-empty').hidden = filtered.nodes.length !== 0;
+    if (!filtered.nodes.length) emptyContent($('map-empty'), !!query || state.filter !== 'all' || !!focusId);
+    const world = $('world');
+    const activeId = document.activeElement?.dataset?.node;
+    world.replaceChildren(); world.setAttribute('transform', `translate(${camera.x} ${camera.y}) scale(${camera.k})`);
+    const visibleIds = new Set(filtered.nodes.filter(node => {
+      const p = positions.get(node.id), x = p.x * camera.k + camera.x, y = p.y * camera.k + camera.y;
+      return x > -150 && y > -100 && x < size.width + 150 && y < size.height + 100;
+    }).map(n => n.id));
+    for (const edge of filtered.edges) {
+      const a = positions.get(edge.from), b = positions.get(edge.to);
+      // Cull only offscreen geometry, never truncate the graph's data.
+      if (!visibleIds.has(edge.from) && !visibleIds.has(edge.to)) {
+        const left = Math.min(a.x, b.x) * camera.k + camera.x, right = Math.max(a.x, b.x) * camera.k + camera.x;
+        const top = Math.min(a.y, b.y) * camera.k + camera.y, bottom = Math.max(a.y, b.y) * camera.k + camera.y;
+        if (right < 0 || left > size.width || bottom < 0 || top > size.height) continue;
+      }
+      const highlight = selection === edge.from || selection === edge.to;
+      world.append(svgEl('line', { x1: a.x, y1: a.y, x2: b.x, y2: b.y, class: `edge ${edge.kind}${highlight ? ' highlight' : ''}` }));
+      if (edge.label && highlight && camera.k > .35) world.append(svgEl('text', { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 - 7, class: 'edge-label' }, short(edge.label, 24)));
+    }
+    let index = 0;
+    for (const node of filtered.nodes) {
+      if (!visibleIds.has(node.id)) continue;
+      const p = positions.get(node.id), colors = A.palette(scene(node)), radius = node.kind === 'paper' ? 30 : ['note', 'note-ref'].includes(node.kind) ? 26 : 22;
+      const g = svgEl('g', { transform: `translate(${p.x} ${p.y})`, class: `node ${node.kind}${node.done ? ' done' : ''}${selection === node.id ? ' selected' : ''}`, role: 'button', tabindex: '0', 'data-node': node.id, 'aria-label': nodeTitle(node) });
+      g.append(svgEl('title', {}, nodeTitle(node)), svgEl('circle', { r: radius + 8, class: 'halo' }));
+      g.append(svgEl('circle', { r: radius, fill: node.kind === 'paper' ? 'var(--wash)' : colors[0], stroke: node.kind === 'paper' ? 'var(--accent)' : colors[2], 'stroke-width': 1.6 }));
+      if (node.kind === 'todo' && camera.k > .3) {
+        const clipId = `star-clip-${index++}`, clip = svgEl('clipPath', { id: clipId }); clip.append(svgEl('circle', { r: radius - 1 })); g.append(clip);
+        g.append(svgEl('image', { href: image(node), x: -radius, y: -radius, width: radius * 2, height: radius * 2, preserveAspectRatio: 'xMidYMid slice', 'clip-path': `url(#${clipId})` }));
+        if (node.done) g.append(svgEl('text', { y: 1, class: 'node-symbol', fill: colors[1] }, '✓'));
+      } else g.append(svgEl('text', { y: 1, class: 'node-symbol', fill: colors[1] }, ['note', 'note-ref'].includes(node.kind) ? '✦' : node.kind === 'paper' ? '▤' : node.kind === 'missing' ? '?' : node.done ? '✓' : '·'));
+      if (camera.k > .22 || selection === node.id) g.append(svgEl('text', { y: radius + 21, class: 'node-label', style: `font-size:${Math.max(12, 10 / camera.k)}px` }, short(nodeTitle(node))));
+      world.append(g);
+      if (activeId === node.id) g.focus({ preventScroll: true });
+    }
+  }
+  function localPoint(event) { const r = $('canvas').getBoundingClientRect(); return { x: event.clientX - r.left, y: event.clientY - r.top }; }
+  function cancelDrag() {
+    if (!drag) return;
+    const pointer = drag.pointer; drag = null; rebuild();
+    if ($('canvas')) { $('canvas').classList.remove('dragging'); if ($('canvas').hasPointerCapture(pointer)) $('canvas').releasePointerCapture(pointer); }
+    schedulePaint();
+  }
+  function bindCanvas() {
+    const canvas = $('canvas');
+    canvas.addEventListener('pointerdown', e => {
+      if (e.button !== 0 || drag) return;
+      const node = e.target.closest('[data-node]');
+      if (node) node.focus({ preventScroll: true }); else canvas.focus({ preventScroll: true });
+      drag = { pointer: e.pointerId, x: e.clientX, y: e.clientY, key: node?.dataset.node, camera: { ...camera }, pos: node ? { ...positions.get(node.dataset.node) } : null, moved: false, generation };
+
+    });
+    canvas.addEventListener('pointermove', e => {
+      if (!drag || drag.pointer !== e.pointerId) return;
+      const dx = e.clientX - drag.x, dy = e.clientY - drag.y;
+      if (!drag.moved && Math.hypot(dx, dy) < 4) return;
+      if (!canvas.hasPointerCapture(e.pointerId)) canvas.setPointerCapture(e.pointerId);
+      drag.moved = true; canvas.classList.add('dragging');
+      if (drag.key) positions.set(drag.key, { x: drag.pos.x + dx / camera.k, y: drag.pos.y + dy / camera.k });
+      else camera = { ...drag.camera, x: drag.camera.x + dx, y: drag.camera.y + dy };
+      schedulePaint();
+    });
+    canvas.addEventListener('pointerup', e => {
+      if (!drag || drag.pointer !== e.pointerId) return;
+      const completed = drag, position = completed.key ? positions.get(completed.key) : null;
+      drag = null; canvas.classList.remove('dragging');
+      if (canvas.hasPointerCapture(e.pointerId)) canvas.releasePointerCapture(e.pointerId);
+      if (completed.moved) {
+        suppressClick = true; setTimeout(() => { suppressClick = false; }, 80);
+        if (completed.key && completed.generation === generation) {
+          if (!commit({ ...state, positions: { ...state.positions, [completed.key]: position } })) { rebuild(); schedulePaint(); }
+        }
+      }
+    });
+    canvas.addEventListener('pointercancel', cancelDrag);
+    canvas.addEventListener('pointerleave', () => { if (drag && !canvas.hasPointerCapture(drag.pointer)) cancelDrag(); });
+    canvas.addEventListener('lostpointercapture', cancelDrag);
+    canvas.addEventListener('click', e => {
+      if (suppressClick) return;
+      const node = e.target.closest('[data-node]');
+      if (!node) { selection = null; render(); return; }
+      const key = node.dataset.node;
+      if (e.shiftKey && selection && selection !== key) commit(C.setLink(state, selection, key));
+      else select(key);
+    });
+    canvas.addEventListener('dblclick', e => {
+      if (e.target.closest('[data-node]')) return;
+      const p = localPoint(e); editNote(null, { x: (p.x - camera.x) / camera.k, y: (p.y - camera.y) / camera.k });
+    });
+    canvas.addEventListener('wheel', e => {
+      e.preventDefault(); const p = localPoint(e);
+      camera = C.zoom(camera, Math.exp(-e.deltaY * (e.deltaMode === 1 ? .04 : .0015)), p.x, p.y); schedulePaint();
+    }, { passive: false });
+  }
+  function closeDialog() {
+    if (dialog.open) dialog.close(); claims();
+    if (lastFocused?.isConnected) lastFocused.focus({ preventScroll: true });
+  }
+  function openForm(titleKey, build, submit, submitKey = 'save', danger = false) {
+    if (mini || blocked) return;
+    if (dialog.open) dialog.close();
+    lastFocused = document.activeElement;
+    dialog.replaceChildren();
+    const form = el('form'), head = el('div', undefined, 'dialog-head'), area = el('div'), actions = el('div', undefined, 'dialog-actions');
+    head.append(el('h2', t(titleKey)), button('×', closeDialog, 'icon')); head.lastChild.setAttribute('aria-label', t('close'));
+    const submitButton = el('button', t(submitKey), danger ? 'danger' : 'primary'); submitButton.type = 'submit';
+    actions.append(button(t('cancel'), closeDialog, 'secondary'), submitButton);
+    form.append(head, area, actions); dialog.append(form); build(area);
+    form.addEventListener('submit', async e => {
+      e.preventDefault(); if (submitButton.disabled || !form.reportValidity()) return;
+      submitButton.disabled = true;
+      try { if (await submit(area)) { if (dialog.contains(form)) closeDialog(); } }
+      catch (error) { problem(error); }
+      finally { submitButton.disabled = false; }
+    });
+    dialog.showModal(); claims();
+  }
+  function confirmDialog(title, body, action, danger = false) {
+    openForm(title, area => area.append(el('p', t(body))), action, 'save', danger);
+  }
+  function field(area, caption, tag = 'input', value = '') {
+    const label = el('label', undefined, 'field'); label.append(el('span', t(caption)));
+    const input = el(tag); input.value = value; label.append(input); area.append(label); return input;
+  }
+  async function chooseSources() {
+    await queue.request();
+    if (stale) { toast('stale'); return; }
+    const choices = new Map();
+    openForm('sources', area => {
+      area.append(el('p', t('sourceHint'), 'small'));
+      if (!papers.length) area.append(el('p', t('noPaper')));
+      const list = el('div', undefined, 'source-list');
+      const available = papers.map(p => ({ id: p.id, title: p.title || t('untitled') }));
+      state.sources.filter(id => !papers.some(p => p.id === id)).forEach(id => available.push({ id, title: `${t('unavailable')} · ${short(id, 12)}` }));
+      available.forEach(paper => {
+        const label = el('label', undefined, 'source-option'), input = el('input'); input.type = 'checkbox'; input.checked = state.sources.includes(paper.id);
+        choices.set(paper.id, input); label.append(input, el('span', paper.title)); list.append(label);
+      });
+      area.append(list);
+    }, () => {
+      const sources = [...choices].filter(([, input]) => input.checked).map(([key]) => key);
+      if (!commit({ ...state, sources })) return false;
+      fitNeeded = true; queue.request(); return true;
+    });
+  }
+  function editNote(node = null, point = null) {
+    let title, body;
+    const baseline = node ? JSON.stringify(state.notes.find(n => n.id === node.id)) : null;
+    openForm(node ? 'edit' : 'newNote', area => {
+      title = field(area, 'title', 'input', node?.title || ''); title.required = true;
+      body = field(area, 'body', 'textarea', node?.body || '');
+    }, () => {
+      if (!title.value.trim()) { title.focus(); return false; }
+      if (node && baseline !== JSON.stringify(state.notes.find(n => n.id === node.id))) { toast('conflict'); return false; }
+      const id = node?.id || `n:${crypto.randomUUID()}`;
+      const note = { id, title: title.value.trim(), body: body.value };
+      const next = { ...state, notes: node ? state.notes.map(n => n.id === id ? note : n) : [...state.notes, note] };
+      if (point) next.positions = { ...state.positions, [id]: point };
+      if (!commit(next)) return false;
+      selection = id; if (!point && !node) fitNeeded = true; render(); return true;
+    });
+  }
+  function newTodo() {
+    if (stale) { toast('stale'); return; }
+    const targets = papers.filter(p => p.type === 'todo' && state.sources.includes(p.id));
+    if (!targets.length) { chooseSources(); return; }
+    let paper, text;
+    openForm('newTodo', area => {
+      paper = field(area, 'papers', 'select');
+      targets.forEach(p => { const option = el('option', p.title || t('untitled')); option.value = p.id; paper.append(option); });
+      text = field(area, 'title'); text.required = true;
+    }, async () => {
+      if (!text.value.trim()) { text.focus(); return false; }
+      return mutate('append', 'todos.append', { paperId: paper.value, todos: [{ text: text.value.trim() }] });
+    });
+  }
+  function editTodo(node) {
+    let text;
+    const baseline = node.todo.text;
+    openForm('edit', area => { text = field(area, 'title', 'textarea', baseline); text.required = true; }, async () => {
+      if (!text.value.trim()) { text.focus(); return false; }
+      await queue.request();
+      const latest = model.byId.get(node.id);
+      if (stale || latest?.kind !== 'todo' || latest.todo.text !== baseline) { toast('conflict'); return false; }
+      return mutate(node.id, 'todos.update', { paperId: node.todo.paperId, todoId: node.todo.id, text: text.value });
+    });
+  }
+  function editLink(from) {
+    const candidates = model.nodes.filter(n => n.id !== from);
+    if (!candidates.length) { toast('noTarget'); return; }
+    let target, label;
+    openForm('link', area => {
+      target = field(area, 'target', 'select');
+      candidates.forEach(node => { const option = el('option', nodeTitle(node)); option.value = node.id; target.append(option); });
+      label = field(area, 'relation');
+    }, () => {
+      if (!model.byId.has(from) || !model.byId.has(target.value)) { toast('conflict'); return false; }
+      return commit(C.setLink(state, from, target.value, label.value));
+    });
+  }
+  async function mutate(key, method, params) {
+    if (!ready || blocked || mini || stale || pending.has(key)) return false;
+    const restoreTaskFocus = document.activeElement?.dataset.action === 'completion' && document.activeElement?.closest('[data-card]')?.dataset.card === key;
+    pending.add(key); render();
+    try {
+      await host.workspace.request(method, params);
+      await queue.request();
+      return true;
+    } catch (error) {
+      stale = true;
+      toast('operationFailed', error?.code || error?.message || '');
+      // A timeout can mean "committed, acknowledgement lost". Read only; never replay a mutation.
+      await queue.request();
+      return false;
+    } finally {
+      pending.delete(key); render();
+      if (restoreTaskFocus && document.activeElement === document.body) {
+        const card = [...document.querySelectorAll('[data-card]')].find(card => card.dataset.card === key);
+        card?.querySelector('[data-action=completion]')?.focus({ preventScroll: true });
+      }
+    }
+  }
+  function loadImage(source) {
+    return new Promise((resolve, reject) => {
+      const img = new Image(); img.onload = () => resolve(img); img.onerror = () => reject(new Error('invalidImage')); img.src = source;
+    });
+  }
+  async function compressImage(file) {
+    if (!file || !/^image\/(png|jpeg|webp|gif)$/.test(file.type)) throw new Error('invalidImage');
+    if (file.size > 20 * 1024 * 1024) throw new Error('imageTooLarge');
+    const url = URL.createObjectURL(file);
+    try {
+      const img = await loadImage(url);
+      if (!img.naturalWidth || img.naturalWidth * img.naturalHeight > 32e6) throw new Error('imageTooLarge');
+      const canvas = document.createElement('canvas');
+      let ratio = Math.min(1, 1024 / Math.max(img.naturalWidth, img.naturalHeight));
+      // Covers need thumbnail quality, not a second full-resolution photo library.
+      for (let attempt = 0; attempt < 5; attempt++) {
+        canvas.width = Math.max(1, Math.round(img.naturalWidth * ratio)); canvas.height = Math.max(1, Math.round(img.naturalHeight * ratio));
+        canvas.getContext('2d').drawImage(img, 0, 0, canvas.width, canvas.height);
+        const data = canvas.toDataURL('image/webp', .82);
+        if (C.bytes(data) <= 512 * 1024) return data;
+        ratio *= .7;
+      }
+      throw new Error('imageTooLarge');
+    } finally { URL.revokeObjectURL(url); }
+  }
+  async function attachImage(file, target) {
+    const node = model.byId.get(target);
+    if (!node || !['note', 'todo', 'note-ref'].includes(node.kind)) { toast('selectedImage'); return; }
+    const job = ++imageJob, version = generation;
+    try {
+      const data = await compressImage(file);
+      if (job !== imageJob || version !== generation || !model.byId.has(target)) return;
+      commit({ ...state, covers: { ...state.covers, [target]: { scene: scene(model.byId.get(target)), image: data } } });
+    } catch (error) { problem(error); }
+  }
+  function download(content, type, name) {
+    const blob = content instanceof Blob ? content : new Blob([content], { type });
+    const url = URL.createObjectURL(blob), link = el('a'); link.href = url; link.download = name;
+    document.body.append(link); link.click(); link.remove(); setTimeout(() => URL.revokeObjectURL(url), 60000);
+  }
+  function downloadJson(value) {
+    download(JSON.stringify({ format: 'papertodo.starpaper', version: 1, state: value }), 'application/json', 'Starpaper-backup.json');
+  }
+  async function importBackup(file) {
+    if (!file) return;
+    try {
+      if (file.size > C.MAX_BYTES * 2) throw new Error('capacity'); // pretty-printed export can exceed compact JSON size
+      const value = JSON.parse(await file.text());
+      if (value.format !== 'papertodo.starpaper' || value.version !== 1) throw new Error('stateVersion');
+      const imported = C.validate(value.state);
+      confirmDialog('import', 'importHint', () => {
+        if (!commit(imported)) return false;
+        imageJob++; selection = null; focusId = null; query = ''; $('search').value = ''; fitNeeded = true;
+        queue.request(); render(); return true;
+      });
+    } catch (error) { problem(error); }
+  }
+  function exportMap() {
+    const filtered = C.visibleGraph(model, state.filter, query, focusId);
+    if (!filtered.nodes.length) { toast('noMatch'); return; }
+    const xs = filtered.nodes.map(n => positions.get(n.id).x), ys = filtered.nodes.map(n => positions.get(n.id).y);
+    const x = xs.reduce((a, b) => Math.min(a, b), Infinity) - 140, y = ys.reduce((a, b) => Math.min(a, b), Infinity) - 100;
+    const width = xs.reduce((a, b) => Math.max(a, b), -Infinity) - x + 140, height = ys.reduce((a, b) => Math.max(a, b), -Infinity) - y + 130;
+    const svg = svgEl('svg', { xmlns: NS, viewBox: `${x} ${y} ${width} ${height}`, width: Math.ceil(width), height: Math.ceil(height) });
+    const style = getComputedStyle(document.documentElement), paper = style.getPropertyValue('--paper').trim(), text = style.getPropertyValue('--text').trim(), accent = style.getPropertyValue('--accent').trim();
+    svg.append(svgEl('title', {}, t('map')), svgEl('rect', { x, y, width, height, fill: paper }));
+    filtered.edges.forEach(edge => {
+      const a = positions.get(edge.from), b = positions.get(edge.to);
+      const line = svgEl('line', { x1: a.x, y1: a.y, x2: b.x, y2: b.y, stroke: accent, 'stroke-opacity': '.45', 'stroke-width': 1.5 });
+      if (edge.kind !== 'manual') line.setAttribute('stroke-dasharray', '4 5');
+      svg.append(line);
+      if (edge.label) svg.append(svgEl('text', { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 - 5, fill: text, 'font-size': 11, 'text-anchor': 'middle' }, edge.label));
+    });
+    filtered.nodes.forEach(node => {
+      const p = positions.get(node.id), group = svgEl('g'); group.append(svgEl('title', {}, nodeTitle(node)));
+      group.append(svgEl('circle', { cx: p.x, cy: p.y, r: 23, fill: A.palette(scene(node))[0], stroke: accent, 'stroke-width': 1.5 }));
+      group.append(svgEl('text', { x: p.x, y: p.y + 6, 'text-anchor': 'middle', 'font-size': 18, fill: accent }, node.done ? '✓' : node.kind === 'paper' ? '▤' : '✦'));
+      group.append(svgEl('text', { x: p.x, y: p.y + 47, 'text-anchor': 'middle', 'font-family': 'sans-serif', 'font-size': 13, fill: text }, short(nodeTitle(node), 34)));
+      svg.append(group);
+    });
+    download(new XMLSerializer().serializeToString(svg), 'image/svg+xml', 'Starpaper-map.svg');
+  }
+  async function exportCard(node) {
+    const source = image(node), title = nodeTitle(node), subtitle = node.todo?.paperTitle || t('knowledge');
+    const img = await loadImage(source), canvas = document.createElement('canvas'); canvas.width = 960; canvas.height = 1120;
+    const ctx = canvas.getContext('2d'), colors = A.palette(scene(node));
+    ctx.fillStyle = '#fcfaf5'; ctx.fillRect(0, 0, 960, 1120);
+    const ratio = Math.max(960 / img.width, 630 / img.height), w = img.width * ratio, h = img.height * ratio;
+    ctx.save(); ctx.beginPath(); ctx.rect(0, 0, 960, 630); ctx.clip(); ctx.drawImage(img, (960 - w) / 2, (630 - h) / 2, w, h); ctx.restore();
+    ctx.fillStyle = colors[1]; ctx.font = '24px sans-serif'; ctx.fillText(short(subtitle, 38), 70, 698);
+    ctx.fillStyle = '#343c38'; ctx.font = '38px sans-serif';
+    const words = typeof Intl.Segmenter === 'function' ? [...new Intl.Segmenter(locale, { granularity: 'grapheme' }).segment(title)].map(s => s.segment) : [...title];
+    const lines = []; let line = '';
+    words.forEach(char => {
+      if (char === '\n' || ctx.measureText(line + char).width > 820) { lines.push(line); line = char === '\n' ? '' : char; }
+      else line += char;
+    });
+    if (line) lines.push(line);
+    lines.slice(0, 5).forEach((value, i) => ctx.fillText(i === 4 && lines.length > 5 ? short(value, Math.max(1, [...value].length - 1)) + '…' : value, 70, 764 + i * 52));
+    ctx.fillStyle = colors[1]; ctx.font = '23px sans-serif'; ctx.fillText(node.done ? `✓ ${t('done')}` : '✦ Starpaper', 70, 1054);
+    const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+    if (!blob) throw new Error('invalidImage');
+    download(blob, 'image/png', 'Starpaper-card.png');
+  }
+
+  async function loadWorkspace() {
+    // Only paper metadata is read before the user chooses sources. No all-workspace todo scan.
+    const sources = [...state.sources];
+    const all = await host.workspace.request('papers.list');
+    if (!Array.isArray(all) || all.some(p => typeof p.id !== 'string' || typeof p.type !== 'string' || typeof p.title !== 'string')) throw new Error('protocolData');
+    const nextPapers = all.filter(p => p.type === 'todo' || (p.type === 'note' && p.bodyProviderId === 'builtin.markdown'));
+    const nextTodos = [], nextNotes = [];
+    for (const paper of nextPapers.filter(p => sources.includes(p.id))) {
+      if (paper.type === 'todo') {
+        const items = await host.workspace.request('todos.list', { paperId: paper.id, includeBlank: false });
+        if (!Array.isArray(items) || items.some(item => item.paperId !== paper.id || typeof item.id !== 'string' || typeof item.text !== 'string' || typeof item.done !== 'boolean')) throw new Error('protocolData');
+        nextTodos.push(...items);
+      } else {
+        const note = await host.workspace.request('notes.get', { paperId: paper.id });
+        if (note && (note.paperId !== paper.id || typeof note.contentAvailable !== 'boolean' || typeof note.content !== 'string')) throw new Error('protocolData');
+        if (note) nextNotes.push(note);
+      }
+    }
+    return { papers: nextPapers, todos: nextTodos, sourceNotes: nextNotes };
+  }
+  function renderMini() {
+    const box = el('main', undefined, 'mini'), head = el('div', undefined, 'mini-head');
+    head.append(el('strong', '✦ ' + t('name')), el('span', t('local'))); box.append(head);
+    const tasks = model.nodes.filter(n => n.kind === 'todo'), open = tasks.filter(n => !n.done);
+    const ideas = model.nodes.filter(n => n.kind === 'note' || n.kind === 'note-ref');
+    const counts = el('div'); counts.append(el('span', String(open.length), 'mini-count'), el('span', t('open') + ' · ' + ideas.length + ' ' + t('knowledge'), 'small')); box.append(counts);
+    const list = (open.length ? open : ideas).slice(0, 3);
+    list.forEach(node => { const row = el('div', undefined, 'mini-row'), img = el('img'); img.src = image(node); img.alt = ''; row.append(img, el('span', nodeTitle(node))); box.append(row); });
+    if (!list.length) box.append(el('p', t('emptyTitle'), 'small'));
+    if (stale) box.append(el('p', t('stale'), 'small'));
+    app.replaceChildren(box);
+    publishMiniReady();
+  }
+  function publishMiniReady() {
+    if (!mini || miniReady || (!workspaceLoaded && !blocked)) return;
+    miniReady = true;
+    // The host owns publication/visibility. Signal only after our own first real layout.
+    requestAnimationFrame(() => { if (ready) { app.getBoundingClientRect(); host.mini.ready(); } });
+  }
+  function blockState(error) {
+    blocked = true; imageJob++; generation++; cancelDrag();
+    queue?.dispose(); unsubscribe?.(); unsubscribe = null; resize?.disconnect();
+    cancelAnimationFrame(frame); frame = 0; closeDialog();
+    const panel = el('main', undefined, 'empty'); panel.append(el('h2', t('invalidState')), el('p', t(I.rows[error?.message] ? error.message : 'invalidState')));
+    if (!mini) panel.append(button(t('export'), () => downloadJson(original), 'primary'));
+    app.replaceChildren(panel); mounted = false; publishMiniReady();
+  }
+  function initialize(message) {
+    host = window.papertodo || host;
+    if (!host) return;
+    queue?.dispose(); unsubscribe?.(); unsubscribe = null; resize?.disconnect();
+    generation++; imageJob++; pending.clear(); history.clear();
+    ready = true; blocked = false; workspaceLoaded = false; mini = message.surface === 'mini' || host.surface === 'mini';
+    visible = message.visible !== false; original = message.state;
+    locale = I.language(message.settings?.language, navigator.language); t = I.translator(locale); theme(message.theme);
+    try { state = C.validate(message.state); } catch (error) { blockState(error); return; }
+    if (!mini) {
+      // A provider is only registered after validation. It must never flush a guessed empty state.
+      host.registerStateProvider(() => { if (blocked) throw new Error('invalidState'); return state; });
+    }
+    queue = new C.RefreshQueue(loadWorkspace, snapshot => {
+      papers = snapshot.papers; todos = snapshot.todos; sourceNotes = snapshot.sourceNotes; stale = false; workspaceLoaded = true; render();
+    }, () => { stale = true; workspaceLoaded = true; render(); });
+    if (!mini && host.onHostEvent) {
+      unsubscribe = host.onHostEvent(['paper.created', 'paper.changed', 'paper.deleted', 'todo.created', 'todo.changed', 'todo.deleted', 'note.changed'], () => { if (visible && !blocked) queue.request(); }, { excludeOwnOperations: false });
+    }
+    mounted = false; fitNeeded = true; selection = null; focusId = null; render(); queue.request();
+  }
+  function onMessage(message) {
+    if (!message || typeof message.type !== 'string') return;
+    if (message.type === 'initialize') { initialize(message); return; }
+    if (!ready) return;
+    if (message.type === 'stateChanged') {
+      original = message.state;
+      if (blocked) return; // Recovery requires reopening the document, not an automatic overwrite.
+      try {
+        const next = C.validate(message.state);
+        if (JSON.stringify(next) === JSON.stringify(state)) return;
+        cancelDrag(); state = next; generation++; imageJob++; history.clear(); fitNeeded = true;
+        render(); queue.request(); // Never echo a received state back to the host.
+      } catch (error) { blockState(error); }
+    } else if (message.type === 'settingsChanged') {
+      locale = I.language(message.settings?.language, navigator.language); t = I.translator(locale); translate(); render();
+    } else if (message.type === 'themeChanged' || message.type === 'typographyChanged') {
+      theme(message.theme); render();
+    } else if (message.type === 'visibilityChanged') {
+      visible = message.visible !== false;
+      if (!visible) { cancelDrag(); cancelAnimationFrame(frame); frame = 0; }
+      else { render(); if (!blocked) queue.request(); }
+    } else if (message.type === 'activated') {
+      if (!blocked) queue.request();
+    } else if (message.type === 'cancelInteractions' || message.type === 'deactivated') {
+      cancelDrag();
+    } else if (message.type === 'hostSubscriptionError') {
+      stale = true; render(); toast('stale');
+    }
+  }
+  window.addEventListener('papertodo', event => onMessage(event.detail));
+  dialog.addEventListener('close', claims);
+  dialog.addEventListener('cancel', event => { event.preventDefault(); closeDialog(); });
+  function isEditing(target) { return !!target?.closest('input, textarea, select, [contenteditable="true"]'); }
+  document.addEventListener('keydown', event => {
+    if (!ready || blocked || mini || event.isComposing) return;
+    if (event.key === 'Escape') {
+      if (dialog.open) { event.preventDefault(); closeDialog(); }
+      else if (selection || focusId || drag) { event.preventDefault(); cancelDrag(); selection = null; focusId = null; render(); }
+      return;
+    }
+    if (dialog.open || isEditing(event.target)) return;
+    if ((event.ctrlKey || event.metaKey) && ['z', 'y'].includes(event.key.toLowerCase())) {
+      event.preventDefault(); undo(event.key.toLowerCase() === 'y' || event.shiftKey); return;
+    }
+    const node = event.target.closest('#canvas [data-node]');
+    if (node && (event.key === 'Enter' || event.key === ' ')) { event.preventDefault(); select(node.dataset.node); return; }
+    if (event.target.id === 'canvas' || node) {
+      const delta = { ArrowLeft: [45, 0], ArrowRight: [-45, 0], ArrowUp: [0, 45], ArrowDown: [0, -45] }[event.key];
+      if (delta) { event.preventDefault(); camera.x += delta[0]; camera.y += delta[1]; schedulePaint(); }
+      else if (event.key.toLowerCase() === 'f') { event.preventDefault(); fitAll(); }
+      else if (['+', '=', '-'].includes(event.key)) { event.preventDefault(); camera = C.zoom(camera, event.key === '-' ? .8 : 1.25, size.width / 2, size.height / 2); schedulePaint(); }
+    }
+  });
+  $('image-file').onchange = event => { const file = event.target.files[0]; if (file) attachImage(file, imageTarget); };
+  $('backup-file').onchange = event => { const file = event.target.files[0]; if (file) importBackup(file).catch(problem); };
+  document.addEventListener('paste', event => {
+    if (!ready || blocked || mini || dialog.open || isEditing(event.target)) return;
+    const file = [...(event.clipboardData?.items || [])].find(item => item.kind === 'file' && item.type.startsWith('image/'))?.getAsFile();
+    if (file) { event.preventDefault(); attachImage(file, selection); }
+  });
+  document.addEventListener('dragover', event => { if (!mini && event.dataTransfer?.types.includes('Files')) event.preventDefault(); });
+  document.addEventListener('drop', event => {
+    if (!ready || blocked || mini || dialog.open || !event.dataTransfer?.files.length) return;
+    event.preventDefault(); const file = event.dataTransfer.files[0];
+    const target = event.target.closest('[data-node]')?.dataset.node || event.target.closest('[data-card]')?.dataset.card || selection;
+    attachImage(file, target);
+  });
+  window.addEventListener('pagehide', () => {
+    ready = false; generation++; imageJob++; queue?.dispose(); unsubscribe?.(); resize?.disconnect();
+    cancelAnimationFrame(frame); clearTimeout(toastTimer);
+  });
+
+  // Explicit, memory-only preview. Production index.html never substitutes fake host data.
+  function previewHost() {
+    const samplePapers = [
+      { id: 'preview-tasks', type: 'todo', title: '让想法落地', bodyProviderId: '' },
+      { id: 'preview-notes', type: 'note', title: '设计原则', bodyProviderId: 'builtin.markdown' }
+    ];
+    const sampleTasks = [
+      ['reading', '读完《设计中的设计》', false], ['drawing', '画一张自己的星图', false],
+      ['code', '完成插件的第一轮测试', true], ['health', '傍晚去公园散步', false],
+      ['travel', '安排一场周末短途旅行', false], ['grow', '给阳台的植物浇水', true]
+    ].map(([id, text, done], order) => ({ id, text, done, order, paperId: 'preview-tasks', paperTitle: '让想法落地' }));
+    const sampleNote = { paperId: 'preview-notes', paperTitle: '设计原则', contentAvailable: true, content: '纸片优先，即时使用。\n\n从 [[微小行动]] 开始，把想法放进日常，而不是放进另一个管理系统。' };
+    let listener = () => {};
+    const preview = {
+      surface: 'body', saveState() {}, registerStateProvider() {},
+      paper: { setHeaderText() {}, setCapsulePresentation() {} }, body: { setInputClaims() {} },
+      onHostEvent(types, handler) { listener = handler; return () => { listener = () => {}; }; },
+      workspace: { async request(method, args = {}) {
+        if (method === 'papers.list') return structuredClone(samplePapers);
+        if (method === 'todos.list') return structuredClone(sampleTasks.filter(item => item.paperId === args.paperId));
+        if (method === 'notes.get') return structuredClone(sampleNote);
+        if (method === 'todos.update') {
+          const item = sampleTasks.find(item => item.id === args.todoId && item.paperId === args.paperId);
+          if (!item) throw new Error('unavailable');
+          if (typeof args.done === 'boolean') item.done = args.done;
+          if (typeof args.text === 'string') item.text = args.text;
+          listener({ type: 'todo.changed' }); return { paperId: args.paperId, todoId: args.todoId };
+        }
+        if (method === 'todos.append') {
+          const ids = args.todos.map(item => { const id = crypto.randomUUID(); sampleTasks.push({ ...item, id, done: false, order: sampleTasks.length, paperId: args.paperId, paperTitle: '让想法落地' }); return id; });
+          listener({ type: 'todo.created' }); return { paperId: args.paperId, todoIds: ids };
+        }
+        throw new Error('protocolData');
+      } }
+    };
+    const sample = { ...C.blank(), sources: ['preview-tasks', 'preview-notes'], notes: [
+      { id: 'n:curiosity', title: '保持好奇', body: '把看到的、想到的，留成一颗星。\n\n通过 [[微小行动]]，让好奇心有一个落点。' },
+      { id: 'n:action', title: '微小行动', body: '不等待一个完整计划。\n先做一件今天可以完成的小事。\n\n关联：[[设计原则]]' },
+      { id: 'n:garden', title: '想法花园', body: '知识不必排成一列。\n让想法像植物一样，自由生长。' }
+    ], links: [
+      { from: 'n:curiosity', to: C.todoKey('preview-tasks', 'reading'), label: '输入' },
+      { from: 'n:garden', to: C.todoKey('preview-tasks', 'drawing'), label: '创作' },
+      { from: 'n:action', to: C.todoKey('preview-tasks', 'health'), label: '今天就做' }
+    ] };
+    host = preview; initialize({ type: 'initialize', surface: 'body', state: sample, settings: { language: 'zh' } });
+  }
+  if (demo) previewHost();
+  else { app.replaceChildren(el('main', t('waiting'), 'empty')); }
+})();

--- a/plugins/com.papertodo.starpaper/web/art.js
+++ b/plugins/com.papertodo.starpaper/web/art.js
@@ -1,0 +1,36 @@
+/* Original, deterministic SVG illustrations. No remote images, fonts, AI calls or dependencies. */
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.StarArt = api;
+})(globalThis, function () {
+  'use strict';
+  const palettes = {
+    orbit: ['#f0eaf8', '#756091', '#b09cc9', '#f8f5fc'],
+    read: ['#e9eee8', '#547161', '#9bb49c', '#fcfaf3'],
+    code: ['#e7eef5', '#4f718d', '#99b8cb', '#f5f9fc'],
+    grow: ['#e9f0df', '#627c49', '#a6ba78', '#faf8ee'],
+    travel: ['#f6eadb', '#ac7850', '#d6b38a', '#fff9eb'],
+    health: ['#f6e5e1', '#ac6d66', '#d7a29a', '#fff5ed'],
+    create: ['#f5e9ef', '#976780', '#c7a0b6', '#fff6f3'],
+    focus: ['#e5eeed', '#537978', '#99b9b2', '#f6faf4']
+  };
+  function palette(scene) { return palettes[scene] || palettes.orbit; }
+  function svg(scene, seed = 0) {
+    const [bg, ink, soft, paper] = palette(scene);
+    const shapes = {
+      orbit: `<ellipse cx="160" cy="102" rx="99" ry="31" transform="rotate(-24 160 102)"/><circle cx="160" cy="99" r="44" fill="${soft}" stroke="none"/><path d="M72 142q104-9 161-79"/><circle cx="231" cy="65" r="9" fill="${paper}"/><path d="M104 43v16m-8-8h16M231 135v12m-6-6h12"/>`,
+      read: `<path d="M69 60q47-17 89 5v91q-41-26-89-8z" fill="${paper}"/><path d="M158 65q47-22 92-5v88q-47-9-92 8z" fill="${paper}"/><path d="M158 68v83M85 81q28-5 54 4m-54 12q28-5 54 4m-54 12q28-5 42 1m57-28q25-12 48-7m-48 23q25-12 48-7m-48 23q25-12 36-9" stroke="${soft}"/><path d="M206 44v56l9-8 9 3V42" fill="${soft}" stroke="none"/>`,
+      code: `<rect x="63" y="46" width="192" height="116" rx="11" fill="${paper}"/><path d="M63 70h192" stroke="${soft}"/><circle cx="79" cy="58" r="3" fill="${soft}" stroke="none"/><circle cx="92" cy="58" r="3" fill="${soft}" stroke="none"/><path d="m127 91-24 21 24 20m65-41 24 21-24 20m-19-46-20 54"/><path d="M108 177h108m-81-15-5 15m49-15 5 15"/>`,
+      grow: `<path d="M133 124h56l-9 48h-38z" fill="${paper}"/><path d="M160 125V56"/><path d="M161 109q-49 0-49-34 46-1 49 34M161 90q0-36 39-40 1 38-39 40M160 70q-29-8-24-35 28 5 24 35" fill="${soft}"/><path d="M100 173h123" stroke="${soft}"/><circle cx="221" cy="93" r="17" stroke-dasharray="2 8"/>`,
+      travel: `<path d="M37 158 111 71l51 58 35-45 88 74z" fill="${paper}"/><path d="m88 98 23-27 23 26-22-8z" fill="${soft}" stroke="none"/><circle cx="219" cy="53" r="22" fill="${soft}" stroke="none"/><path d="M43 169h238M62 180h154" stroke="${soft}"/><path d="m170 50 42-22-17 43-7-20z" fill="${paper}"/>`,
+      health: `<path d="M112 113c-68-40-21-93 14-48l34 38 34-38c35-45 82 8 14 48l-48 44z" fill="${paper}"/><path d="M87 105h40l14-25 20 52 18-34 12 7h47"/><path d="M121 174h78" stroke="${soft}"/>`,
+      create: `<path d="M92 166q-31-83 36-111 66-24 93 36 12 37-25 24-25-10-22 18 4 35-38 36z" fill="${paper}"/><circle cx="118" cy="88" r="10" fill="${soft}" stroke="none"/><circle cx="151" cy="72" r="9" fill="${ink}" stroke="none"/><circle cx="186" cy="87" r="9" fill="${soft}" stroke="none"/><path d="m173 164 43-92 11 5-42 93z" fill="${soft}"/><path d="M173 164q-17 5-13 18 16 7 25-12" fill="${ink}"/>`,
+      focus: `<path d="M113 41h96m-96 128h96M124 43c0 36 0 42 36 61-36 19-36 27-36 63m73-124c0 36 0 42-36 61 36 19 36 27 36 63"/><path d="m131 65 30 33 29-33zM130 160l31-37 31 37z" fill="${soft}" stroke="none"/><path d="M82 76v15m-7-7h14m145 44v15m-7-7h14" stroke="${soft}"/>`
+    };
+    const dot = 20 + (Number(seed) >>> 0) % 22;
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 210"><rect width="320" height="210" fill="${bg}"/><circle cx="160" cy="104" r="85" fill="${paper}" opacity=".28"/><g fill="none" stroke="${ink}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">${shapes[scene] || shapes.orbit}</g><g fill="${soft}" opacity=".8"><circle cx="${dot}" cy="53" r="2"/><circle cx="281" cy="118" r="2.5"/><circle cx="59" cy="182" r="1.5"/></g></svg>`;
+  }
+  function data(scene, seed) { return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg(scene, seed))}`; }
+  return Object.freeze({ palette, svg, data });
+});

--- a/plugins/com.papertodo.starpaper/web/core.js
+++ b/plugins/com.papertodo.starpaper/web/core.js
@@ -1,0 +1,227 @@
+/* Starpaper's data model is independent of the DOM and the PaperTodo transport. */
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.StarCore = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+  const SCHEMA = 1;
+  const MAX_BYTES = 10 * 1024 * 1024; // PaperTodo API 2.1 per-paper JSON limit.
+  const SCENES = Object.freeze(['orbit', 'read', 'code', 'grow', 'travel', 'health', 'create', 'focus']);
+  const bytes = value => new TextEncoder().encode(typeof value === 'string' ? value : JSON.stringify(value)).length;
+  const own = (object, key) => Object.prototype.hasOwnProperty.call(object, key);
+  const record = value => value !== null && typeof value === 'object' && !Array.isArray(value);
+  const fail = code => { throw new Error(code); };
+  const id = value => typeof value === 'string' && value.length > 0 && value.length <= 512 &&
+    !['__proto__', 'constructor', 'prototype'].includes(value);
+  function blank() {
+    return { schema: SCHEMA, sources: [], notes: [], links: [], positions: {}, covers: {},
+      view: 'map', filter: 'all', wiki: true };
+  }
+  function safeImage(value) {
+    return typeof value === 'string' && /^data:image\/(?:png|jpeg|webp);base64,[A-Za-z0-9+/]+={0,2}$/.test(value);
+  }
+  // Fail closed: invalid/future state is never normalized into an empty writable document.
+  function validate(raw) {
+    if (raw == null || (record(raw) && Object.keys(raw).length === 0)) return blank();
+    if (!record(raw) || raw.schema !== SCHEMA) fail('stateVersion');
+    for (const key of ['sources', 'notes', 'links']) if (!Array.isArray(raw[key])) fail('invalidState');
+    if (!record(raw.positions) || !record(raw.covers)) fail('invalidState');
+    if (!['map', 'cards'].includes(raw.view) || !['all', 'open', 'done'].includes(raw.filter) || typeof raw.wiki !== 'boolean') fail('invalidState');
+    const seen = new Set();
+    for (const source of raw.sources) {
+      if (!id(source) || seen.has(source)) fail('invalidState');
+      seen.add(source);
+    }
+    seen.clear();
+    for (const note of raw.notes) {
+      if (!record(note) || !id(note.id) || !note.id.startsWith('n:') || seen.has(note.id) ||
+          typeof note.title !== 'string' || !note.title.trim() || typeof note.body !== 'string') fail('invalidState');
+      seen.add(note.id);
+    }
+    seen.clear();
+    for (const link of raw.links) {
+      if (!record(link) || !id(link.from) || !id(link.to) || link.from === link.to || typeof link.label !== 'string') fail('invalidState');
+      const key = pair(link.from, link.to);
+      if (seen.has(key)) fail('invalidState');
+      seen.add(key);
+    }
+    for (const [key, pos] of Object.entries(raw.positions)) {
+      if (!id(key) || !record(pos) || !Number.isFinite(pos.x) || !Number.isFinite(pos.y) ||
+          Math.abs(pos.x) > 1e7 || Math.abs(pos.y) > 1e7) fail('invalidState');
+    }
+    for (const [key, cover] of Object.entries(raw.covers)) {
+      if (!id(key) || !record(cover) || !SCENES.includes(cover.scene) ||
+          (cover.image !== undefined && cover.image !== null && !safeImage(cover.image))) fail('invalidImage');
+    }
+    if (bytes(raw) > MAX_BYTES) fail('capacity');
+    // A versioned file is a complete document. Return it unchanged: no silent field loss.
+    return raw;
+  }
+  function pair(a, b) { return JSON.stringify(a < b ? [a, b] : [b, a]); }
+  const todoKey = (paperId, todoId) => `t:${encodeURIComponent(paperId)}:${encodeURIComponent(todoId)}`;
+  const paperKey = paperId => `p:${encodeURIComponent(paperId)}`;
+  function hash(text) {
+    let h = 2166136261;
+    for (const c of String(text)) { h ^= c.codePointAt(0); h = Math.imul(h, 16777619); }
+    return h >>> 0;
+  }
+  function sceneFor(text) {
+    const groups = [
+      ['read', /读|阅读|书|学习|论文|read|book|learn|study|読|勉強|독서|공부/i],
+      ['code', /代码|编程|修复|测试|插件|code|bug|test|develop|プログラム|코드|개발/i],
+      ['grow', /植物|花|园|种植|grow|plant|garden|花|植物|식물|정원/i],
+      ['travel', /旅行|出游|机票|游览|出发|travel|trip|flight|旅|여행/i],
+      ['health', /运动|健身|跑|训练|散步|workout|health|gym|run|運動|운동/i],
+      ['create', /画|设计|创作|写作|音乐|拍摄|draw|design|write|music|写真|그림|디자인/i],
+      ['focus', /专注|整理|规划|计划|focus|plan|organize|計画|집중|계획/i]
+    ];
+    return groups.find(([, re]) => re.test(text))?.[0] || 'orbit';
+  }
+  function setLink(state, from, to, label = '') {
+    if (!id(from) || !id(to) || from === to) fail('selfLink');
+    const links = state.links.filter(link => pair(link.from, link.to) !== pair(from, to));
+    return { ...state, links: [...links, { from, to, label: String(label).trim() }] };
+  }
+  function removeNote(state, noteId) {
+    const positions = { ...state.positions }, covers = { ...state.covers };
+    delete positions[noteId]; delete covers[noteId];
+    return { ...state, notes: state.notes.filter(n => n.id !== noteId), positions, covers,
+      links: state.links.filter(e => e.from !== noteId && e.to !== noteId) };
+  }
+  function wikiTargets(text) {
+    return [...String(text).matchAll(/\[\[([^\[\]\n]+)\]\]/g)].map(match => match[1].trim()).filter(Boolean);
+  }
+  function graph(state, papers, todos, sourceNotes = []) {
+    const nodes = [], edges = [], byId = new Map();
+    function add(node) { if (!byId.has(node.id)) { nodes.push(node); byId.set(node.id, node); } }
+    for (const source of state.sources) {
+      const paper = papers.find(p => p.id === source);
+      const note = sourceNotes.find(n => n.paperId === source);
+      add({ id: paperKey(source), kind: paper?.type === 'note' ? 'note-ref' : 'paper',
+        title: paper?.title || '', body: note?.contentAvailable ? note.content : '',
+        paperId: source, missing: !paper, unavailable: paper?.type === 'note' && !note?.contentAvailable });
+    }
+    for (const todo of todos) {
+      if (!state.sources.includes(todo.paperId)) continue;
+      const key = todoKey(todo.paperId, todo.id);
+      add({ id: key, kind: 'todo', title: todo.text, body: todo.text, done: !!todo.done, todo,
+        scene: state.covers[key]?.scene || sceneFor(todo.text) });
+      edges.push({ from: paperKey(todo.paperId), to: key, kind: 'contains', label: '' });
+    }
+    for (const note of state.notes) add({ ...note, kind: 'note', scene: state.covers[note.id]?.scene || sceneFor(note.title) });
+    // A missing external reference is not proof of deletion. Keep it visible, never prune its data.
+    for (const link of state.links) {
+      for (const key of [link.from, link.to]) if (!byId.has(key)) add({ id: key, kind: 'missing', title: '', missing: true });
+      edges.push({ ...link, kind: 'manual' });
+    }
+    if (state.wiki) {
+      const titles = new Map(), used = new Set(edges.map(e => pair(e.from, e.to)));
+      for (const node of nodes.filter(n => n.kind === 'note' || n.kind === 'note-ref')) {
+        const key = node.title.trim().normalize('NFC');
+        titles.set(key, titles.has(key) ? null : node.id); // Ambiguous names never create guessed facts.
+      }
+      for (const node of nodes) for (const target of wikiTargets(node.body || '')) {
+        const to = titles.get(target.normalize('NFC'));
+        if (!to || to === node.id || used.has(pair(node.id, to))) continue;
+        used.add(pair(node.id, to)); edges.push({ from: node.id, to, kind: 'wiki', label: '' });
+      }
+    }
+    return { nodes, edges, byId };
+  }
+  function visibleGraph(model, filter, query = '', focusId = null) {
+    const queryText = query.trim().toLocaleLowerCase();
+    let allowed = new Set(model.nodes.filter(n =>
+      (n.kind !== 'todo' || filter === 'all' || (filter === 'done') === n.done) &&
+      (!queryText || `${n.title}\n${n.body || ''}`.toLocaleLowerCase().includes(queryText))).map(n => n.id));
+    if (focusId && model.byId.has(focusId)) {
+      const neighborhood = new Set([focusId]);
+      model.edges.forEach(e => { if (e.from === focusId) neighborhood.add(e.to); if (e.to === focusId) neighborhood.add(e.from); });
+      allowed = new Set([...allowed].filter(key => neighborhood.has(key)));
+    }
+    return { nodes: model.nodes.filter(n => allowed.has(n.id)), edges: model.edges.filter(e => allowed.has(e.from) && allowed.has(e.to)) };
+  }
+  function layout(model, positions = {}) {
+    const result = new Map(), papers = model.nodes.filter(n => n.kind === 'paper');
+    const counts = papers.map(p => model.nodes.filter(n => n.todo?.paperId === p.paperId).length);
+    const gap = 430 + Math.sqrt(Math.max(0, ...counts)) * 110;
+    const cols = Math.max(1, Math.ceil(Math.sqrt(papers.length + 1)));
+    papers.forEach((paper, i) => {
+      const center = { x: (i % cols + 1) * gap, y: Math.floor(i / cols) * gap };
+      result.set(paper.id, center);
+      const tasks = model.nodes.filter(n => n.todo?.paperId === paper.paperId).sort((a, b) => a.id.localeCompare(b.id));
+      tasks.forEach((node, j) => {
+        const angle = j * 2.3999632297 + (hash(paper.id) % 100) / 100;
+        const radius = 130 + Math.sqrt(j) * 74;
+        result.set(node.id, { x: center.x + Math.cos(angle) * radius, y: center.y + Math.sin(angle) * radius });
+      });
+    });
+    const others = model.nodes.filter(n => !result.has(n.id)).sort((a, b) => a.id.localeCompare(b.id));
+    others.forEach((node, i) => {
+      const angle = i * 2.3999632297 - Math.PI / 2, radius = others.length === 1 ? 0 : 125 + Math.sqrt(i) * 80;
+      result.set(node.id, { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius });
+    });
+    for (const [key, pos] of Object.entries(positions)) if (result.has(key)) result.set(key, { ...pos });
+    return result;
+  }
+  function fit(nodes, positions, width, height) {
+    if (!nodes.length) return { x: width / 2, y: height / 2, k: 1 };
+    let x1 = Infinity, y1 = Infinity, x2 = -Infinity, y2 = -Infinity;
+    for (const n of nodes) {
+      const p = positions.get(n.id); if (!p) continue;
+      x1 = Math.min(x1, p.x - 95); y1 = Math.min(y1, p.y - 58);
+      x2 = Math.max(x2, p.x + 95); y2 = Math.max(y2, p.y + 74);
+    }
+    const k = Math.min(1.25, Math.max(.01, Math.min(Math.max(40, width - 64) / (x2 - x1), Math.max(40, height - 64) / (y2 - y1))));
+    return { x: width / 2 - (x1 + x2) / 2 * k, y: height / 2 - (y1 + y2) / 2 * k, k };
+  }
+  function zoom(camera, factor, x, y) {
+    const k = Math.max(.01, Math.min(4, camera.k * factor)), ratio = k / camera.k;
+    return { k, x: x - (x - camera.x) * ratio, y: y - (y - camera.y) * ratio };
+  }
+  class History {
+    constructor(limit = 30, budget = 24 * 1024 * 1024) { this.limit = limit; this.budget = budget; this.clear(); }
+    clear() { this.past = []; this.future = []; }
+    push(state) {
+      this.past.push({ state, size: bytes(state) }); this.future = [];
+      let size = this.past.reduce((sum, entry) => sum + entry.size, 0);
+      while (this.past.length > 1 && (this.past.length > this.limit || size > this.budget)) size -= this.past.shift().size;
+    }
+    undo(current) {
+      if (!this.past.length) return current;
+      this.future.push({ state: current, size: bytes(current) }); return this.past.pop().state;
+    }
+    redo(current) {
+      if (!this.future.length) return current;
+      this.past.push({ state: current, size: bytes(current) }); return this.future.pop().state;
+    }
+  }
+  // Coalesce refreshes, but never publish an obsolete response after a newer event/source selection.
+  class RefreshQueue {
+    constructor(load, publish, onError) { this.load = load; this.publish = publish; this.onError = onError; this.revision = 0; this.running = false; this.disposed = false; }
+    request() {
+      if (this.disposed) return Promise.resolve();
+      this.revision++;
+      if (!this.running) this.idle = this.drain();
+      return this.idle;
+    }
+    async drain() {
+      if (this.running || this.disposed) return;
+      this.running = true;
+      try {
+        let done;
+        do {
+          const revision = this.revision;
+          try {
+            const value = await this.load();
+            if (!this.disposed && revision === this.revision) this.publish(value);
+          } catch (error) { if (!this.disposed && revision === this.revision) this.onError(error); }
+          done = revision === this.revision;
+        } while (!done && !this.disposed);
+      } finally { this.running = false; }
+    }
+    dispose() { this.disposed = true; }
+  }
+  return Object.freeze({ SCHEMA, MAX_BYTES, SCENES, blank, validate, bytes, safeImage, pair, todoKey, paperKey,
+    hash, sceneFor, setLink, removeNote, wikiTargets, graph, visibleGraph, layout, fit, zoom, History, RefreshQueue, own });
+});

--- a/plugins/com.papertodo.starpaper/web/i18n.js
+++ b/plugins/com.papertodo.starpaper/web/i18n.js
@@ -1,0 +1,94 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.StarI18n = api;
+})(globalThis, function () {
+  'use strict';
+  // Each row is zh / en / ja / ko. Keep all four variants together when adding UI copy.
+  const rows = {
+    name: ['星笺', 'Starpaper', '星のノート', '별빛 노트'],
+    tagline: ['让灵感相连，让行动生长。', 'Connect ideas. Give plans a little life.', 'ひらめきをつなぎ、行動を育てる。', '생각을 잇고, 계획을 키워요.'],
+    map: ['知识星图', 'Constellation', '知識の星図', '지식 별자리'],
+    cards: ['待办图鉴', 'Illustrated tasks', 'タスク図鑑', '할 일 도감'],
+    local: ['离线 · 本地', 'Offline · local', 'オフライン · ローカル', '오프라인 · 로컬'],
+    demo: ['演示数据 · 不会修改 PaperTodo', 'Demo · no PaperTodo data is changed', 'デモ · PaperTodo のデータは変更されません', '데모 · PaperTodo 데이터는 변경되지 않습니다'],
+    sources: ['选择纸片', 'Choose papers', '用紙を選択', '용지 선택'],
+    sourceHint: ['只读取选中纸片的正文；标记完成会修改原待办。取消来源选择不会删除原始数据。', 'Only selected papers are read. Completing a task changes the original. Deselecting never deletes it.', '選択した用紙だけを読み取ります。完了操作は元のタスクに反映されます。選択を外しても削除されません。', '선택한 용지만 읽습니다. 완료 상태는 원본에 반영됩니다. 선택을 해제해도 삭제되지 않습니다.'],
+    newNote: ['新建知识', 'New idea', '知識を追加', '지식 추가'],
+    newTodo: ['新建待办', 'New task', 'タスクを追加', '할 일 추가'],
+    search: ['搜索标题与内容…', 'Search titles and text…', 'タイトル・内容を検索…', '제목과 내용 검색…'],
+    all: ['全部', 'All', 'すべて', '전체'], open: ['未完成', 'Open', '未完了', '미완료'], done: ['已完成', 'Done', '完了', '완료'],
+    undo: ['撤销星图编辑（不撤销原待办）', 'Undo board edit (not host tasks)', '星図の編集を元に戻す（元のタスクは対象外）', '별자리 편집 실행 취소 (원본 할 일 제외)'],
+    redo: ['重做星图编辑', 'Redo board edit', '星図の編集をやり直す', '별자리 편집 다시 실행'],
+    more: ['更多', 'More', 'その他', '더 보기'], fit: ['全图', 'Fit all', '全体表示', '전체 보기'],
+    arrange: ['整理布局', 'Arrange', '整列', '정렬'],
+    arrangeHint: ['恢复自动布局？知识和连线都会保留，布局可撤销。', 'Restore the automatic layout? Ideas and links stay intact. You can undo this.', '自動配置に戻しますか？知識と関連は残り、操作を元に戻せます。', '자동 배치로 되돌릴까요? 지식과 연결은 유지되며 실행 취소할 수 있습니다.'],
+    export: ['导出备份', 'Export backup', 'バックアップを保存', '백업 내보내기'],
+    import: ['导入备份', 'Import backup', 'バックアップを読み込む', '백업 가져오기'],
+    exportSvg: ['导出星图 SVG', 'Export map as SVG', '星図を SVG で保存', '별자리를 SVG로 저장'],
+    exportCard: ['导出插画卡片', 'Export illustrated card', 'イラストカードを保存', '일러스트 카드 저장'],
+    help: ['使用说明', 'Guide', '使い方', '사용 안내'],
+    helpText: ['拖动节点摆放，拖动画布平移，滚轮缩放。选中节点后 Shift+单击另一节点可快速连线，也可用“关联”填写关系。正文中的 [[知识标题]] 会生成虚线链接；同名知识不自动猜测。双击空白处新建知识。Ctrl+Z / Ctrl+Y 只处理星图本地编辑。插画显示在本插件，不改变原待办行。', 'Drag nodes to arrange; drag the canvas to pan; use the wheel to zoom. Shift-click another node to connect, or use Link to name the relationship. [[Idea title]] creates a dashed reference; duplicate titles are not guessed. Double-click the canvas to add an idea. Ctrl+Z / Ctrl+Y only affect local board edits. Illustrations live here, not in the original task rows.', 'ノードのドラッグで配置、余白のドラッグで移動、ホイールで拡大縮小。別のノードを Shift+クリックすると関連を追加できます。「関連」で名前も付けられます。[[知識のタイトル]] は点線の参照になります。同名の場合は推測しません。余白をダブルクリックで知識を追加。Ctrl+Z / Ctrl+Y は星図のみが対象です。イラストはこのプラグイン内に表示されます。', '노드를 끌어 배치하고, 배경을 끌어 이동하며, 휠로 확대합니다. 다른 노드를 Shift+클릭하면 연결할 수 있고, 연결 메뉴에서 관계 이름을 지정합니다. [[지식 제목]]은 점선 참조를 만듭니다. 중복 제목은 추측하지 않습니다. 배경을 두 번 클릭하면 지식을 추가합니다. Ctrl+Z / Ctrl+Y는 별자리 편집만 되돌립니다. 일러스트는 이 플러그인 안에만 표시됩니다.'],
+    knowledge: ['知识', 'Ideas', '知識', '지식'], tasks: ['待办', 'Tasks', 'タスク', '할 일'], papers: ['纸片', 'Papers', '用紙', '용지'],
+    link: ['关联', 'Link', '関連', '연결'], relation: ['关系说明（可选）', 'Relationship (optional)', '関連の説明（任意）', '관계 설명 (선택)'],
+    target: ['目标节点', 'Target node', '関連先', '연결 대상'], noTarget: ['先再创建一个知识节点或选择待办纸。', 'Add another idea or choose a task paper first.', '別の知識を追加するか、タスクの用紙を選択してください。', '다른 지식을 추가하거나 할 일 용지를 먼저 선택하세요.'],
+    related: ['相邻节点', 'Connections', '関連するノード', '연결된 노드'],
+    focus: ['只看相邻节点', 'Focus on connections', '関連ノードに絞る', '연결된 노드만 보기'],
+    unfocus: ['退出聚焦', 'Show all nodes', '絞り込みを解除', '모든 노드 보기'],
+    wiki: ['[[标题]] 自动关联', 'Link [[titles]] automatically', '[[タイトル]] を自動参照', '[[제목]] 자동 연결'],
+    manual: ['手动关联', 'Manual link', '手動の関連', '수동 연결'], reference: ['正文引用', 'Text reference', '本文の参照', '본문 참조'],
+    contains: ['所属纸片', 'Paper membership', '所属する用紙', '소속 용지'],
+    unlink: ['移除连线', 'Remove link', '関連を解除', '연결 제거'],
+    title: ['标题', 'Title', 'タイトル', '제목'], body: ['内容 · 支持 [[知识标题]]', 'Text · supports [[Idea title]]', '内容 · [[知識のタイトル]] に対応', '내용 · [[지식 제목]] 지원'],
+    edit: ['编辑', 'Edit', '編集', '편집'], save: ['保存', 'Save', '保存', '저장'], cancel: ['取消', 'Cancel', 'キャンセル', '취소'], close: ['关闭', 'Close', '閉じる', '닫기'],
+    remove: ['删除知识', 'Delete idea', '知識を削除', '지식 삭제'],
+    removeHint: ['仅删除这个知识节点及其连线，不删除任何原始待办。可以撤销。', 'Delete this idea and its links only. Original tasks are not deleted. You can undo this.', 'この知識と関連のみ削除します。元のタスクは削除されず、操作を元に戻せます。', '이 지식과 연결만 삭제합니다. 원본 할 일은 삭제하지 않으며 실행 취소할 수 있습니다.'],
+    complete: ['标记完成', 'Mark done', '完了にする', '완료로 표시'], reopen: ['恢复未完成', 'Mark open', '未完了に戻す', '미완료로 표시'],
+    illustration: ['插画', 'Illustration', 'イラスト', '일러스트'],
+    image: ['使用本地图片', 'Use local image', 'ローカル画像を使う', '로컬 이미지 사용'],
+    imageHint: ['支持 PNG / JPEG / WebP / GIF。也可粘贴或拖入图片；自动缩小并保存副本，不依赖原文件。', 'PNG / JPEG / WebP / GIF. You can also paste or drop an image. A resized copy is stored, independent of the original file.', 'PNG / JPEG / WebP / GIF に対応。貼り付け・ドロップも可能。縮小したコピーを保存するため元ファイルは不要です。', 'PNG / JPEG / WebP / GIF 지원. 붙여넣기나 끌어넣기도 가능합니다. 축소한 사본을 저장하므로 원본 파일이 필요하지 않습니다.'],
+    resetCover: ['恢复自动插画', 'Restore automatic art', '自動イラストに戻す', '자동 일러스트 복원'],
+    orbit: ['星轨', 'Orbit', '星の軌道', '별의 궤도'], read: ['书页', 'Reading', '読書', '독서'], code: ['代码', 'Code', 'コード', '코드'],
+    grow: ['生长', 'Growth', '成長', '성장'], travel: ['远行', 'Travel', '旅', '여행'], health: ['活力', 'Wellbeing', '健康', '활력'], create: ['创作', 'Create', '創作', '창작'], focusScene: ['专注', 'Focus', '集中', '집중'],
+    emptyTitle: ['一颗想法，就能点亮星图。', 'One idea starts a constellation.', 'ひとつの知識から、星図が始まる。', '생각 하나가 별자리의 시작입니다.'],
+    emptyText: ['创建一个知识节点，或选取现有待办、笔记纸。没有数据会被自动导入或修改。', 'Add an idea or choose existing task or note papers. Nothing is imported or changed automatically.', '知識を追加するか、既存の用紙を選択してください。自動で読み込んだり変更したりしません。', '지식을 추가하거나 기존 할 일 용지를 선택하세요. 자동으로 가져오거나 수정하지 않습니다.'],
+    noTasks: ['这里还没有待办', 'No tasks here yet', 'タスクはまだありません', '아직 할 일이 없습니다'],
+    noMatch: ['没有匹配的节点', 'No matching nodes', '一致するノードがありません', '일치하는 노드가 없습니다'],
+    noPaper: ['请先在 PaperTodo 创建一张待办纸，再点刷新。', 'Create a task paper in PaperTodo, then refresh.', 'PaperTodo でタスク用紙を作成してから更新してください。', 'PaperTodo에서 할 일 용지를 만든 후 새로고침하세요.'],
+    refresh: ['刷新', 'Refresh', '更新', '새로고침'], loading: ['正在读取…', 'Loading…', '読み込み中…', '불러오는 중…'],
+    stale: ['读取失败；保留上次成功读取的内容。请刷新后再操作。', 'Read failed; the last successful snapshot is kept. Refresh before editing host tasks.', '読み込み失敗。前回の内容を保持しています。更新してから元のタスクを操作してください。', '읽기 실패. 마지막으로 읽은 내용을 유지합니다. 새로고침 후 원본 할 일을 수정하세요.'],
+    unavailable: ['引用暂不可用', 'Reference unavailable', '参照を利用できません', '참조를 사용할 수 없음'],
+    missingHint: ['原始对象可能已删除、自动清理或不再可读取。连线与插图不会被自动抹掉；这不是一条可编辑的原始待办。', 'The original may be deleted, auto-cleared, or unreadable. Links and art are kept. This is not an editable original task.', '元の項目が削除・自動整理されたか、読み取れない可能性があります。関連と画像は保持されます。この参照から元のタスクは編集できません。', '원본이 삭제·자동 정리되었거나 읽을 수 없을 수 있습니다. 연결과 그림은 유지됩니다. 이 참조는 편집 가능한 원본 할 일이 아닙니다.'],
+    waiting: ['请在 PaperTodo 中加载插件；浏览器预览请打开 preview.html。', 'Load this plugin in PaperTodo. For a browser demo, open preview.html.', 'PaperTodo で読み込んでください。ブラウザーのデモは preview.html を開きます。', 'PaperTodo에서 플러그인을 불러오세요. 브라우저 데모는 preview.html을 여세요.'],
+    stateVersion: ['数据版本不兼容，已停止写入。请先导出原始数据。', 'Incompatible data version; writes are blocked. Export the original data first.', 'データのバージョンが非対応のため書き込みを停止しました。まず元データを保存してください。', '호환되지 않는 데이터 버전으로 쓰기를 중단했습니다. 원본 데이터를 먼저 내보내세요.'],
+    invalidState: ['数据格式异常，未覆盖原始数据。', 'Invalid document; the original has not been overwritten.', 'データ形式が不正です。元データは上書きしていません。', '데이터 형식이 잘못되었습니다. 원본은 덮어쓰지 않았습니다.'],
+    invalidImage: ['不支持这份图片数据。请选择可解码的本地位图。', 'Unsupported image data. Choose a decodable local raster image.', 'この画像には対応していません。読み込めるローカル画像を選択してください。', '지원하지 않는 이미지입니다. 읽을 수 있는 로컬 비트맵을 선택하세요.'],
+    capacity: ['超出宿主每张纸 10 MiB 的状态容量，未提交这次修改。可导出备份后移除部分图片。', 'This exceeds the host’s 10 MiB per-paper state limit. The change was not submitted. Back up, then remove some images.', '宿主の用紙あたり 10 MiB 制限を超えるため変更していません。バックアップ後、画像を減らしてください。', '호스트의 용지당 10 MiB 제한을 초과하여 변경하지 않았습니다. 백업한 뒤 일부 이미지를 제거하세요.'],
+    importHint: ['将替换这张星图的知识、连线和插图；不会创建、删除或覆盖原始待办。其他设备上的原始待办 ID 可能无法对应。可撤销。', 'Replace this board’s ideas, links and art. Original tasks are not created, deleted or overwritten. Task IDs may not resolve on another installation. Undo is available.', 'この星図の知識・関連・画像を置き換えます。元のタスクを作成・削除・上書きしません。別の環境ではタスク ID が一致しない場合があります。元に戻せます。', '이 별자리의 지식·연결·그림을 교체합니다. 원본 할 일은 생성·삭제·덮어쓰지 않습니다. 다른 환경에서는 할 일 ID가 일치하지 않을 수 있습니다. 실행 취소가 가능합니다.'],
+    operationFailed: ['操作未确认。请先刷新核对原待办，再决定是否重试；不会自动重发。', 'Operation not confirmed. Refresh and check the original before retrying. It will not be resent automatically.', '操作を確認できませんでした。更新して元のタスクを確認してから再試行してください。自動再送はしません。', '작업 결과를 확인하지 못했습니다. 새로고침하여 원본을 확인한 뒤 재시도하세요. 자동으로 재전송하지 않습니다.'],
+    conflict: ['内容已在其他位置变化。请重新打开编辑器，避免覆盖更新。', 'Content changed elsewhere. Reopen the editor to avoid overwriting it.', '他の場所で内容が変更されました。上書きを避けるため編集画面を開き直してください。', '다른 위치에서 내용이 변경되었습니다. 덮어쓰지 않도록 편집기를 다시 여세요.'],
+    selfLink: ['请选择另一个节点。', 'Choose a different node.', '別のノードを選択してください。', '다른 노드를 선택하세요.'],
+    selectedImage: ['先选中一个待办或知识节点，再放入图片。', 'Select a task or idea before adding an image.', 'タスクまたは知識を選択してから画像を追加してください。', '이미지를 추가하기 전에 할 일이나 지식을 선택하세요.'],
+    imageTooLarge: ['图片过大，请先缩小到 20 MiB / 3200 万像素以内。', 'Resize the image below 20 MiB / 32 megapixels first.', '画像を 20 MiB / 3200 万画素以下に縮小してください。', '먼저 이미지를 20 MiB / 3200만 화소 이하로 줄이세요.'],
+    savedByHost: ['编辑会立即提交宿主保存；备份不包含原始待办或引用笔记正文。', 'Edits are submitted to the host immediately. Backups do not contain original task or referenced note text.', '編集はすぐに宿主へ保存要求します。バックアップに元のタスクや参照メモの本文は含まれません。', '편집은 즉시 호스트에 저장 요청됩니다. 백업에는 원본 할 일이나 참조 메모 본문이 포함되지 않습니다.'],
+    previewOnly: ['演示只在当前页面内存中运行，刷新会重置。', 'The demo is memory-only and resets when reloaded.', 'デモはメモリ内のみで動作し、再読み込みすると初期化されます。', '데모는 메모리에서만 동작하며 새로고침하면 초기화됩니다.'],
+    hint: ['拖动 · 滚轮缩放 · Shift+单击连线', 'Drag · wheel to zoom · Shift-click to link', 'ドラッグ · ホイールで拡大 · Shift+クリックで関連', '끌기 · 휠로 확대 · Shift+클릭으로 연결'],
+    selected: ['已选', 'Selected', '選択済み', '선택됨'],
+    untitled: ['未命名纸片', 'Untitled paper', '無題の用紙', '제목 없는 용지'],
+    clearFilter: ['清除筛选', 'Clear filters', '絞り込みを解除', '필터 해제'],
+    readOnlyNote: ['实时引用的笔记正文。请在原笔记纸编辑；这里可配图和连线。', 'Live note reference. Edit the original note; add art and links here.', '元のメモの参照です。本文は元の用紙で編集し、ここでは画像や関連を追加します。', '실시간 메모 참조입니다. 원본 메모에서 편집하고 여기에서는 그림과 연결을 추가하세요.'],
+    zoomIn: ['放大', 'Zoom in', '拡大', '확대'], zoomOut: ['缩小', 'Zoom out', '縮小', '축소'],
+    protocolData: ['宿主返回的数据格式不符合 API 2.1。', 'The host response does not match API 2.1.', '宿主の応答が API 2.1 の形式と一致しません。', '호스트 응답이 API 2.1 형식과 다릅니다.']
+  };
+  const languages = ['zh', 'en', 'ja', 'ko'];
+  function language(value, system = 'zh') {
+    const requested = !value || value === 'auto' ? system : value;
+    const prefix = String(requested).slice(0, 2).toLowerCase();
+    return languages.includes(prefix) ? prefix : 'en';
+  }
+  function translator(locale) {
+    const index = languages.indexOf(language(locale));
+    return key => rows[key]?.[index] ?? key;
+  }
+  return Object.freeze({ rows, languages, language, translator });
+});

--- a/plugins/com.papertodo.starpaper/web/index.html
+++ b/plugins/com.papertodo.starpaper/web/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'">
+  <title>星笺 · Starpaper</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="core.js" defer></script>
+  <script src="i18n.js" defer></script>
+  <script src="art.js" defer></script>
+  <script src="app.js" defer></script>
+</head>
+<body>
+  <div id="app" aria-busy="true"></div>
+  <div id="toast" role="status" aria-live="polite" hidden></div>
+  <dialog id="dialog"></dialog>
+  <input id="image-file" type="file" accept="image/png,image/jpeg,image/webp,image/gif" hidden>
+  <input id="backup-file" type="file" accept=".json,application/json" hidden>
+</body>
+</html>

--- a/plugins/com.papertodo.starpaper/web/preview.html
+++ b/plugins/com.papertodo.starpaper/web/preview.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'">
+  <title>星笺 · Starpaper</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="core.js" defer></script>
+  <script src="i18n.js" defer></script>
+  <script src="art.js" defer></script>
+  <script src="app.js" defer></script>
+</head>
+<body data-preview="true">
+  <div id="app" aria-busy="true"></div>
+  <div id="toast" role="status" aria-live="polite" hidden></div>
+  <dialog id="dialog"></dialog>
+  <input id="image-file" type="file" accept="image/png,image/jpeg,image/webp,image/gif" hidden>
+  <input id="backup-file" type="file" accept=".json,application/json" hidden>
+</body>
+</html>

--- a/plugins/com.papertodo.starpaper/web/style.css
+++ b/plugins/com.papertodo.starpaper/web/style.css
@@ -1,0 +1,146 @@
+:root {
+  color-scheme: light;
+  --paper: #f8f6f0; --text: #343c38; --weak: #798078; --accent: #637d6c;
+  --border: #d8dcd2; --font: 'Segoe UI', 'Microsoft YaHei UI', system-ui, sans-serif;
+  --host-scale: 1; --panel: color-mix(in srgb, var(--paper), var(--text) 3%);
+  --wash: color-mix(in srgb, var(--paper), var(--accent) 9%);
+  font: calc(13px * var(--host-scale))/1.55 var(--font);
+  color: var(--text); background: var(--paper);
+}
+* { box-sizing: border-box; }
+html, body, #app { margin: 0; width: 100%; height: 100%; overflow: hidden; }
+[hidden] { display: none !important; }
+button, input, select, textarea { font: inherit; color: inherit; }
+button, summary, select, input[type=checkbox] { cursor: pointer; }
+button { border: 1px solid transparent; border-radius: 9px; background: transparent; padding: 6px 10px; line-height: 1.5; }
+button:hover:not(:disabled), summary:hover { background: var(--wash); }
+button:disabled { opacity: .42; cursor: default; }
+button:focus-visible, summary:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible, svg:focus-visible, [role=button]:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 3px;
+}
+button.primary { background: var(--accent); color: var(--paper); }
+button.primary:hover:not(:disabled) { background: color-mix(in srgb, var(--accent), var(--text) 14%); }
+button.secondary { border-color: var(--border); }
+button.danger { color: #bd5c53; border-color: color-mix(in srgb, var(--paper), #bd5c53 30%); }
+button.icon { min-width: 32px; font-size: 18px; padding: 3px 7px; }
+button.wide { width: 100%; }
+input:not([type=checkbox]), textarea, select { background: var(--paper); border: 1px solid var(--border); border-radius: 8px; padding: 7px 9px; min-width: 0; }
+input[type=checkbox] { accent-color: var(--accent); width: 17px; height: 17px; flex: 0 0 auto; }
+textarea { resize: vertical; min-height: 140px; width: 100%; }
+label.field { display: grid; gap: 5px; margin-bottom: 15px; }
+.small, small { font-size: .85rem; color: var(--weak); }
+p { margin: 0 0 12px; }
+h1, h2, h3 { margin: 0; font-weight: 600; }
+.shell { display: flex; flex-direction: column; height: 100%; }
+.top { padding: 16px 22px 0; }
+.brand-row, .actions, .tools, .search-row, .bottom, .inspector-head, .dialog-head { display: flex; align-items: center; gap: 9px; }
+.brand-row { justify-content: space-between; }
+.brand { display: flex; align-items: center; gap: 9px; font-size: 16px; font-weight: 600; letter-spacing: .07em; }
+.brand-mark { color: var(--accent); font-size: 25px; font-weight: 400; }
+.local-badge { font-size: 10px; padding: 3px 7px; border: 1px solid var(--border); border-radius: 20px; color: var(--weak); font-weight: 400; letter-spacing: 0; white-space: nowrap; }
+.intro { padding: 17px 0 13px; }
+.intro h1 { font-size: 23px; font-family: Georgia, 'Noto Serif CJK SC', 'Microsoft YaHei', serif; font-weight: 500; letter-spacing: .02em; }
+.intro p { color: var(--weak); font-size: 12px; margin: 5px 0 0; }
+.tools { flex-wrap: wrap; justify-content: space-between; padding: 8px 0 10px; }
+.tabs { display: inline-flex; border-radius: 10px; padding: 3px; background: var(--panel); border: 1px solid var(--border); }
+.tabs button { padding: 5px 12px; border-radius: 7px; font-size: .92rem; }
+.tabs button[aria-selected=true] { background: var(--paper); box-shadow: 0 1px 4px #0000000c; color: var(--accent); }
+.search-row { padding-bottom: 13px; }
+.search-row input { flex: 1; width: 70px; background: transparent; }
+.search-row select { max-width: 115px; background: transparent; }
+.source-button { white-space: nowrap; font-size: .9rem; }
+.menu { position: relative; }
+.menu summary { list-style: none; font-size: 19px; border-radius: 8px; text-align: center; padding: 0 9px; }
+.menu summary::-webkit-details-marker { display: none; }
+.menu-items { position: absolute; top: 32px; right: 0; width: 210px; padding: 7px; background: var(--paper); border: 1px solid var(--border); box-shadow: 0 10px 35px #0002; border-radius: 12px; z-index: 6; }
+.menu-items button { display: block; width: 100%; text-align: left; }
+.menu-items label { display: flex; gap: 6px; padding: 8px 4px; font-size: .88rem; }
+.status-banner, .demo-banner { padding: 7px 18px; border-block: 1px solid var(--border); font-size: .86rem; background: var(--wash); }
+.status-banner { color: #aa6455; }
+.stage { flex: 1; min-height: 130px; display: flex; position: relative; overflow: hidden; border-block: 1px solid var(--border); }
+.map-pane { flex: 1; min-width: 0; position: relative; overflow: hidden; background-image: radial-gradient(color-mix(in srgb, var(--border), transparent 20%) .75px, transparent .75px); background-size: 22px 22px; }
+#canvas { width: 100%; height: 100%; display: block; touch-action: none; user-select: none; cursor: grab; }
+#canvas.dragging { cursor: grabbing; }
+.node { cursor: pointer; outline: none; }
+.node circle { transition: opacity 120ms; }
+.node:hover .halo, .node:focus .halo { opacity: .7; }
+.node .halo { fill: none; stroke: var(--accent); stroke-width: 1.5px; opacity: 0; }
+.node.selected .halo { opacity: 1; stroke-width: 2px; }
+.node.done { opacity: .52; }
+.node.missing { opacity: .65; }
+.node-symbol { font-size: 19px; font-family: var(--font); text-anchor: middle; dominant-baseline: middle; pointer-events: none; }
+.node-label, .edge-label { text-anchor: middle; font-family: var(--font); fill: var(--text); paint-order: stroke; stroke: var(--paper); stroke-width: 4px; stroke-linejoin: round; pointer-events: none; }
+.node-label { font-size: 12px; }
+.node.paper .node-label { font-weight: 600; font-size: 13px; }
+.edge { stroke: color-mix(in srgb, var(--border), var(--accent) 25%); stroke-width: 1.3px; fill: none; vector-effect: non-scaling-stroke; }
+.edge.contains { stroke-dasharray: 2 6; opacity: .65; }
+.edge.wiki { stroke-dasharray: 5 5; }
+.edge.highlight { stroke: var(--accent); stroke-width: 1.8px; opacity: .95; }
+.edge-label { font-size: 11px; fill: var(--accent); }
+.map-controls { position: absolute; right: 13px; bottom: 12px; display: flex; gap: 2px; padding: 4px; background: var(--paper); border: 1px solid var(--border); border-radius: 11px; box-shadow: 0 2px 8px #00000008; }
+.map-controls button { padding: 3px 8px; font-size: 12px; }
+.map-hint { position: absolute; left: 16px; bottom: 19px; max-width: 52%; font-size: 10px; color: var(--weak); pointer-events: none; }
+.empty { position: absolute; inset: 20% 16px auto; text-align: center; max-width: 450px; margin: auto; }
+.empty-mark { font-size: 65px; color: var(--accent); opacity: .45; line-height: 1.1; margin-bottom: 18px; }
+.empty h2 { font-size: 18px; margin-bottom: 10px; font-weight: 500; }
+.empty p { color: var(--weak); font-size: 12px; }
+.empty .actions { justify-content: center; flex-wrap: wrap; }
+.cards-pane { flex: 1; min-width: 0; overflow-y: auto; padding: 21px; position: relative; scrollbar-width: thin; scrollbar-color: var(--border) transparent; }
+.card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 195px), 1fr)); gap: 18px; }
+.task-card { border: 1px solid var(--border); border-radius: 13px; overflow: hidden; background: var(--paper); content-visibility: auto; contain-intrinsic-size: auto 290px; }
+.task-card.selected { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+.card-art { padding: 0; display: block; width: 100%; border-radius: 0; overflow: hidden; }
+.card-art img { width: 100%; height: 155px; display: block; object-fit: cover; }
+.card-content { padding: 12px 14px 14px; }
+.card-meta { font-size: 10px; color: var(--weak); letter-spacing: .03em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.card-title { padding: 4px 0 7px; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; font-size: 14px; line-height: 1.6; text-align: left; width: 100%; border-radius: 0; }
+.task-card.done .card-title { text-decoration: line-through; color: var(--weak); }
+.task-card.done img { opacity: .65; }
+.completion { display: flex; align-items: center; gap: 7px; padding: 3px 0; font-size: 11px; color: var(--weak); }
+.checkmark { width: 20px; height: 20px; border-radius: 50%; border: 1px solid var(--border); display: inline-grid; place-items: center; color: var(--accent); font-size: 12px; }
+[aria-checked=true] .checkmark { background: var(--wash); border-color: var(--accent); }
+.inspector { width: 275px; flex-shrink: 0; padding: 15px; border-left: 1px solid var(--border); overflow-y: auto; background: var(--paper); z-index: 3; scrollbar-width: thin; }
+.inspector-head { justify-content: space-between; margin-bottom: 10px; color: var(--weak); font-size: 11px; }
+.inspector-art { height: 146px; width: 100%; border-radius: 10px; object-fit: cover; display: block; margin-bottom: 13px; }
+.inspector h2 { font-size: 17px; overflow-wrap: anywhere; margin-bottom: 7px; }
+.inspector-text { white-space: pre-wrap; overflow-wrap: anywhere; font-size: 12px; margin: 12px 0; max-height: 230px; overflow-y: auto; }
+.inspector .actions { gap: 4px; flex-wrap: wrap; margin: 10px 0; }
+.inspector section { border-top: 1px solid var(--border); margin-top: 16px; padding-top: 12px; }
+.inspector h3 { font-size: 11px; letter-spacing: .04em; color: var(--weak); margin-bottom: 9px; font-weight: 500; }
+.inspector select { width: 100%; margin: 6px 0 10px; }
+.inspector .small { font-size: 10px; }
+.connection { display: flex; align-items: center; gap: 2px; }
+.connection .link-target { flex: 1; min-width: 0; text-align: left; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-size: 11px; }
+.connection small { font-size: 9px; display: block; }
+.bottom { justify-content: space-between; padding: 9px 20px; color: var(--weak); font-size: 10px; min-height: 34px; }
+.legend { display: inline-flex; gap: 12px; }
+.legend span::before { content: '●'; color: var(--accent); font-size: 7px; margin-right: 5px; }
+dialog { color: var(--text); background: var(--paper); border: 1px solid var(--border); border-radius: 16px; padding: 21px; width: min(460px, calc(100vw - 24px)); max-height: calc(100vh - 28px); overflow-y: auto; box-shadow: 0 16px 60px #0003; }
+dialog::backdrop { background: #1b27284d; }
+.dialog-head { justify-content: space-between; margin-bottom: 15px; }
+.dialog-head h2 { font-size: 18px; }
+.dialog-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 19px; }
+.source-option { display: flex; align-items: center; gap: 9px; padding: 8px 2px; border-bottom: 1px solid var(--border); overflow-wrap: anywhere; }
+.source-list { max-height: 260px; overflow-y: auto; }
+#toast { position: fixed; bottom: 43px; left: 50%; transform: translateX(-50%); max-width: min(540px, 92vw); width: max-content; border: 1px solid var(--border); background: var(--text); color: var(--paper); border-radius: 11px; padding: 11px 15px; font-size: 12px; box-shadow: 0 4px 20px #0002; z-index: 20; }
+.fault { padding: 25px; height: 100%; overflow-y: auto; }
+.fault h2 { font-size: 18px; margin-bottom: 15px; }
+.mini { padding: 14px 17px; height: 100%; overflow: hidden; }
+.mini-head { display: flex; justify-content: space-between; align-items: center; color: var(--weak); font-size: 11px; margin-bottom: 13px; }
+.mini-head strong { color: var(--accent); font-size: 15px; font-weight: 500; }
+.mini-count { font-size: 23px; color: var(--accent); margin-right: 5px; }
+.mini-row { display: flex; align-items: center; gap: 9px; margin-top: 10px; }
+.mini-row img { width: 39px; height: 34px; object-fit: cover; border-radius: 6px; }
+.mini-row span { font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+@media (max-width: 760px) { .inspector { position: absolute; right: 12px; bottom: 12px; width: min(320px, calc(100% - 24px)); max-height: calc(100% - 24px); border: 1px solid var(--border); border-radius: 13px; box-shadow: 0 8px 35px #0002; } }
+@media (max-width: 520px) {
+  .top { padding: 10px 12px 0; } .intro { display: none; } .tools { padding-top: 12px; gap: 6px; }
+  .tabs button { padding-inline: 7px; } .source-button { font-size: 11px; padding-inline: 4px; }
+  .search-row { gap: 5px; } .map-hint { display: none; } .cards-pane { padding: 12px; } .card-grid { gap: 12px; }
+  .card-art img { height: 135px; } .local-badge { display: none; } .bottom { padding: 7px 12px; } .legend { gap: 7px; }
+}
+@media (max-width: 330px) { .tools .actions { width: 100%; } .search-row { flex-wrap: wrap; } .source-button { margin-left: auto; } .brand { font-size: 14px; } }
+@media (max-height: 490px) { .intro { display: none; } .top { padding-top: 7px; } .brand-row { min-height: 25px; } .tools { padding-block: 5px; } .search-row { padding-bottom: 7px; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { transition: none !important; animation: none !important; scroll-behavior: auto !important; } }
+
+@media (max-width: 520px) and (max-height: 550px) { .inspector-art { height: 86px; } }


### PR DESCRIPTION
## 交付

新增独立的 API 2.1 Web 插件 **星笺 · Starpaper 1.0.0**：把本地知识、原始待办与现有 Markdown 笔记连成星图，提供离线插画图鉴。基于 `75494e324c70d76ccd5aaaef20fd05c18a7d6083`；一个完整提交，不修改主程序实现。

- `plugin-samples/PaperTodo.Plugin.Starpaper/`：源码、说明、打包脚本、行为测试。
- `plugins/com.papertodo.starpaper/`：与源码逐字节一致的直接加载版本。
- `.github/workflows/starpaper.yml`：独立模型/浏览器检查、部署副本校验、ZIP 和截图产物。

## 已实现

### 知识星图
本地知识增删改、精确且无歧义的 `[[标题]]` 关联、现有 Markdown 只读引用、手动命名关联与 Shift+单击连线。节点拖拽、平移缩放、搜索、完成筛选、邻居聚焦、全图定位、自动布局和本地撤销/重做。布局是确定性的静态布局，不持续运行力导向模拟。不会因为筛选或原始对象暂不可读而删除关系/封面。

### 待办图鉴与插画
按用户选择读取原待办纸，使用真实 Paper ID / Todo ID 新建、编辑、标记完成。八种原创、本地矢量插画，按关键词默认选择并可手动切换；这是离线模板，不是 AI 绘画。支持本地位图、粘贴、拖入，保存压缩副本；插画在插件内部显示，不注入原始待办行。可导出 960×1120 PNG 卡片、SVG 星图、JSON 备份及确认后导入。

### 宿主与数据边界
不声明 provider Runtime，不进行后台轮询，不接管 PaperWindow / Edge / Top Bar。标准宿主胶囊与只读 320×240 Mini；Mini 无状态 writer、键盘输入、全页 pointer claim，首个真实布局后才 ready。正文不可用时胶囊是上次摘要，不承诺常驻实时统计。

本地状态使用宿主管理的 per-paper state，实际 UTF-8 字节数检查 10 MiB 限额，不静默截断。原始待办与引用笔记正文不复制进插件状态。无 localStorage/IndexedDB、云端服务或第三方前端依赖。读取失败保留最后完整快照；过期请求不覆盖新请求；写入失败不自动重发。损坏/未来版本数据停止写入并允许原始导出。中英日韩界面、宿主主题/字体、窄窗口及减少动效适配。

## 验证

本地已运行：
- `node --test .../tests/core.test.cjs`：**21/21 通过**。
- Chromium + Playwright API 2.1 mock：**20/20 通过**，包含真实 DOM 操作、拖拽单次提交、异步失败、引用、图片与 PNG 尺寸、导入撤销、只读 Mini、窄窗口和键盘完成回归。
- JavaScript 语法、`git diff --check`、部署副本逐字节一致、确定性 ZIP 打包通过。

本地受管 Chromium 禁止 HTTP/file 导航，因此本地浏览器测试使用显式 `--inline` 模式加载同一 JS/CSS；**不代表 CSP/资源加载或 Windows/WPF/WebView2 真机已验证**。新增 CI 默认走原始 HTML/CSP + 本地 HTTP 模式；HEAD `[ci]` 同时请求现有 Windows 构建。Windows 实机插件加载、退出重启持久化、Edge 出入场和混合 DPI 仍需手测，未伪装为已通过。

安装包：`com.papertodo.starpaper/` 解压到 `plugins/` 后重启，在新笔记纸选择此正文插件，再选择来源。主程序发布包不捆绑插件。

## 知识影响

没有改变现有架构、ownership、插件合同或 Agent 执行规则；不修改 Architecture、Decisions 或 AGENTS。不把独立分发插件记成主程序内置功能。沿用项目现有授权与 Required Notice。