### PR TITLE
fix: 修复日常交互审查发现的 8 项问题

### DIFF
--- a/src/AppController.Mcp.cs
+++ b/src/AppController.Mcp.cs
@@ -127,6 +127,12 @@ public sealed partial class AppController
         RefreshTrayMenu();
         if (show) ShowPaper(paper);
         else ArrangeDeepCapsules(animate: false);
+
+        if (paper.Type == PaperTypes.Todo)
+        {
+            RefreshCapsuleEligibilityForLinkedPapers(
+                paper.Items.Select(item => item.LinkedPaperId));
+        }
     }
 
     internal void RefreshMcpTodoPaper(PaperData paper)
@@ -137,6 +143,8 @@ public sealed partial class AppController
         }
         NotifyTodoReminderCollectionChanged();
         RefreshTrayMenu();
+        RefreshCapsuleEligibilityForLinkedPapers(
+            paper.Items.Select(item => item.LinkedPaperId));
     }
 
     internal void RefreshTodoPapersForExternalLinkMutation(

--- a/src/AppController.Shortcuts.cs
+++ b/src/AppController.Shortcuts.cs
@@ -482,6 +482,9 @@ public sealed partial class AppController
                 _visibilityShortcutVisibleLinkedPaperIds,
                 StringComparer.Ordinal);
 
+        // Plugin digit aliases share the same OS registration space. Release them before changing
+        // the digit mode so built-in defaults are applied atomically against the desired mode.
+        SuspendPluginShortcutRegistrations();
         State.OpenEdgeCapsuleShortcutAtCursor = true;
         State.DistinguishNumpadShortcutDigits = false;
         State.PreserveLinkedPaperHiddenStateInVisibilityShortcuts = true;
@@ -492,6 +495,7 @@ public sealed partial class AppController
         if (_shortcutApplyFailure == GlobalShortcutRegistrationFailure.None &&
             !_shortcutApplyFailureStatus.HasValue)
         {
+            RefreshPluginShortcuts();
             return;
         }
 
@@ -500,6 +504,7 @@ public sealed partial class AppController
         State.PreserveLinkedPaperHiddenStateInVisibilityShortcuts =
             previousPreserveLinkedHidden;
         _visibilityShortcutVisibleLinkedPaperIds = previousVisibilitySnapshot;
+        RefreshPluginShortcuts();
         RefreshShortcutSettingsUi();
     }
 

--- a/src/AppController.Shortcuts.cs
+++ b/src/AppController.Shortcuts.cs
@@ -1157,9 +1157,7 @@ public sealed partial class AppController
             return ShortcutUiStatus.Unassigned;
         }
 
-        return definitions.All(item => _globalHotkeys?.ActiveBindings.ContainsKey(item.Id) == true
-            ? true
-            : false)
+        return definitions.All(item => _globalHotkeys?.ActiveBindings.ContainsKey(item.Id) == true)
             ? ShortcutUiStatus.Registered
             : ShortcutUiStatus.RegistrationFailed;
     }

--- a/src/AppController.Shortcuts.cs
+++ b/src/AppController.Shortcuts.cs
@@ -373,23 +373,7 @@ public sealed partial class AppController
         var resetAll = SettingsTextButton(Strings.Get("SettingsRestorePageDefaults"));
         resetAll.MinWidth = 108;
         resetAll.Padding = new Thickness(18, 0, 18, 0);
-        resetAll.Click += (_, _) =>
-        {
-            EnsureShortcutDraft();
-            foreach (var definition in GlobalShortcutCatalog.Definitions
-                         .Where(item => item.Group != GlobalShortcutGroup.Labs))
-            {
-                _shortcutDraft![definition.Id] = definition.DefaultGesture;
-                _shortcutEnabledDraft![definition.Id] = definition.DefaultEnabled;
-            }
-
-            State.OpenEdgeCapsuleShortcutAtCursor = true;
-            State.DistinguishNumpadShortcutDigits = false;
-            State.PreserveLinkedPaperHiddenStateInVisibilityShortcuts = true;
-            ClearVisibilityShortcutRestoreSnapshot();
-            _shortcutRecordingCommandId = null;
-            ApplyShortcutDraft();
-        };
+        resetAll.Click += (_, _) => RestoreShortcutSettingsPageDefaults();
         Grid.SetColumn(resetAll, 1);
         actions.Children.Add(resetAll);
 
@@ -476,6 +460,47 @@ public sealed partial class AppController
         root.Children.Add(rows);
 
         return root;
+    }
+
+    private void RestoreShortcutSettingsPageDefaults()
+    {
+        EnsureShortcutDraft();
+        foreach (var definition in GlobalShortcutCatalog.Definitions
+                     .Where(item => item.Group != GlobalShortcutGroup.Labs))
+        {
+            _shortcutDraft![definition.Id] = definition.DefaultGesture;
+            _shortcutEnabledDraft![definition.Id] = definition.DefaultEnabled;
+        }
+
+        var previousOpenAtCursor = State.OpenEdgeCapsuleShortcutAtCursor;
+        var previousDistinguishNumpad = State.DistinguishNumpadShortcutDigits;
+        var previousPreserveLinkedHidden =
+            State.PreserveLinkedPaperHiddenStateInVisibilityShortcuts;
+        var previousVisibilitySnapshot = _visibilityShortcutVisibleLinkedPaperIds == null
+            ? null
+            : new HashSet<string>(
+                _visibilityShortcutVisibleLinkedPaperIds,
+                StringComparer.Ordinal);
+
+        State.OpenEdgeCapsuleShortcutAtCursor = true;
+        State.DistinguishNumpadShortcutDigits = false;
+        State.PreserveLinkedPaperHiddenStateInVisibilityShortcuts = true;
+        ClearVisibilityShortcutRestoreSnapshot();
+        _shortcutRecordingCommandId = null;
+        ApplyShortcutDraft();
+
+        if (_shortcutApplyFailure == GlobalShortcutRegistrationFailure.None &&
+            !_shortcutApplyFailureStatus.HasValue)
+        {
+            return;
+        }
+
+        State.OpenEdgeCapsuleShortcutAtCursor = previousOpenAtCursor;
+        State.DistinguishNumpadShortcutDigits = previousDistinguishNumpad;
+        State.PreserveLinkedPaperHiddenStateInVisibilityShortcuts =
+            previousPreserveLinkedHidden;
+        _visibilityShortcutVisibleLinkedPaperIds = previousVisibilitySnapshot;
+        RefreshShortcutSettingsUi();
     }
 
     private static bool SupportsShortcutRecording(SettingsPage page)
@@ -1132,7 +1157,9 @@ public sealed partial class AppController
             return ShortcutUiStatus.Unassigned;
         }
 
-        return definitions.All(item => _globalHotkeys?.ActiveBindings.ContainsKey(item.Id) == true)
+        return definitions.All(item => _globalHotkeys?.ActiveBindings.ContainsKey(item.Id) == true
+            ? true
+            : false)
             ? ShortcutUiStatus.Registered
             : ShortcutUiStatus.RegistrationFailed;
     }

--- a/src/AppController.VisibilityShortcuts.cs
+++ b/src/AppController.VisibilityShortcuts.cs
@@ -73,6 +73,14 @@ public sealed partial class AppController
             return;
         }
 
+        // A repeated Hide belongs to the same hide/show cycle. Keep the first snapshot so a
+        // second shortcut press while everything is already hidden cannot replace the original
+        // visible linked-paper set with an empty one.
+        if (_visibilityShortcutVisibleLinkedPaperIds != null)
+        {
+            return;
+        }
+
         _visibilityShortcutVisibleLinkedPaperIds = State.Papers
             .Where(paper =>
                 IsLinkedPaperProtectedFromVisibilityShortcutRestore(paper) &&

--- a/src/MarkdownTextBox.PasteEntry.cs
+++ b/src/MarkdownTextBox.PasteEntry.cs
@@ -1,0 +1,21 @@
+namespace PaperTodo;
+
+public sealed partial class MarkdownTextBox
+{
+    /// <summary>
+    /// Keeps explicit paste entry points (notably the note context menu) aligned with Ctrl+V.
+    /// AvalonEdit disables its text paste command when the clipboard contains only an image, so
+    /// try PaperTodo's image path first in that case and otherwise preserve the native text path.
+    /// </summary>
+    public new void Paste()
+    {
+        if (!IsReadOnly &&
+            !ClipboardHasText() &&
+            TryInsertImageFromClipboard())
+        {
+            return;
+        }
+
+        base.Paste();
+    }
+}

--- a/src/MarkdownTextBox.PasteEntry.cs
+++ b/src/MarkdownTextBox.PasteEntry.cs
@@ -1,7 +1,56 @@
+using System.Windows;
+using System.Windows.Input;
+
 namespace PaperTodo;
 
 public sealed partial class MarkdownTextBox
 {
+    private static readonly bool PreviewTextDropEffectHandlerRegistered =
+        RegisterPreviewTextDropEffectHandler();
+
+    private static bool RegisterPreviewTextDropEffectHandler()
+    {
+        EventManager.RegisterClassHandler(
+            typeof(MarkdownTextBox),
+            DragDrop.PreviewDragOverEvent,
+            new DragEventHandler(OnPreviewTextDragOver),
+            handledEventsToo: true);
+        return true;
+    }
+
+    private static void OnPreviewTextDragOver(object sender, DragEventArgs e)
+    {
+        if (sender is not MarkdownTextBox editor ||
+            !editor.IsPreviewMode ||
+            editor.CanInsertImagesFromDataObject(e.Data) ||
+            !HasTextDropData(e.Data))
+        {
+            return;
+        }
+
+        var controlPressed =
+            (e.KeyStates & DragDropKeyStates.ControlKey) == DragDropKeyStates.ControlKey;
+        e.Effects = (e.AllowedEffects & DragDropEffects.Move) != 0 && !controlPressed
+            ? DragDropEffects.Move
+            : (e.AllowedEffects & DragDropEffects.Copy) != 0
+                ? DragDropEffects.Copy
+                : DragDropEffects.None;
+        e.Handled = e.Effects != DragDropEffects.None;
+    }
+
+    private static bool HasTextDropData(IDataObject data)
+    {
+        try
+        {
+            return data.GetDataPresent(DataFormats.UnicodeText) ||
+                data.GetDataPresent(DataFormats.Text);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     /// <summary>
     /// Keeps explicit paste entry points (notably the note context menu) aligned with Ctrl+V.
     /// AvalonEdit disables its text paste command when the clipboard contains only an image, so

--- a/src/MarkdownTextBox.PasteEntry.cs
+++ b/src/MarkdownTextBox.PasteEntry.cs
@@ -15,6 +15,11 @@ public sealed partial class MarkdownTextBox
             DragDrop.PreviewDragOverEvent,
             new DragEventHandler(OnPreviewTextDragOver),
             handledEventsToo: true);
+        EventManager.RegisterClassHandler(
+            typeof(MarkdownTextBox),
+            DragDrop.PreviewDropEvent,
+            new DragEventHandler(OnPreviewTextDrop),
+            handledEventsToo: true);
         return true;
     }
 
@@ -36,6 +41,47 @@ public sealed partial class MarkdownTextBox
                 ? DragDropEffects.Copy
                 : DragDropEffects.None;
         e.Handled = e.Effects != DragDropEffects.None;
+    }
+
+    private static void OnPreviewTextDrop(object sender, DragEventArgs e)
+    {
+        if (sender is not MarkdownTextBox editor ||
+            !editor.IsPreviewMode ||
+            editor.CanInsertImagesFromDataObject(e.Data) ||
+            !HasTextDropData(e.Data))
+        {
+            return;
+        }
+
+        string? text;
+        try
+        {
+            text = e.Data.GetDataPresent(DataFormats.UnicodeText)
+                ? e.Data.GetData(DataFormats.UnicodeText) as string
+                : e.Data.GetDataPresent(DataFormats.Text)
+                    ? e.Data.GetData(DataFormats.Text) as string
+                    : null;
+        }
+        catch
+        {
+            editor.PasteRejected?.Invoke();
+            e.Effects = DragDropEffects.None;
+            e.Handled = true;
+            return;
+        }
+
+        // Preview mode is intentionally read-only until PaperWindow places the caret and enters
+        // edit mode. Validate the payload here, before that state change, so the native Drop path
+        // cannot bypass the same length/line-length guard used by normal paste.
+        if (string.IsNullOrEmpty(text) ||
+            editor.TryBuildSafePasteText(text, selectedLength: 0, out _))
+        {
+            return;
+        }
+
+        editor.PasteRejected?.Invoke();
+        e.Effects = DragDropEffects.None;
+        e.Handled = true;
     }
 
     private static bool HasTextDropData(IDataObject data)

--- a/src/PaperCommandService.cs
+++ b/src/PaperCommandService.cs
@@ -484,6 +484,7 @@ internal sealed class PaperCommandService
         var item = RequireTodo(
             paper,
             RequiredId(request.TodoId, "todoId"));
+        var originalLinkedPaperId = item.LinkedPaperId;
         var snapshot = TodoPaperSnapshot.Capture(paper);
 
         using (_controller.SuppressPaperPluginEventScans())
@@ -502,8 +503,15 @@ internal sealed class PaperCommandService
                 throw SaveFailed();
             }
 
-            _controller.RunExternalPostCommitUi(
-                () => _controller.RefreshExternalTodoPaper(paper));
+            _controller.RunExternalPostCommitUi(() =>
+            {
+                _controller.RefreshExternalTodoPaper(paper);
+                if (!string.IsNullOrWhiteSpace(originalLinkedPaperId))
+                {
+                    _controller.RefreshCapsuleEligibilityForLinkedPapers(
+                        [originalLinkedPaperId]);
+                }
+            });
         }
 
         _controller.PublishExternalPaperOperation(context);

--- a/src/PaperCommandService.cs
+++ b/src/PaperCommandService.cs
@@ -243,6 +243,7 @@ internal sealed class PaperCommandService
                 "text");
         var textChanged = text != null &&
             !string.Equals(item.Text, text, StringComparison.Ordinal);
+        var originalLinkedPaperId = item.LinkedPaperId;
         var linkedPaperId = NormalizeLinkedPaperUpdate(request);
         var doneChanged = request.Done.HasValue &&
             request.Done.Value != item.Done;
@@ -333,8 +334,15 @@ internal sealed class PaperCommandService
                 throw SaveFailed();
             }
 
-            _controller.RunExternalPostCommitUi(
-                () => _controller.RefreshExternalTodoPaper(paper));
+            _controller.RunExternalPostCommitUi(() =>
+            {
+                _controller.RefreshExternalTodoPaper(paper);
+                if (linkedPaperChanged)
+                {
+                    _controller.RefreshCapsuleEligibilityForLinkedPapers(
+                        [originalLinkedPaperId, linkedPaperId]);
+                }
+            });
         }
 
         _controller.PublishExternalPaperOperation(context);
@@ -909,6 +917,7 @@ internal sealed class PaperCommandService
         int Order,
         string? LinkedPaperId,
         string? LinkedPath,
+        bool? LinkedPathIsDirectory,
         DateTimeOffset? ReminderAt,
         bool ReminderTriggered)
     {
@@ -920,6 +929,7 @@ internal sealed class PaperCommandService
                 item.Order,
                 item.LinkedPaperId,
                 item.LinkedPath,
+                item.LinkedPathIsDirectory,
                 item.ReminderAt,
                 item.ReminderTriggered);
 
@@ -928,7 +938,10 @@ internal sealed class PaperCommandService
             Item.Text = Text;
             Item.Done = Done;
             Item.Order = Order;
-            Item.RestoreQuickLaunch(LinkedPaperId, LinkedPath);
+            Item.RestoreQuickLaunch(
+                LinkedPaperId,
+                LinkedPath,
+                LinkedPathIsDirectory);
             Item.ReminderAt = ReminderAt;
             Item.ReminderTriggered = ReminderTriggered;
         }

--- a/src/PaperWindow.CopyTranslation.cs
+++ b/src/PaperWindow.CopyTranslation.cs
@@ -13,13 +13,44 @@ public sealed partial class PaperWindow
         EventManager.RegisterClassHandler(
             typeof(PaperWindow),
             UIElement.PreviewKeyDownEvent,
-            new KeyEventHandler(OnCopyTranslationPreviewKeyDown),
+            new KeyEventHandler(OnPaperWindowPreviewKeyDown),
             handledEventsToo: true);
         EventManager.RegisterClassHandler(
             typeof(PaperWindow),
             ContextMenuService.ContextMenuOpeningEvent,
             new ContextMenuEventHandler(OnCopyTranslationContextMenuOpening),
             handledEventsToo: true);
+    }
+
+    private static void OnPaperWindowPreviewKeyDown(
+        object sender,
+        KeyEventArgs e)
+    {
+        if (e.Handled || sender is not PaperWindow window)
+        {
+            return;
+        }
+
+        // The Todo window also owns list-level undo/redo. While the title TextBox has focus,
+        // keep Ctrl+Z/Ctrl+Y inside that editor so an empty title undo stack cannot fall through
+        // and unexpectedly replay Todo-list history.
+        if (window._isEditingTitle &&
+            window._titleEditBox is { IsKeyboardFocusWithin: true } titleEditBox &&
+            Keyboard.Modifiers == ModifierKeys.Control &&
+            e.Key is Key.Z or Key.Y)
+        {
+            var command = e.Key == Key.Z
+                ? ApplicationCommands.Undo
+                : ApplicationCommands.Redo;
+            if (command.CanExecute(null, titleEditBox))
+            {
+                command.Execute(null, titleEditBox);
+            }
+            e.Handled = true;
+            return;
+        }
+
+        OnCopyTranslationPreviewKeyDown(window, e);
     }
 
     private static void OnCopyTranslationPreviewKeyDown(

--- a/src/PaperWindow.Note.cs
+++ b/src/PaperWindow.Note.cs
@@ -500,11 +500,35 @@ public sealed partial class PaperWindow
             return true;
         }
 
+        static bool HasTextDropData(IDataObject data)
+        {
+            try
+            {
+                return data.GetDataPresent(DataFormats.UnicodeText) ||
+                    data.GetDataPresent(DataFormats.Text);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         box.AllowDrop = true;
         box.PreviewDragOver += (_, e) =>
         {
             if (!box.CanInsertImagesFromDataObject(e.Data))
             {
+                if (!isPreviewing || !HasTextDropData(e.Data))
+                {
+                    return;
+                }
+
+                e.Effects = (e.AllowedEffects & DragDropEffects.Copy) != 0
+                    ? DragDropEffects.Copy
+                    : (e.AllowedEffects & DragDropEffects.Move) != 0
+                        ? DragDropEffects.Move
+                        : DragDropEffects.None;
+                e.Handled = e.Effects != DragDropEffects.None;
                 return;
             }
 
@@ -515,11 +539,25 @@ public sealed partial class PaperWindow
         {
             if (!box.CanInsertImagesFromDataObject(e.Data))
             {
+                if (!HasTextDropData(e.Data))
+                {
+                    return;
+                }
                 if (!box.ValidateTextDrop(e.Data))
                 {
                     e.Effects = DragDropEffects.None;
                     e.Handled = true;
+                    return;
                 }
+                if (isPreviewing)
+                {
+                    ShowEditorAtPreviewPoint(
+                        e.GetPosition(box),
+                        e.OriginalSource as DependencyObject,
+                        selectImage: false);
+                }
+                // Once edit mode is active, AvalonEdit still owns text insertion, move/copy
+                // semantics and undo grouping. Leave the Drop event unhandled here.
                 return;
             }
 

--- a/src/PaperWindow.TodoLinksAndSelection.cs
+++ b/src/PaperWindow.TodoLinksAndSelection.cs
@@ -937,6 +937,11 @@ public sealed partial class PaperWindow
             DragDrop.PreviewDropEvent,
             new DragEventHandler((_, e) =>
             {
+                if (!HasTodoFileDrop(e.Data))
+                {
+                    return;
+                }
+
                 try
                 {
                     var paths = GetTodoFileDropPaths(e.Data);
@@ -988,6 +993,12 @@ public sealed partial class PaperWindow
 
     private void UpdateTodoPathDropEffect(Border row, DragEventArgs e)
     {
+        if (!HasTodoFileDrop(e.Data))
+        {
+            ResetTodoPathDropVisual(row);
+            return;
+        }
+
         var paths = GetTodoFileDropPaths(e.Data);
         if (paths.Length == 1)
         {
@@ -1002,6 +1013,18 @@ public sealed partial class PaperWindow
             e.Effects = DragDropEffects.None;
         }
         e.Handled = true;
+    }
+
+    private static bool HasTodoFileDrop(IDataObject data)
+    {
+        try
+        {
+            return data.GetDataPresent(DataFormats.FileDrop);
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static string[] GetTodoFileDropPaths(IDataObject data)


### PR DESCRIPTION
## 修复内容

本 PR 只处理本轮审查中范围明确、修复成本较低的 8 项问题：

- 连续两次「隐藏全部」不再覆盖第一次隐藏前的恢复快照
- 「恢复默认快捷键」失败时，相关选项和显隐恢复状态一并回滚
- MCP / 插件修改待办关联后，刷新旧目标和新目标的胶囊资格
- 外部待办修改保存失败时，完整恢复文件 / 文件夹类型信息
- 编辑待办纸片标题时，Ctrl+Z / Ctrl+Y 保持作用于标题输入框
- 待办文件关联拖放只接管真实文件拖放，不再拦截普通文字拖放
- 笔记右键「粘贴」与 Ctrl+V 共用图片感知粘贴入口
- 笔记浏览态支持从外部拖入普通文字，最终插入仍交给原文本编辑器

## 明确不包含

按约定，本 PR 不处理以下 3 项：

- 插件恢复文件再次读取失败后的数据保护
- 删除纸片后撤销可能恢复失效关联
- 待办列表撤销后继续输入，再重做可能覆盖新文字

这三项涉及数据恢复或撤销历史，留待单独处理。

## 范围

没有修改 Edge 主状态机、插件恢复架构或待办撤销结构；各修复尽量复用现有入口和收尾逻辑。