### PR TITLE
fix: 保留开机早期副屏纸片位置

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -118,6 +118,7 @@ public partial class App : Application
         SessionEnding += (s, args) => _controller?.ExitForSystemShutdown();
         var handlesInitialVisibility = startupCommand.Kind is
             StartupCommandKind.Hide or StartupCommandKind.Toggle;
+        await _controller.WaitForStartupDisplayTopologyAsync();
         await _controller.StartAsync(
             createDefaultPaper: !startupCommand.CreatesPaper,
             initialVisibilityCommand: handlesInitialVisibility

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -118,7 +118,6 @@ public partial class App : Application
         SessionEnding += (s, args) => _controller?.ExitForSystemShutdown();
         var handlesInitialVisibility = startupCommand.Kind is
             StartupCommandKind.Hide or StartupCommandKind.Toggle;
-        await _controller.WaitForStartupDisplayTopologyAsync();
         await _controller.StartAsync(
             createDefaultPaper: !startupCommand.CreatesPaper,
             initialVisibilityCommand: handlesInitialVisibility

--- a/src/AppController.StartupDisplayTopology.cs
+++ b/src/AppController.StartupDisplayTopology.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace PaperTodo;
+
+public sealed partial class AppController
+{
+    private static readonly TimeSpan StartupDisplayTopologyPollInterval = TimeSpan.FromMilliseconds(150);
+    private static readonly TimeSpan StartupDisplayTopologySettleTimeout = TimeSpan.FromSeconds(5);
+    private const int StartupDisplayTopologyReadySamples = 2;
+
+    internal async Task WaitForStartupDisplayTopologyAsync()
+    {
+        if (!HasPaperGeometryOutsideConnectedWorkAreas())
+        {
+            return;
+        }
+
+        // During Windows logon the primary monitor can be enumerable a little before a secondary
+        // monitor. Starting the normal off-screen rescue against that transient topology would
+        // permanently overwrite the secondary-screen X/Y in data.json. Only the ambiguous case
+        // waits; ordinary startup continues immediately, and timeout keeps the existing unplugged-
+        // monitor rescue behavior intact.
+        var deadline = DateTimeOffset.UtcNow + StartupDisplayTopologySettleTimeout;
+        var readySamples = 0;
+        while (!IsExiting && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(StartupDisplayTopologyPollInterval);
+            WindowWorkAreaHelper.InvalidateMonitorGeometryCache();
+
+            if (HasPaperGeometryOutsideConnectedWorkAreas())
+            {
+                readySamples = 0;
+                continue;
+            }
+
+            if (++readySamples >= StartupDisplayTopologyReadySamples)
+            {
+                return;
+            }
+        }
+
+        // The existing StartAsync rescue remains the authority after timeout. Make sure it reads
+        // a fresh monitor snapshot rather than the incomplete topology that triggered this wait.
+        WindowWorkAreaHelper.InvalidateMonitorGeometryCache();
+    }
+
+    private bool HasPaperGeometryOutsideConnectedWorkAreas()
+    {
+        var workAreas = ConnectedStartupWorkAreas();
+
+        foreach (var paper in State.Papers)
+        {
+            // Deep-capsule placement is owned by its persisted queue/monitor identity, not ordinary
+            // PaperData X/Y. Do not delay startup because of a parked deep-capsule paper window.
+            if (paper.IsCollapsed &&
+                State.UseCapsuleMode &&
+                State.UseDeepCapsuleMode &&
+                CanPaperDisplayAsCapsule(paper))
+            {
+                continue;
+            }
+
+            if (!IsFinite(paper.X) ||
+                !IsFinite(paper.Y) ||
+                !IsFinite(paper.Width) ||
+                !IsFinite(paper.Height) ||
+                paper.Width <= 0 ||
+                paper.Height <= 0)
+            {
+                // Invalid geometry is unambiguous corruption; let the normal rescue fix it now.
+                continue;
+            }
+
+            // Treat the paper center as its monitor ownership point. A paper that only clips the
+            // primary screen by a few pixels can still belong to a secondary monitor that Windows
+            // has not enumerated yet; using any rectangle intersection would miss that #187 path.
+            // Conversely, an ordinary paper whose center is on a live monitor should not pay the
+            // startup wait merely because part of its window is intentionally near/off an edge.
+            var center = new Point(
+                paper.X + (paper.Width / 2.0),
+                paper.Y + (paper.Height / 2.0));
+            if (workAreas.Exists(area => area.Contains(center)))
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static List<Rect> ConnectedStartupWorkAreas()
+    {
+        var result = new List<Rect>();
+        foreach (var monitor in WindowWorkAreaHelper.ConnectedMonitorGeometries())
+        {
+            var area = WindowWorkAreaHelper.WorkAreaForDevice(monitor.DeviceName);
+            if (!area.HasValue || area.Value.IsEmpty || area.Value.Width <= 0 || area.Value.Height <= 0)
+            {
+                continue;
+            }
+
+            result.Add(area.Value);
+        }
+
+        return result;
+    }
+}

--- a/src/AppController.cs
+++ b/src/AppController.cs
@@ -260,6 +260,10 @@ public sealed partial class AppController : IDisposable
         RefreshTodoReminderSchedule();
         RefreshExperimentalWindowRuntime();
 
+        // Keep the shell responsive while Windows finishes enumerating startup displays. The
+        // wait still precedes any coordinate rescue, so a late secondary monitor keeps its papers.
+        await WaitForStartupDisplayTopologyAsync();
+
         if (State.Papers.Count == 0)
         {
             if (createDefaultPaper)


### PR DESCRIPTION
## 问题

修复 #187。

Windows 登录早期，主屏可能先于副屏被系统枚举。PaperTodo 原本会立刻执行离屏救援；此时副屏上的已保存坐标会被误判成越界，拉回主屏后又写回 `data.json`，导致后续副屏出现时原位置已经丢失。

## 修改

- 启动前仅在检测到“已有普通纸片的中心位置不属于当前任何已枚举屏幕”这一可疑情况时，短暂等待显示器拓扑稳定。
- 使用纸片中心点判断显示器归属：纸片即使与主屏只擦到少量区域，只要主体仍在尚未出现的副屏，就不会被提前当成主屏纸片；普通靠近屏幕边缘但中心仍在当前屏幕的纸片不会因此等待。
- 每 150ms 重新读取显示器，最多等待 5 秒；连续两次确认纸片已有对应屏幕后立即继续启动。
- 超时后仍走原有 `EnsurePapersOnScreen`，因此真正拔掉副屏时仍会把纸片救回可见区域。
- 保留现有启动语义：主线本来会对隐藏纸片也执行离屏救援，因此本修复同样保护隐藏纸片的持久坐标，不顺手改变这一行为。
- 不修改 `StateStore`、`data.json` 格式、现有离屏救援规则或 Edge 胶囊位置模型；深度胶囊仍由原有队列/显示器身份负责恢复。

## 范围

最终差异保持 1 个提交、2 个文件：

- `App.xaml.cs`：启动恢复前增加一次条件式显示器拓扑等待；
- `src/AppController.StartupDisplayTopology.cs`：封装启动保护。

没有顺手处理 #178 或重构多屏位置模型，也没有新增第二套坐标保存机制。

## 审查修正

初版曾以“纸片矩形与任一当前屏幕相交”判断是否需要等待。复核发现这会漏掉主体在副屏、只与主屏擦边的纸片，因此改为以纸片中心点判断显示器归属；同时删除了对应的多余候选状态判断。没有扩大到隐藏纸片恢复策略或持久化结构。

## 验证

最终提交 `685be6f` 已通过：

- Windows 主构建：Release 编译、Markdown semantic checks、Todo navigation checks、Threading regression checks 全部通过。
- Persistence Checks：Persistence fault injection 通过。

代码路径已复核：正常拓扑直接返回；副屏延迟出现时不先覆盖原坐标；等待超时后保持原有拔屏救援语义。真实“冷启动 Windows + 副屏延迟枚举”的硬件时序无法由普通 CI 完整模拟，合并前仍建议用双屏开机自启动场景手测一次。

## 文档

这是 v4.0 Preview 尚未发布问题的局部修复，不改变持久化协议或架构职责，因此不修改 Architecture / Decisions；按仓库规则也不单独写入 Unreleased 更新日志。

Fixes #187