### PR TITLE
修复激活态边缘胶囊回墙时的形态闪烁

### DIFF
--- a/src/EdgeCapsuleTargetPlanner.cs
+++ b/src/EdgeCapsuleTargetPlanner.cs
@@ -37,10 +37,10 @@ internal static class EdgeCapsuleTargetPlanner
         var preview = !retracted &&
             !dockedSuppressed &&
             model.Preview == EdgeCapsulePreviewState.Open;
-        // The detached floating HWND owns every visible drag pixel. Keep the suppressed permanent
-        // docked endpoint compact so Hovered/Active cannot continue hidden width mutations behind
-        // that cover.
-        var expanded = !ownsFloatingHost &&
+        // Keep the permanent endpoint compact only while it is actually suppressed. DockingReveal
+        // exposes that endpoint underneath the fading floating cover, so it must already use the
+        // final Hovered/Active geometry before input authority is handed back.
+        var expanded = !dockedSuppressed &&
             !preview &&
             !retracted &&
             (model.State.Visual is

--- a/src/EdgeCapsuleTargetPlanner.cs
+++ b/src/EdgeCapsuleTargetPlanner.cs
@@ -34,13 +34,16 @@ internal static class EdgeCapsuleTargetPlanner
             EdgeCapsuleGestureState.FloatingTransfer or
             EdgeCapsuleGestureState.FloatingReordering or
             EdgeCapsuleGestureState.DockingHandoff;
+        var keepPermanentEndpointCompact = model.State.Gesture is
+            EdgeCapsuleGestureState.FloatingTransfer or
+            EdgeCapsuleGestureState.FloatingReordering;
         var preview = !retracted &&
             !dockedSuppressed &&
             model.Preview == EdgeCapsulePreviewState.Open;
-        // Keep the permanent endpoint compact only while it is actually suppressed. DockingReveal
-        // exposes that endpoint underneath the fading floating cover, so it must already use the
-        // final Hovered/Active geometry before input authority is handed back.
-        var expanded = !dockedSuppressed &&
+        // Free floating drag keeps the hidden permanent endpoint compact. Once docking hand-off
+        // begins, that endpoint becomes the authoritative physical target even while suppressed,
+        // so Handoff, Reveal and the final interactive frame must share one Hovered/Active geometry.
+        var expanded = !keepPermanentEndpointCompact &&
             !preview &&
             !retracted &&
             (model.State.Visual is


### PR DESCRIPTION
## 问题
激活态边缘胶囊拖出后回墙时，会先落到较窄的贴边形态，随后在交接过程中反复补全边角并闪烁后才稳定。非激活态不明显；边缘浏览开关与此路径无关。

## 原因
`d6e663e` 为了让自由浮动拖拽期间被遮住的永久槽位保持紧凑，把 Hovered/Active 的展开条件绑定到了 `ownsFloatingHost`。这个范围同时包含 `DockingHandoff` 和 `DockingReveal`。

问题不只在 Reveal：回墙动画的目标几何会在 `DockingHandoff` 阶段先捕获，进入 `DockingReveal` 后又重新核对。如果 Handoff 仍是紧凑宽度，而 Reveal/Idle 才切到最终 Active 宽度，交接校验会把这次宽度变化当成目标改变并触发回滚/重试，正好表现为边角重复补全和闪烁。

## 修复
把“保持永久槽位紧凑”的范围收窄到真正自由浮动的两个阶段：

- `FloatingTransfer`
- `FloatingReordering`

从 `DockingHandoff` 开始，永久端点就使用最终 Hovered/Active 几何；但 Handoff 期间仍保持 `DockedSuppressed`、内容透明且不可命中。`DockingReveal` 继续使用同一份几何，只揭开真实端点；最终回到 Idle 时只恢复输入，不再改变宽度或边角。

因此现在的边界是：

`自由浮动（隐藏端点紧凑） → Handoff（最终几何但隐藏） → Reveal（同一最终几何、不可输入） → Idle（同一几何、恢复输入）`

扩大审查同时核对了 Reveal 相关的预览禁用、命中禁用、队列代理 visual authority、显示器/DPI 延迟刷新、层级恢复等路径；这些绑定属于交接原子性保护，不需要放宽。

改动仍仅限 `EdgeCapsuleTargetPlanner.cs` 的形态判定和注释。