### PR TITLE
feat: 浏览态优先保持鼠标锚点向下展开

### DIFF
--- a/src/AppController.EdgeCapsulePreviewPlacement.cs
+++ b/src/AppController.EdgeCapsulePreviewPlacement.cs
@@ -1,0 +1,58 @@
+namespace PaperTodo;
+
+public sealed partial class AppController
+{
+    internal bool CanKeepEdgeCapsulePreviewAtCurrentTop(
+        PaperData paper,
+        double previewHeightDip)
+    {
+        if (!double.IsFinite(previewHeightDip) ||
+            previewHeightDip <= 0 ||
+            !_windows.TryGetValue(paper.Id, out var window) ||
+            !window.TryGetEdgeCapsuleAppliedGeometry(out var geometry) ||
+            geometry.Bounds.IsEmpty)
+        {
+            return false;
+        }
+
+        var probe = new DeviceScreenPoint(
+            geometry.Bounds.Left,
+            geometry.Bounds.Top);
+        if (!WindowWorkAreaHelper.TryGetMonitorGeometryAtDeviceScreenPoint(
+                probe,
+                out var monitor))
+        {
+            return false;
+        }
+
+        // Use the already-applied host DPI rather than a fresh monitor-only DPI estimate. During
+        // mixed-DPI queue browsing the HWND is the authority for the physical size Windows is
+        // actually presenting. The target card alone decides whether pointer anchoring is viable;
+        // followers are allowed to extend below the work area by the normal queue policy.
+        var scaleY = double.IsFinite(geometry.DpiScaleY)
+            ? Math.Max(1, geometry.DpiScaleY)
+            : Math.Max(1, monitor.DpiScaleY);
+        var previewHeightDevice = Math.Max(
+            1,
+            (int)Math.Ceiling(previewHeightDip * scaleY));
+        var bottomMarginDevice = Math.Max(
+            0,
+            (int)Math.Ceiling(EdgeCapsuleLayout.TopMargin * scaleY));
+        return geometry.Bounds.Top + previewHeightDevice <=
+            monitor.WorkArea.Bottom - bottomMarginDevice;
+    }
+}
+
+internal static class EdgeCapsulePreviewViewportPolicy
+{
+    public static bool CanKeepCurrentTop(
+        PaperData paper,
+        double previewHeightDip)
+    {
+        var controller = AppController.Current;
+        return controller != null &&
+            controller.CanKeepEdgeCapsulePreviewAtCurrentTop(
+                paper,
+                previewHeightDip);
+    }
+}

--- a/src/EdgeCapsulePreview.cs
+++ b/src/EdgeCapsulePreview.cs
@@ -151,9 +151,11 @@ internal sealed record EdgeCapsulePreviewLayoutSession(
     IReadOnlyDictionary<string, double> TopOffsetsDip);
 
 /// <summary>
-/// Pure preview placement policy. The compact queue remains the base plan. During one browsing
-/// session only the owner has a non-standard height; transfers reuse the old preview space and keep
-/// the newly hovered capsule anchored on the pointer side. Full compaction happens only on exit.
+/// Preview placement policy. The compact queue remains the base plan. During one browsing session
+/// only the owner has a non-standard height. Downward transfers keep the newly hovered capsule at
+/// its current pointer-side position whenever that preview itself still fits the monitor; only a
+/// space-constrained target falls back to filling the released preview region. Full compaction
+/// happens on exit.
 /// </summary>
 internal static class EdgeCapsulePreviewLayoutCoordinator
 {
@@ -209,10 +211,9 @@ internal static class EdgeCapsulePreviewLayoutCoordinator
         var newHeight = Math.Max(compactHeight, size.HeightDip);
         var tops = currentTops.ToArray();
 
-        // Preview browsing deliberately keeps queue-relative motion even if a tall card or its
-        // followers extend beyond the monitor work area. Do not clamp the card height or shrink the
-        // whole corridor here; the important invariant is that a transfer does not move the target
-        // out from under a stationary pointer.
+        // Preview browsing deliberately keeps queue-relative motion even if followers extend below
+        // the monitor work area. Only the target preview itself decides whether its pointer-side top
+        // can be retained; overflow followers are allowed by the normal queue policy.
         if (oldIndex < 0)
         {
             tops[newIndex] = baseTops[newIndex];
@@ -224,11 +225,34 @@ internal static class EdgeCapsulePreviewLayoutCoordinator
                 compactHeight,
                 gap);
         }
+        else if (newIndex > oldIndex &&
+                 CanKeepPointerSideTopOnDownwardTransfer(
+                     papers,
+                     newIndex,
+                     newHeight))
+        {
+            // Prefer interaction continuity over packing density while the target card itself has
+            // room. The newly hovered capsule is already under the pointer, so leave its top exactly
+            // where it is and let the preview grow downward. Followers may overflow just as a long
+            // compact queue may; the released upper region stays empty until the session ends.
+            for (var index = 0; index < newIndex; index++)
+            {
+                tops[index] = baseTops[index];
+            }
+            tops[newIndex] = currentTops[newIndex];
+            PushFollowingMembers(
+                tops,
+                currentTops,
+                newIndex,
+                newHeight,
+                compactHeight,
+                gap);
+        }
         else if (newIndex > oldIndex)
         {
-            // Moving downward: compact only the released upper side. Keep the lower anchor of the
-            // newly hovered capsule (and everything below it) where it already is, then grow the new
-            // preview upward into the space released by the old owner.
+            // Space-constrained downward transfer: compact only the released upper side. Keep the
+            // lower anchor of the newly hovered capsule (and everything below it) where it already
+            // is, then grow the new preview upward into the space released by the old owner.
             for (var index = 0; index < newIndex; index++)
             {
                 tops[index] = baseTops[index];
@@ -313,6 +337,21 @@ internal static class EdgeCapsulePreviewLayoutCoordinator
         }
 
         return new EdgeCapsuleQueuePlan(basePlan.Queues, placements);
+    }
+
+    private static bool CanKeepPointerSideTopOnDownwardTransfer(
+        IReadOnlyList<PaperData> papers,
+        int ownerIndex,
+        double ownerHeight)
+    {
+        if (ownerIndex < 0 || ownerIndex >= papers.Count)
+        {
+            return false;
+        }
+
+        return EdgeCapsulePreviewViewportPolicy.CanKeepCurrentTop(
+            papers[ownerIndex],
+            ownerHeight);
     }
 
     private static void PushFollowingMembers(


### PR DESCRIPTION
## 改动
- A → B 向下浏览时，只要 B 自身能从当前鼠标位置完整向下展开，就保持 B 的当前位置，不再优先填补上方空位。
- 只有 B 自身会越出工作区时，才回退到原有补位策略。
- 允许 B 下方的后续胶囊按现有队列规则继续向下延伸，不把 follower 是否越界作为 B 是否需要补位的条件。
- 使用目标胶囊当前已应用的物理位置和实际 HWND DPI 判断可用空间，兼容多屏/混合 DPI。

## 验证
- Release Build
- Markdown semantic checks
- Todo navigation checks
- Threading regression checks

以上均通过。