### PR TITLE
refactor: 精简重复交互与设置路径

### DIFF
--- a/src/AppController.Settings.cs
+++ b/src/AppController.Settings.cs
@@ -545,18 +545,6 @@ public sealed partial class AppController
         RebuildTrayMenu();
     }
 
-    private UIElement CreateMarkdownRenderSegmentSelector()
-    {
-        var segments = new[]
-        {
-            (MarkdownRenderModes.Off, Strings.Get("MarkdownRenderOff")),
-            (MarkdownRenderModes.Basic, Strings.Get("MarkdownRenderBasic")),
-            (MarkdownRenderModes.Enhanced, Strings.Get("MarkdownRenderEnhanced"))
-        };
-
-        return CreateSegmentSelector(segments, State.MarkdownRenderMode, SetMarkdownRenderMode);
-    }
-
     private void SetImageReferenceTextMode(string mode)
     {
         var normalized = ImageReferenceTextModes.Normalize(mode);
@@ -625,70 +613,11 @@ public sealed partial class AppController
         ApplyTypographySettingsChange();
     }
 
-    private UIElement CreateOverallFontScaleStepper()
-    {
-        var container = new Border
-        {
-            BorderBrush = TrayBorderBrush,
-            BorderThickness = new Thickness(1),
-            CornerRadius = new CornerRadius(6),
-            Background = Brushes.Transparent,
-            Margin = new Thickness(0, 4, 0, 10),
-            Height = 28,
-            HorizontalAlignment = HorizontalAlignment.Stretch
-        };
-
-        var grid = new Grid();
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-
-        var valueText = new TextBlock
-        {
-            Text = OverallFontScaleText(),
-            HorizontalAlignment = HorizontalAlignment.Center,
-            VerticalAlignment = VerticalAlignment.Center,
-            FontSize = AppTypography.Scale(13),
-            FontWeight = FontWeights.SemiBold,
-            Foreground = TrayTextBrush
-        };
-        Grid.SetColumn(valueText, 1);
-
-        Border StepButton(string glyph, int column, double delta)
-        {
-            var glyphText = new TextBlock
-            {
-                Text = glyph,
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center,
-                FontFamily = AppTypography.SymbolFontFamily,
-                FontSize = AppTypography.Scale(15),
-                Foreground = TrayTextBrush
-            };
-            var button = new Border
-            {
-                Width = 34,
-                Background = Brushes.Transparent,
-                Cursor = System.Windows.Input.Cursors.Hand,
-                Child = glyphText
-            };
-            button.MouseEnter += (_, _) => button.Background = TrayHoverBrush;
-            button.MouseLeave += (_, _) => button.Background = Brushes.Transparent;
-            button.MouseLeftButtonDown += (_, e) =>
-            {
-                SetOverallFontScale(State.Zoom + delta);
-                e.Handled = true;
-            };
-            Grid.SetColumn(button, column);
-            return button;
-        }
-
-        grid.Children.Add(StepButton("−", 0, -OverallFontScales.Step));
-        grid.Children.Add(valueText);
-        grid.Children.Add(StepButton("＋", 2, OverallFontScales.Step));
-        container.Child = grid;
-        return container;
-    }
+    private UIElement CreateOverallFontScaleStepper() =>
+        CreateSettingsStepper(
+            OverallFontScaleText,
+            () => SetOverallFontScale(State.Zoom - OverallFontScales.Step),
+            () => SetOverallFontScale(State.Zoom + OverallFontScales.Step));
 
     private string OverallFontScaleText()
     {
@@ -871,72 +800,11 @@ public sealed partial class AppController
         return container;
     }
 
-    private UIElement CreateMaxTitleLengthStepper()
-    {
-        var container = new Border
-        {
-            BorderBrush = TrayBorderBrush,
-            BorderThickness = new Thickness(1),
-            CornerRadius = new CornerRadius(6),
-            Background = Brushes.Transparent,
-            Margin = new Thickness(0, 4, 0, 10),
-            Height = 28,
-            HorizontalAlignment = HorizontalAlignment.Stretch
-        };
-
-        var grid = new Grid();
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-
-        var valueText = new TextBlock
-        {
-            Text = State.MaxTitleLength.ToString(CultureInfo.InvariantCulture),
-            HorizontalAlignment = HorizontalAlignment.Center,
-            VerticalAlignment = VerticalAlignment.Center,
-            FontSize = AppTypography.Scale(13),
-            FontWeight = FontWeights.SemiBold,
-            Foreground = TrayTextBrush
-        };
-        Grid.SetColumn(valueText, 1);
-
-        Border StepButton(string glyph, int column, Action onClick)
-        {
-            var glyphText = new TextBlock
-            {
-                Text = glyph,
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center,
-                FontFamily = AppTypography.SymbolFontFamily,
-                FontSize = AppTypography.Scale(15),
-                Foreground = TrayTextBrush
-            };
-            var button = new Border
-            {
-                Width = 34,
-                Background = Brushes.Transparent,
-                Cursor = System.Windows.Input.Cursors.Hand,
-                Child = glyphText
-            };
-            button.MouseEnter += (_, _) => button.Background = TrayHoverBrush;
-            button.MouseLeave += (_, _) => button.Background = Brushes.Transparent;
-            button.MouseLeftButtonDown += (_, e) =>
-            {
-                onClick();
-                valueText.Text = State.MaxTitleLength.ToString(CultureInfo.InvariantCulture);
-                e.Handled = true;
-            };
-            Grid.SetColumn(button, column);
-            return button;
-        }
-
-        grid.Children.Add(StepButton("−", 0, () => SetMaxTitleLength(State.MaxTitleLength - 1)));
-        grid.Children.Add(valueText);
-        grid.Children.Add(StepButton("＋", 2, () => SetMaxTitleLength(State.MaxTitleLength + 1)));
-
-        container.Child = grid;
-        return container;
-    }
+    private UIElement CreateMaxTitleLengthStepper() =>
+        CreateSettingsStepper(
+            () => State.MaxTitleLength.ToString(CultureInfo.InvariantCulture),
+            () => SetMaxTitleLength(State.MaxTitleLength - 1),
+            () => SetMaxTitleLength(State.MaxTitleLength + 1));
 
     private void SetMaxTitleLength(int value)
     {
@@ -1195,71 +1063,6 @@ public sealed partial class AppController
         column.Children.Add(content);
     }
 
-    private static void MovePluginMoreSettingsButtonsToTail(DependencyObject root)
-    {
-        if (root is Panel panel)
-        {
-            Button? moreButton = null;
-            for (var index = panel.Children.Count - 1; index >= 0; index--)
-            {
-                var child = panel.Children[index];
-                if (child is Button directButton && IsPluginMoreSettingsButton(directButton))
-                {
-                    moreButton = directButton;
-                    panel.Children.RemoveAt(index);
-                    continue;
-                }
-
-                if (child is WrapPanel wrap)
-                {
-                    var nestedButton = wrap.Children
-                        .OfType<Button>()
-                        .FirstOrDefault(IsPluginMoreSettingsButton);
-                    if (nestedButton != null)
-                    {
-                        wrap.Children.Remove(nestedButton);
-                        moreButton = nestedButton;
-                        if (wrap.Children.Count == 1)
-                        {
-                            var remaining = wrap.Children[0];
-                            wrap.Children.RemoveAt(0);
-                            panel.Children.RemoveAt(index);
-                            panel.Children.Insert(index, remaining);
-                        }
-                        else if (wrap.Children.Count == 0)
-                        {
-                            panel.Children.RemoveAt(index);
-                        }
-                    }
-                }
-            }
-
-            foreach (UIElement child in panel.Children)
-            {
-                MovePluginMoreSettingsButtonsToTail(child);
-            }
-
-            if (moreButton != null)
-            {
-                moreButton.Margin = new Thickness(0, 8, 0, 0);
-                moreButton.HorizontalAlignment = HorizontalAlignment.Left;
-                panel.Children.Add(moreButton);
-            }
-            return;
-        }
-
-        var count = VisualTreeHelper.GetChildrenCount(root);
-        for (var index = 0; index < count; index++)
-        {
-            MovePluginMoreSettingsButtonsToTail(VisualTreeHelper.GetChild(root, index));
-        }
-    }
-
-    private static bool IsPluginMoreSettingsButton(Button button) =>
-        string.Equals(
-            button.Content?.ToString(),
-            Strings.Get("PluginsMoreSettings"),
-            StringComparison.Ordinal);
 
     private UIElement BuildLabsWindowCoordinationSettings()
     {

--- a/src/AppController.SettingsSteppers.cs
+++ b/src/AppController.SettingsSteppers.cs
@@ -1,0 +1,77 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace PaperTodo;
+
+public sealed partial class AppController
+{
+    private UIElement CreateSettingsStepper(
+        Func<string> valueText,
+        Action decrement,
+        Action increment)
+    {
+        var container = new Border
+        {
+            BorderBrush = TrayBorderBrush,
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(6),
+            Background = Brushes.Transparent,
+            Margin = new Thickness(0, 4, 0, 10),
+            Height = 28,
+            HorizontalAlignment = HorizontalAlignment.Stretch
+        };
+
+        var grid = new Grid();
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var value = new TextBlock
+        {
+            Text = valueText(),
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            FontSize = AppTypography.Scale(13),
+            FontWeight = FontWeights.SemiBold,
+            Foreground = TrayTextBrush
+        };
+        Grid.SetColumn(value, 1);
+
+        Border StepButton(string glyph, int column, Action onClick)
+        {
+            var button = new Border
+            {
+                Width = 34,
+                Background = Brushes.Transparent,
+                Cursor = Cursors.Hand,
+                Child = new TextBlock
+                {
+                    Text = glyph,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    FontFamily = AppTypography.SymbolFontFamily,
+                    FontSize = AppTypography.Scale(15),
+                    Foreground = TrayTextBrush
+                }
+            };
+            button.MouseEnter += (_, _) => button.Background = TrayHoverBrush;
+            button.MouseLeave += (_, _) => button.Background = Brushes.Transparent;
+            button.MouseLeftButtonDown += (_, e) =>
+            {
+                onClick();
+                value.Text = valueText();
+                e.Handled = true;
+            };
+            Grid.SetColumn(button, column);
+            return button;
+        }
+
+        grid.Children.Add(StepButton("−", 0, decrement));
+        grid.Children.Add(value);
+        grid.Children.Add(StepButton("＋", 2, increment));
+        container.Child = grid;
+        return container;
+    }
+}

--- a/src/AppController.Shortcuts.cs
+++ b/src/AppController.Shortcuts.cs
@@ -1461,80 +1461,23 @@ public sealed partial class AppController
         return ordered;
     }
 
-    private UIElement CreateDeepCapsuleTitleMeasureLimitStepper()
-    {
-        var container = new Border
-        {
-            BorderBrush = TrayBorderBrush,
-            BorderThickness = new Thickness(1),
-            CornerRadius = new CornerRadius(6),
-            Background = Brushes.Transparent,
-            Margin = new Thickness(0, 4, 0, 10),
-            Height = 28,
-            HorizontalAlignment = HorizontalAlignment.Stretch
-        };
-
-        var grid = new Grid();
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-        grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-
-        var valueText = new TextBlock
-        {
-            Text = DeepCapsuleTitleMeasureLimitText(),
-            HorizontalAlignment = HorizontalAlignment.Center,
-            VerticalAlignment = VerticalAlignment.Center,
-            FontSize = AppTypography.Scale(13),
-            FontWeight = FontWeights.SemiBold,
-            Foreground = TrayTextBrush
-        };
-        Grid.SetColumn(valueText, 1);
-
-        Border StepButton(string glyph, int column, Action onClick)
-        {
-            var glyphText = new TextBlock
+    private UIElement CreateDeepCapsuleTitleMeasureLimitStepper() =>
+        CreateSettingsStepper(
+            DeepCapsuleTitleMeasureLimitText,
+            () =>
             {
-                Text = glyph,
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center,
-                FontFamily = AppTypography.SymbolFontFamily,
-                FontSize = AppTypography.Scale(15),
-                Foreground = TrayTextBrush
-            };
-            var button = new Border
+                var current = State.DeepCapsuleTitleMeasureCharacterLimit;
+                SetDeepCapsuleTitleMeasureCharacterLimit(
+                    current == 0 ? PaperTitles.MaxConfigurableTitleLength : current - 1);
+            },
+            () =>
             {
-                Width = 34,
-                Background = Brushes.Transparent,
-                Cursor = Cursors.Hand,
-                Child = glyphText
-            };
-            button.MouseEnter += (_, _) => button.Background = TrayHoverBrush;
-            button.MouseLeave += (_, _) => button.Background = Brushes.Transparent;
-            button.MouseLeftButtonDown += (_, e) =>
-            {
-                onClick();
-                valueText.Text = DeepCapsuleTitleMeasureLimitText();
-                e.Handled = true;
-            };
-            Grid.SetColumn(button, column);
-            return button;
-        }
-
-        grid.Children.Add(StepButton("−", 0, () =>
-        {
-            var current = State.DeepCapsuleTitleMeasureCharacterLimit;
-            SetDeepCapsuleTitleMeasureCharacterLimit(current == 0 ? PaperTitles.MaxConfigurableTitleLength : current - 1);
-        }));
-        grid.Children.Add(valueText);
-        grid.Children.Add(StepButton("＋", 2, () =>
-        {
-            var current = State.DeepCapsuleTitleMeasureCharacterLimit;
-            SetDeepCapsuleTitleMeasureCharacterLimit(current == 0 ? 0 : current >= PaperTitles.MaxConfigurableTitleLength ? 0 : current + 1);
-        }));
-
-        container.Child = grid;
-        return container;
-    }
+                var current = State.DeepCapsuleTitleMeasureCharacterLimit;
+                SetDeepCapsuleTitleMeasureCharacterLimit(
+                    current == 0
+                        ? 0
+                        : current >= PaperTitles.MaxConfigurableTitleLength ? 0 : current + 1);
+            });
 
     private string DeepCapsuleTitleMeasureLimitText()
     {

--- a/src/MarkdownSemanticPresentation.cs
+++ b/src/MarkdownSemanticPresentation.cs
@@ -152,7 +152,7 @@ internal sealed partial class MarkdownSemanticPresentation : IDisposable
     /// <summary>当前字号缩放系数（0.5..1.5）。图形元素的像素度量乘它后与文本同步缩放。</summary>
     internal double ZoomFactor() => ComputeScale();
 
-    private static bool TryGetTextPoint(
+    internal static bool TryGetTextPoint(
         TextView textView,
         DocumentLine line,
         int absoluteOffset,

--- a/src/MarkdownTextBox.InputLimitNotice.cs
+++ b/src/MarkdownTextBox.InputLimitNotice.cs
@@ -1,5 +1,4 @@
 using System.Windows;
-using System.Windows.Input;
 using System.Windows.Threading;
 
 namespace PaperTodo;
@@ -8,76 +7,11 @@ public sealed partial class MarkdownTextBox
 {
     private bool _textLimitNoticeShown;
 
-    // Observe the same routed input that the editor already validates, but ask the editor's
-    // canonical CanApplyTextReplacement() authority whether the operation is allowed. This keeps
-    // user feedback aligned with legacy oversized notes and the image-delimiter exception.
-    private static readonly bool TextLimitNoticeHandlersRegistered =
-        RegisterTextLimitNoticeHandlers();
-
-    private static bool RegisterTextLimitNoticeHandlers()
+    private bool CanApplyTextReplacementWithNotice(string replacement)
     {
-        EventManager.RegisterClassHandler(
-            typeof(MarkdownTextBox),
-            UIElement.PreviewTextInputEvent,
-            new TextCompositionEventHandler(OnTextLimitPreviewTextInput),
-            handledEventsToo: true);
-        EventManager.RegisterClassHandler(
-            typeof(MarkdownTextBox),
-            UIElement.PreviewKeyDownEvent,
-            new KeyEventHandler(OnTextLimitPreviewKeyDown),
-            handledEventsToo: true);
-        return true;
-    }
-
-    private static void OnTextLimitPreviewTextInput(
-        object sender,
-        TextCompositionEventArgs e)
-    {
-        if (sender is not MarkdownTextBox editor ||
-            editor.IsReadOnly ||
-            editor.MaxLength <= 0 ||
-            string.IsNullOrEmpty(e.Text))
-        {
-            return;
-        }
-
-        // The normal editor path first removes an explicitly selected image reference and only
-        // then validates the replacement. Do not predict against the pre-delete document here.
-        if (editor.HasSelectedImageReference)
-        {
-            return;
-        }
-
-        editor.UpdateTextLimitNotice(
-            editor.CanApplyTextReplacement(e.Text));
-    }
-
-    private static void OnTextLimitPreviewKeyDown(object sender, KeyEventArgs e)
-    {
-        if (sender is not MarkdownTextBox editor ||
-            editor.IsReadOnly ||
-            editor.MaxLength <= 0)
-        {
-            return;
-        }
-
-        string? replacement = null;
-        if (e.Key == Key.Enter && editor._acceptsReturn)
-        {
-            replacement = editor.NewLineTextAtCaret();
-        }
-        else if (e.Key == Key.Tab && editor._acceptsTab)
-        {
-            replacement = "\t";
-        }
-
-        if (replacement == null)
-        {
-            return;
-        }
-
-        editor.UpdateTextLimitNotice(
-            editor.CanApplyTextReplacement(replacement));
+        var inputAllowed = CanApplyTextReplacement(replacement);
+        UpdateTextLimitNotice(inputAllowed);
+        return inputAllowed;
     }
 
     private void UpdateTextLimitNotice(bool inputAllowed)

--- a/src/MarkdownTextBox.PasteEntry.cs
+++ b/src/MarkdownTextBox.PasteEntry.cs
@@ -1,14 +1,16 @@
 using System.Windows;
-using System.Windows.Input;
 
 namespace PaperTodo;
 
 public sealed partial class MarkdownTextBox
 {
-    private static readonly bool PreviewTextDropEffectHandlerRegistered =
-        RegisterPreviewTextDropEffectHandler();
+    // AvalonEdit can consume preview drag events before ordinary instance handlers. Keep this
+    // class-level interception for preview-mode text drops, but route all policy/validation through
+    // the same helpers used by the PaperWindow host instead of maintaining a second implementation.
+    private static readonly bool PreviewTextDropHandlersRegistered =
+        RegisterPreviewTextDropHandlers();
 
-    private static bool RegisterPreviewTextDropEffectHandler()
+    private static bool RegisterPreviewTextDropHandlers()
     {
         EventManager.RegisterClassHandler(
             typeof(MarkdownTextBox),
@@ -33,13 +35,7 @@ public sealed partial class MarkdownTextBox
             return;
         }
 
-        var controlPressed =
-            (e.KeyStates & DragDropKeyStates.ControlKey) == DragDropKeyStates.ControlKey;
-        e.Effects = (e.AllowedEffects & DragDropEffects.Move) != 0 && !controlPressed
-            ? DragDropEffects.Move
-            : (e.AllowedEffects & DragDropEffects.Copy) != 0
-                ? DragDropEffects.Copy
-                : DragDropEffects.None;
+        e.Effects = ResolveTextDropEffect(e);
         e.Handled = e.Effects != DragDropEffects.None;
     }
 
@@ -48,43 +44,17 @@ public sealed partial class MarkdownTextBox
         if (sender is not MarkdownTextBox editor ||
             !editor.IsPreviewMode ||
             editor.CanInsertImagesFromDataObject(e.Data) ||
-            !HasTextDropData(e.Data))
+            !HasTextDropData(e.Data) ||
+            editor.ValidateTextDrop(e.Data))
         {
             return;
         }
 
-        string? text;
-        try
-        {
-            text = e.Data.GetDataPresent(DataFormats.UnicodeText)
-                ? e.Data.GetData(DataFormats.UnicodeText) as string
-                : e.Data.GetDataPresent(DataFormats.Text)
-                    ? e.Data.GetData(DataFormats.Text) as string
-                    : null;
-        }
-        catch
-        {
-            editor.PasteRejected?.Invoke();
-            e.Effects = DragDropEffects.None;
-            e.Handled = true;
-            return;
-        }
-
-        // Preview mode is intentionally read-only until PaperWindow places the caret and enters
-        // edit mode. Validate the payload here, before that state change, so the native Drop path
-        // cannot bypass the same length/line-length guard used by normal paste.
-        if (string.IsNullOrEmpty(text) ||
-            editor.TryBuildSafePasteText(text, selectedLength: 0, out _))
-        {
-            return;
-        }
-
-        editor.PasteRejected?.Invoke();
         e.Effects = DragDropEffects.None;
         e.Handled = true;
     }
 
-    private static bool HasTextDropData(IDataObject data)
+    internal static bool HasTextDropData(IDataObject data)
     {
         try
         {
@@ -95,6 +65,17 @@ public sealed partial class MarkdownTextBox
         {
             return false;
         }
+    }
+
+    internal static DragDropEffects ResolveTextDropEffect(DragEventArgs e)
+    {
+        var controlPressed =
+            (e.KeyStates & DragDropKeyStates.ControlKey) == DragDropKeyStates.ControlKey;
+        return (e.AllowedEffects & DragDropEffects.Move) != 0 && !controlPressed
+            ? DragDropEffects.Move
+            : (e.AllowedEffects & DragDropEffects.Copy) != 0
+                ? DragDropEffects.Copy
+                : DragDropEffects.None;
     }
 
     /// <summary>

--- a/src/MarkdownTextBox.QuoteEditing.cs
+++ b/src/MarkdownTextBox.QuoteEditing.cs
@@ -36,7 +36,7 @@ public sealed partial class MarkdownTextBox
         }
 
         var insertion = NewLineTextFor(line) + prefix;
-        if (MaxLength > 0 && Text.Length + insertion.Length > MaxLength)
+        if (!CanApplyTextReplacement(insertion))
         {
             return false;
         }

--- a/src/MarkdownTextBox.SemanticEditing.cs
+++ b/src/MarkdownTextBox.SemanticEditing.cs
@@ -61,7 +61,7 @@ public sealed partial class MarkdownTextBox
                     else
                     {
                         var insertion = NewLineTextFor(line) + plan.Continuation;
-                        if (MaxLength > 0 && Text.Length + insertion.Length > MaxLength)
+                        if (!CanApplyTextReplacementWithNotice(insertion))
                         {
                             return true;
                         }
@@ -84,7 +84,7 @@ public sealed partial class MarkdownTextBox
             }
         }
 
-        if (!CanApplyTextReplacement(NewLineTextAtCaret()))
+        if (!CanApplyTextReplacementWithNotice(NewLineTextAtCaret()))
         {
             return true;
         }

--- a/src/MarkdownTextBox.TaskCheckBoxes.cs
+++ b/src/MarkdownTextBox.TaskCheckBoxes.cs
@@ -64,9 +64,8 @@ public sealed partial class MarkdownTextBox
     }
 
     /// <summary>
-    /// Activates the rendered task checkbox at a TextView-local point. Keeping hit testing and the
-    /// source mutation behind one narrow method lets interaction checks exercise the same path as
-    /// the mouse handler without synthesizing an OS mouse device.
+    /// Activates the rendered task checkbox at a TextView-local point. Interaction checks use this
+    /// same source mutation path as the real mouse handler without synthesizing an OS mouse device.
     /// </summary>
     internal bool TryToggleRenderedTaskCheckBoxAtPoint(Point textViewPoint)
     {
@@ -88,62 +87,54 @@ public sealed partial class MarkdownTextBox
             return false;
         }
 
+        var textView = TextArea.TextView;
+        Point editorPoint;
         try
         {
-            EnsureVisualLines();
+            editorPoint = textView.TranslatePoint(textViewPoint, this);
         }
         catch
         {
             return false;
         }
 
-        var textView = TextArea.TextView;
-        if (!textView.VisualLinesValid)
+        if (!TryGetCharacterIndexFromPoint(editorPoint, out var offset) ||
+            !textView.VisualLinesValid)
         {
             return false;
         }
 
-        foreach (var visualLine in textView.VisualLines)
+        DocumentLine line;
+        try
         {
-            var visualTop = textView.GetVisualTopByDocumentLine(
-                    visualLine.FirstDocumentLine.LineNumber) -
-                textView.VerticalOffset;
-            var visualBottom = visualTop + visualLine.Height;
-            if (textViewPoint.Y < visualTop - TaskCheckBoxHitPadding ||
-                textViewPoint.Y > visualBottom + TaskCheckBoxHitPadding)
+            line = Document.GetLineByOffset(Math.Clamp(offset, 0, Document.TextLength));
+        }
+        catch
+        {
+            return false;
+        }
+
+        foreach (var candidate in snapshot.SpansForLine(Math.Max(0, line.LineNumber - 1)))
+        {
+            if (candidate.Kind != MarkdownSemanticSpanKind.TaskListMarker ||
+                candidate.Length < 3 ||
+                candidate.Start < line.Offset ||
+                candidate.End > line.EndOffset ||
+                IsTaskMarkerRevealed(line, candidate) ||
+                !MarkdownTaskCheckBoxGeometry.TryGetRect(
+                    textView,
+                    line,
+                    candidate,
+                    out var rect))
             {
                 continue;
             }
 
-            for (var line = visualLine.FirstDocumentLine;
-                 line != null && line.LineNumber <= visualLine.LastDocumentLine.LineNumber;
-                 line = line.NextLine)
+            rect.Inflate(TaskCheckBoxHitPadding, TaskCheckBoxHitPadding);
+            if (rect.Contains(textViewPoint))
             {
-                foreach (var candidate in snapshot.SpansForLine(Math.Max(0, line.LineNumber - 1)))
-                {
-                    if (candidate.Kind != MarkdownSemanticSpanKind.TaskListMarker ||
-                        candidate.Length < 3 ||
-                        candidate.Start < line.Offset ||
-                        candidate.End > line.EndOffset ||
-                        IsTaskMarkerRevealed(line, candidate) ||
-                        !MarkdownTaskCheckBoxGeometry.TryGetRect(
-                            textView,
-                            line,
-                            candidate,
-                            out var rect))
-                    {
-                        continue;
-                    }
-
-                    rect.Inflate(TaskCheckBoxHitPadding, TaskCheckBoxHitPadding);
-                    if (!rect.Contains(textViewPoint))
-                    {
-                        continue;
-                    }
-
-                    task = candidate;
-                    return true;
-                }
+                task = candidate;
+                return true;
             }
         }
 
@@ -186,23 +177,15 @@ public sealed partial class MarkdownTextBox
             return false;
         }
 
-        var state = marker[1];
-        string replacement;
-        if (task.Checked)
+        var replacement = marker[1] switch
         {
-            if (state is not ('x' or 'X'))
-            {
-                return false;
-            }
-            replacement = " ";
-        }
-        else
+            ' ' => "x",
+            'x' or 'X' => " ",
+            _ => null
+        };
+        if (replacement == null)
         {
-            if (state != ' ')
-            {
-                return false;
-            }
-            replacement = "x";
+            return false;
         }
 
         // One source-character replacement is one normal AvalonEdit undo operation and flows through
@@ -221,13 +204,13 @@ internal static class MarkdownTaskCheckBoxGeometry
         out Rect rect)
     {
         rect = Rect.Empty;
-        if (!TryGetTextPoint(
+        if (!MarkdownSemanticPresentation.TryGetTextPoint(
                 textView,
                 line,
                 task.Start,
                 VisualYPosition.TextTop,
                 out var topLeft) ||
-            !TryGetTextPoint(
+            !MarkdownSemanticPresentation.TryGetTextPoint(
                 textView,
                 line,
                 task.End,
@@ -247,29 +230,5 @@ internal static class MarkdownTaskCheckBoxGeometry
             boxSize,
             boxSize);
         return true;
-    }
-
-    private static bool TryGetTextPoint(
-        TextView textView,
-        DocumentLine line,
-        int absoluteOffset,
-        VisualYPosition yPosition,
-        out Point point)
-    {
-        point = default;
-        try
-        {
-            var indexInLine = Math.Clamp(absoluteOffset - line.Offset, 0, line.Length);
-            point = textView.GetVisualPosition(
-                new TextViewPosition(line.LineNumber, indexInLine + 1),
-                yPosition);
-            point.X -= textView.HorizontalOffset;
-            point.Y -= textView.VerticalOffset;
-            return double.IsFinite(point.X) && double.IsFinite(point.Y);
-        }
-        catch
-        {
-            return false;
-        }
     }
 }

--- a/src/MarkdownTextBox.cs
+++ b/src/MarkdownTextBox.cs
@@ -936,11 +936,6 @@ public sealed partial class MarkdownTextBox : TextEditor
 
     public bool ValidateTextDrop(IDataObject dataObject)
     {
-        if (IsReadOnly)
-        {
-            return true;
-        }
-
         string? text;
         try
         {
@@ -1347,7 +1342,7 @@ public sealed partial class MarkdownTextBox : TextEditor
         if (!IsReadOnly &&
             _acceptsReturn &&
             e.Key == System.Windows.Input.Key.Enter &&
-            !CanApplyTextReplacement(NewLineTextAtCaret()))
+            !CanApplyTextReplacementWithNotice(NewLineTextAtCaret()))
         {
             e.Handled = true;
             return;
@@ -1356,7 +1351,7 @@ public sealed partial class MarkdownTextBox : TextEditor
         if (!IsReadOnly &&
             _acceptsTab &&
             e.Key == System.Windows.Input.Key.Tab &&
-            !CanApplyTextReplacement("\t"))
+            !CanApplyTextReplacementWithNotice("\t"))
         {
             e.Handled = true;
             return;
@@ -1374,7 +1369,7 @@ public sealed partial class MarkdownTextBox : TextEditor
 
         if (!IsReadOnly &&
             !string.IsNullOrEmpty(e.Text) &&
-            !CanApplyTextReplacement(e.Text))
+            !CanApplyTextReplacementWithNotice(e.Text))
         {
             e.Handled = true;
             return;

--- a/src/PaperWindow.Note.cs
+++ b/src/PaperWindow.Note.cs
@@ -541,34 +541,17 @@ public sealed partial class PaperWindow
             return true;
         }
 
-        static bool HasTextDropData(IDataObject data)
-        {
-            try
-            {
-                return data.GetDataPresent(DataFormats.UnicodeText) ||
-                    data.GetDataPresent(DataFormats.Text);
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
         box.AllowDrop = true;
         box.PreviewDragOver += (_, e) =>
         {
             if (!box.CanInsertImagesFromDataObject(e.Data))
             {
-                if (!isPreviewing || !HasTextDropData(e.Data))
+                if (!isPreviewing || !MarkdownTextBox.HasTextDropData(e.Data))
                 {
                     return;
                 }
 
-                e.Effects = (e.AllowedEffects & DragDropEffects.Copy) != 0
-                    ? DragDropEffects.Copy
-                    : (e.AllowedEffects & DragDropEffects.Move) != 0
-                        ? DragDropEffects.Move
-                        : DragDropEffects.None;
+                e.Effects = MarkdownTextBox.ResolveTextDropEffect(e);
                 e.Handled = e.Effects != DragDropEffects.None;
                 return;
             }
@@ -580,7 +563,7 @@ public sealed partial class PaperWindow
         {
             if (!box.CanInsertImagesFromDataObject(e.Data))
             {
-                if (!HasTextDropData(e.Data))
+                if (!MarkdownTextBox.HasTextDropData(e.Data))
                 {
                     return;
                 }
@@ -757,6 +740,12 @@ public sealed partial class PaperWindow
 
         MouseButtonEventHandler noteMouseDown = (_, e) =>
         {
+            if (box.RenderedTaskCheckBoxMouseDownHandled)
+            {
+                TraceNoteRender($"PreviewMouseLeftButtonDown ignored: rendered task checkbox isPreviewing={isPreviewing} boxPreview={box.IsPreviewMode}");
+                return;
+            }
+
             if (IsScrollBarInteractionSource(e.OriginalSource as DependencyObject, box))
             {
                 TraceNoteRender($"PreviewMouseLeftButtonDown ignored: scrollbar isPreviewing={isPreviewing} boxPreview={box.IsPreviewMode}");

--- a/src/PaperWindow.PluginLoadedHandlers.cs
+++ b/src/PaperWindow.PluginLoadedHandlers.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+
+namespace PaperTodo;
+
+public sealed partial class PaperWindow
+{
+    private static void EnsurePluginLoadedRefreshHandler(
+        ref bool registered,
+        Action<PaperWindow> refresh)
+    {
+        if (registered)
+        {
+            return;
+        }
+
+        registered = true;
+        EventManager.RegisterClassHandler(
+            typeof(PaperWindow),
+            LoadedEvent,
+            new RoutedEventHandler((sender, _) =>
+            {
+                if (sender is PaperWindow window && !window.IsClosed)
+                {
+                    refresh(window);
+                }
+            }));
+    }
+}

--- a/src/PaperWindow.PluginTodoActions.cs
+++ b/src/PaperWindow.PluginTodoActions.cs
@@ -17,24 +17,10 @@ public sealed partial class PaperWindow
     private bool _pluginTodoActionHooksInstalled;
     private int _pluginTodoActionsAppliedRowsGeneration = -1;
 
-    internal static void EnsurePluginTodoActionsLoadedHandler()
-    {
-        if (_pluginTodoActionsLoadedHandlerRegistered)
-        {
-            return;
-        }
-        _pluginTodoActionsLoadedHandlerRegistered = true;
-        EventManager.RegisterClassHandler(
-            typeof(PaperWindow),
-            LoadedEvent,
-            new RoutedEventHandler((sender, _) =>
-            {
-                if (sender is PaperWindow window && !window.IsClosed)
-                {
-                    window.RefreshPluginTodoActions();
-                }
-            }));
-    }
+    internal static void EnsurePluginTodoActionsLoadedHandler() =>
+        EnsurePluginLoadedRefreshHandler(
+            ref _pluginTodoActionsLoadedHandlerRegistered,
+            static window => window.RefreshPluginTodoActions());
 
     internal void RefreshPluginTodoActions(string? todoId = null)
     {

--- a/src/PaperWindow.PluginTopBar.cs
+++ b/src/PaperWindow.PluginTopBar.cs
@@ -24,24 +24,10 @@ public sealed partial class PaperWindow
     private bool _reconcilingPluginHostActionVisibility;
     private bool _reconcilingPluginTopBarCapacity;
 
-    internal static void EnsurePluginTopBarLoadedHandler()
-    {
-        if (_pluginTopBarLoadedHandlerRegistered)
-        {
-            return;
-        }
-        _pluginTopBarLoadedHandlerRegistered = true;
-        EventManager.RegisterClassHandler(
-            typeof(PaperWindow),
-            LoadedEvent,
-            new RoutedEventHandler((sender, _) =>
-            {
-                if (sender is PaperWindow window && !window.IsClosed)
-                {
-                    window.RefreshPluginTopBarActions();
-                }
-            }));
-    }
+    internal static void EnsurePluginTopBarLoadedHandler() =>
+        EnsurePluginLoadedRefreshHandler(
+            ref _pluginTopBarLoadedHandlerRegistered,
+            static window => window.RefreshPluginTopBarActions());
 
     internal void RefreshPluginTopBarActions()
     {

--- a/src/PaperWindow.PluginTopBarLabels.cs
+++ b/src/PaperWindow.PluginTopBarLabels.cs
@@ -11,24 +11,10 @@ public sealed partial class PaperWindow
     private static bool _pluginTopBarLabelsLoadedHandlerRegistered;
     private StackPanel? _pluginTopBarLabelsHost;
 
-    internal static void EnsurePluginTopBarLabelsLoadedHandler()
-    {
-        if (_pluginTopBarLabelsLoadedHandlerRegistered)
-        {
-            return;
-        }
-        _pluginTopBarLabelsLoadedHandlerRegistered = true;
-        EventManager.RegisterClassHandler(
-            typeof(PaperWindow),
-            LoadedEvent,
-            new RoutedEventHandler((sender, _) =>
-            {
-                if (sender is PaperWindow window && !window.IsClosed)
-                {
-                    window.RefreshPluginTopBarLabels();
-                }
-            }));
-    }
+    internal static void EnsurePluginTopBarLabelsLoadedHandler() =>
+        EnsurePluginLoadedRefreshHandler(
+            ref _pluginTopBarLabelsLoadedHandlerRegistered,
+            static window => window.RefreshPluginTopBarLabels());
 
     protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
     {

--- a/src/PaperWindow.VisualTree.cs
+++ b/src/PaperWindow.VisualTree.cs
@@ -19,19 +19,6 @@ public sealed partial class PaperWindow
         return false;
     }
 
-    /// <summary>
-    /// The built-in note mouse handler currently passes its MarkdownTextBox directly. Keep the
-    /// rendered-task consumption guard on that narrow overload so the reusable scrollbar traversal
-    /// below stays a pure visual-tree question.
-    /// </summary>
-    private static bool IsScrollBarInteractionSource(
-        DependencyObject? current,
-        MarkdownTextBox scope)
-    {
-        return scope.RenderedTaskCheckBoxMouseDownHandled ||
-            IsScrollBarInteractionSource(current, (DependencyObject)scope);
-    }
-
     private static bool IsScrollBarInteractionSource(
         DependencyObject? current,
         DependencyObject scope)

--- a/src/WebPaperBodySession.HostRequests.cs
+++ b/src/WebPaperBodySession.HostRequests.cs
@@ -1,18 +1,10 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using PaperTodo.Plugin;
 
 namespace PaperTodo;
 
 internal static class WebPluginWorkspaceRequests
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true,
-        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
-    };
-
     public static object? Execute(
         IPaperTodoHostApi host,
         string method,
@@ -44,7 +36,7 @@ internal static class WebPluginWorkspaceRequests
     {
         try
         {
-            return payload.Deserialize<T>(JsonOptions)
+            return payload.Deserialize<T>(WebPluginRuntimeInfrastructure.JsonOptions)
                 ?? throw new JsonException("Payload deserialized to null.");
         }
         catch (Exception ex) when (ex is JsonException or NotSupportedException)


### PR DESCRIPTION
## 内容

本 PR 对已确认的重复实现做一次低风险瘦身，不改变产品功能边界：

- 精简 Markdown 任务复选框命中路径，复用现有坐标/源码定位能力
- 输入长度限制统一走真实编辑入口，移除第二套预测监听
- 保留浏览态文字拖放的历史类级拦截，同时统一文字识别、复制/移动选择和长度校验
- 三个设置加减控件共用同一轻量步进控件
- 删除已无调用的旧 Markdown 三档选择器与旧“更多设置”搬运逻辑
- 复用插件窗口 Loaded 注册样板，保持三个插件功能生命周期独立
- Web 插件请求复用已有 JSON 配置
- 引用续行改用统一长度规则

## 范围

不修改 Edge 主状态机、持久化/恢复、插件权限、Markdown 解析协议或数据格式。

## 验证

最终 HEAD 已通过：
- Release 编译
- Markdown 语义检查
- Markdown 编辑检查
- Todo 导航检查
- 线程回归检查

建议使用 Squash merge，避免把分支中的过程提交带入主线。