### PR TITLE
fix: 按 UI 线程共享菜单资源，修复启动跨线程崩溃

### DIFF
--- a/src/PaperWindow.cs
+++ b/src/PaperWindow.cs
@@ -324,8 +324,18 @@ public sealed partial class PaperWindow : Window
     private const string PinNeedlePathData = "M 10.85,15.35 H 13.15 V 22.1 L 12,23.25 L 10.85,22.1 Z";
     private const int TodoMoveAnimationMilliseconds = 150;
 
-    private static readonly ControlTemplate SharedContextMenuTemplate = BuildContextMenuTemplate();
-    private static readonly Style SharedCompactMenuItemStyle = BuildCompactMenuItemStyle();
+    // Static helpers can initialize PaperWindow on a worker thread during startup.
+    // Keep dispatcher-owned menu resources lazy and shared only by their creating thread.
+    // ThreadStatic fields must not have initializers: each UI thread fills its own cache.
+    [ThreadStatic]
+    private static ControlTemplate? _sharedContextMenuTemplate;
+    [ThreadStatic]
+    private static Style? _sharedCompactMenuItemStyle;
+
+    private static ControlTemplate SharedContextMenuTemplate =>
+        _sharedContextMenuTemplate ??= BuildContextMenuTemplate();
+    private static Style SharedCompactMenuItemStyle =>
+        _sharedCompactMenuItemStyle ??= BuildCompactMenuItemStyle();
     private Style? _todoCheckBoxStyle;
     private double _todoCheckBoxStyleScale = double.NaN;
 


### PR DESCRIPTION
启动后台清理会调用 PaperWindow 静态方法；复制转换新增的显式静态构造使该调用能够提前初始化全局菜单模板和样式，之后 UI 创建菜单时触发 FrameworkTemplate.Seal / VerifyAccess 异常。

将两个立即初始化的全局字段改为无初始化器的 ThreadStatic 缓存，通过原有访问属性首次使用时创建。同一 UI 线程的所有纸片继续共享一套资源，不同线程不再共享 Dispatcher 所属对象。保留静态构造、复制转换事件注册和后台清理。

检查：仅修改 PaperWindow.cs，新增 12 行、删除 2 行；git diff --check 通过，并核查 PaperWindow 各 partial 文件静态字段。局部线程归属约束写在代码注释，无产品架构或用户文案变更。

验证限制：当前 Linux 环境未安装 dotnet，未执行本地构建或 Windows 启动手测。HEAD 含 [ci]，交由 Windows CI 编译并运行现有检查。仍需 Windows 验证无插件/空数据启动、多纸片右键菜单及待办/笔记复制转换。