### PR TITLE
fix(settings): 保留 Markdown 动画默认恢复同步

### DIFF
--- a/src/AppController.Settings.cs
+++ b/src/AppController.Settings.cs
@@ -2866,6 +2866,7 @@ public sealed partial class AppController
         foreach (var window in windows)
         {
             window.UpdateMarkdownRenderMode();
+            window.UpdateMarkdownEditAnimation();
             window.UpdateExternalMarkdownExtension();
             window.UpdateTodoLinkFeature();
             window.RefreshPaperTitle();


### PR DESCRIPTION
用于把 #204 早先已经修复的单行设置同步安全合回 pr-175。基于 #204 原始基线，只包含恢复常规设置默认值后对已打开窗口调用 Markdown 动画同步；由 GitHub 三方合并保留当前主线新增的插件弹窗主题刷新等改动。