### PR TITLE
fix(edge): 修复待办预览关联图标挤压与命中区域

### DIFF
--- a/src/EdgeCapsulePreview.Live.cs
+++ b/src/EdgeCapsulePreview.Live.cs
@@ -211,8 +211,10 @@ internal abstract class EdgeCapsuleLivePreviewView : Grid
 
 internal static class EdgeCapsulePreviewMeasure
 {
-    private const double ApproximateGlyphWidthDip = 6.4;
+    private const double BaseApproximateGlyphWidthDip = 6.4;
     private const double FixedChromeReserveWidthDip = 72;
+    private static double ApproximateGlyphWidthDip =>
+        AppTypography.Scale(BaseApproximateGlyphWidthDip);
 
     public static double MeasureWidth(
         string? title,

--- a/src/EdgeCapsulePreview.Live.cs
+++ b/src/EdgeCapsulePreview.Live.cs
@@ -218,7 +218,20 @@ internal static class EdgeCapsulePreviewMeasure
         string? title,
         string? body,
         double minimum,
-        double maximum)
+        double maximum) =>
+        MeasureWidth(
+            title,
+            body,
+            minimum,
+            maximum,
+            FixedChromeReserveWidthDip);
+
+    public static double MeasureWidth(
+        string? title,
+        string? body,
+        double minimum,
+        double maximum,
+        double fixedReserveWidthDip)
     {
         var longest = Math.Max(
             DisplayWidth(title),
@@ -229,7 +242,7 @@ internal static class EdgeCapsulePreviewMeasure
                 .Select(DisplayWidth)
                 .DefaultIfEmpty(0)
                 .Max());
-        var desired = FixedChromeReserveWidthDip +
+        var desired = Math.Max(0, fixedReserveWidthDip) +
             Math.Min(64, longest) * ApproximateGlyphWidthDip;
         return Math.Clamp(Math.Ceiling(desired), minimum, maximum);
     }

--- a/src/EdgeCapsulePreview.Todo.cs
+++ b/src/EdgeCapsulePreview.Todo.cs
@@ -14,6 +14,11 @@ internal sealed class TodoEdgeCapsulePreviewProvider : IEdgeCapsulePreviewProvid
     internal const int MaximumItemCharacters = 512;
     internal const double LinkedTargetButtonSizeDip = 20;
 
+    // Total card width lost before todo text reaches its Grid column:
+    // host close/chrome 22 + view margins 19 + items right margin 2 + row padding 7 +
+    // checkbox column 24 + text margins 6 = 80 DIPs. Marker width is added separately per row.
+    private const double TodoTextLaneFixedReserveDip = 80;
+
     public static TodoEdgeCapsulePreviewProvider Instance { get; } = new();
 
     private TodoEdgeCapsulePreviewProvider()
@@ -28,16 +33,17 @@ internal sealed class TodoEdgeCapsulePreviewProvider : IEdgeCapsulePreviewProvid
             Environment.NewLine,
             items.Select(item => PreviewItemText(item.Text)));
         var markerReserve = MaximumMarkerReserveDip(items);
+        var textLaneReserve = TodoTextLaneFixedReserveDip + markerReserve;
         var width = EdgeCapsulePreviewMeasure.MeasureWidth(
             context.Title,
             body,
             minimum: EdgeCapsulePreviewSize.MinimumWidthDip,
-            maximum: 450);
-        // Optional right-side controls are mounted in an Auto column after the text estimate. Keep
-        // their widest rendered lane in the frozen preview width instead of letting it steal space
-        // from short todo labels after layout.
-        width = Math.Min(450, width + markerReserve);
-        var availableTextWidth = Math.Max(64, width - 60 - markerReserve);
+            maximum: 450,
+            fixedReserveWidthDip: textLaneReserve);
+        // Height estimation must subtract the same fixed lane that width estimation added. Keeping
+        // these two calculations on one reserve prevents the renderer from wrapping text that the
+        // size estimator believed still had room beside the optional marker controls.
+        var availableTextWidth = Math.Max(1, width - textLaneReserve);
         var estimatedLines = items.Count == 0
             ? 1
             : items.Sum(item => Math.Clamp(

--- a/src/EdgeCapsulePreview.Todo.cs
+++ b/src/EdgeCapsulePreview.Todo.cs
@@ -12,6 +12,7 @@ internal sealed class TodoEdgeCapsulePreviewProvider : IEdgeCapsulePreviewProvid
     // the place for browsing the full list.
     internal const int MaximumRenderedItems = 12;
     internal const int MaximumItemCharacters = 512;
+    internal const double LinkedTargetButtonSizeDip = 20;
 
     public static TodoEdgeCapsulePreviewProvider Instance { get; } = new();
 
@@ -26,12 +27,17 @@ internal sealed class TodoEdgeCapsulePreviewProvider : IEdgeCapsulePreviewProvid
         var body = string.Join(
             Environment.NewLine,
             items.Select(item => PreviewItemText(item.Text)));
+        var markerReserve = MaximumMarkerReserveDip(items);
         var width = EdgeCapsulePreviewMeasure.MeasureWidth(
             context.Title,
             body,
             minimum: EdgeCapsulePreviewSize.MinimumWidthDip,
             maximum: 450);
-        var availableTextWidth = Math.Max(64, width - 60);
+        // Optional right-side controls are mounted in an Auto column after the text estimate. Keep
+        // their widest rendered lane in the frozen preview width instead of letting it steal space
+        // from short todo labels after layout.
+        width = Math.Min(450, width + markerReserve);
+        var availableTextWidth = Math.Max(64, width - 60 - markerReserve);
         var estimatedLines = items.Count == 0
             ? 1
             : items.Sum(item => Math.Clamp(
@@ -131,6 +137,35 @@ internal sealed class TodoEdgeCapsulePreviewProvider : IEdgeCapsulePreviewProvid
             ? text + "…"
             : text[..(MaximumItemCharacters - 1)] + "…";
     }
+
+    private static double MaximumMarkerReserveDip(IReadOnlyList<PaperItem> items)
+    {
+        var maximum = 0.0;
+        foreach (var item in items)
+        {
+            var reserve = 0.0;
+            if (item.ReminderAt.HasValue || item.ReminderTriggered)
+            {
+                reserve += AppTypography.Scale(10.5) + 2;
+            }
+            if (HasLinkedTarget(item))
+            {
+                // 20 DIP button + its horizontal margin. The final 2 DIP below belongs to the
+                // marker lane itself and is shared with a reminder marker on the same row.
+                reserve += LinkedTargetButtonSizeDip + 2;
+            }
+            if (reserve > 0)
+            {
+                reserve += 2;
+            }
+            maximum = Math.Max(maximum, reserve);
+        }
+        return maximum;
+    }
+
+    private static bool HasLinkedTarget(PaperItem item) =>
+        !string.IsNullOrWhiteSpace(item.LinkedPaperId) ||
+        !string.IsNullOrWhiteSpace(item.LinkedPath);
 }
 
 internal sealed record TodoEdgeCapsulePreviewSnapshot(
@@ -359,18 +394,42 @@ internal sealed class TodoEdgeCapsulePreviewView : EdgeCapsuleLivePreviewView
 
         if (linkedMarker != null)
         {
-            var link = CreateMarkerText(linkedMarker);
-            link.Cursor = Cursors.Hand;
+            var glyph = CreateMarkerText(linkedMarker);
+            glyph.Margin = new Thickness(0);
+            var link = new Button
+            {
+                Content = glyph,
+                Width = TodoEdgeCapsulePreviewProvider.LinkedTargetButtonSizeDip,
+                Height = TodoEdgeCapsulePreviewProvider.LinkedTargetButtonSizeDip,
+                Margin = new Thickness(1, 0, 1, 0),
+                Padding = new Thickness(0),
+                Background = Brushes.Transparent,
+                BorderBrush = Brushes.Transparent,
+                BorderThickness = new Thickness(0),
+                Cursor = Cursors.Hand,
+                Focusable = false,
+                FocusVisualStyle = null,
+                HorizontalContentAlignment = HorizontalAlignment.Center,
+                VerticalContentAlignment = VerticalAlignment.Center
+            };
             EdgeCapsulePreviewInteraction.SetConsumesPointer(link, true);
             link.MouseEnter += (_, _) =>
+            {
                 link.SetResourceReference(
+                    Control.BackgroundProperty,
+                    "HoverBrushKey");
+                glyph.SetResourceReference(
                     TextBlock.ForegroundProperty,
                     "LinkBrushKey");
+            };
             link.MouseLeave += (_, _) =>
-                link.SetResourceReference(
+            {
+                link.Background = Brushes.Transparent;
+                glyph.SetResourceReference(
                     TextBlock.ForegroundProperty,
                     "WeakTextBrushKey");
-            link.MouseLeftButtonUp += (_, e) =>
+            };
+            link.Click += (_, e) =>
             {
                 Context.OpenTodoLinkedTarget(item.Id);
                 e.Handled = true;


### PR DESCRIPTION
## 修改

- 待办 Edge 预览按真实文字列开销计算宽度：宿主关闭区/外层 chrome、预览边距、行 padding、复选框列、文字 margin 与右侧 marker 共用同一套宽度预算，避免 `↗` / `⌁` 把短文本挤到下一行。
- 宽度估算与高度换行估算改为使用同一个 text-lane reserve，避免“估算认为一行，实际布局变两行”的偏差。
- 预览文字宽度估算跟随全局字体缩放，120% 字体下也不会继续按 100% 字号计算卡片宽度。
- 将原来只对字形本身响应的关联标记改为 20×20 的实际 `Button`，整块按钮区域都可点击。
- 保留宿主现有 preview input authority，按钮继续作为交互控件消费指针，不引入新的命中状态。

## 验证

- 改动涉及 `src/EdgeCapsulePreview.Todo.cs` 与 `src/EdgeCapsulePreview.Live.cs`。
- HEAD 带 `[ci]`，触发 Release CI 构建与现有语义检查。