### PR TITLE
修复插件 / MCP 写入待办的撤销行为

### DIFF
--- a/src/AppController.PluginApi.cs
+++ b/src/AppController.PluginApi.cs
@@ -95,6 +95,16 @@ public sealed partial class AppController
         return TrySaveNow(sync: true);
     }
 
+    internal void RecordExternalTodoMutationUndoStep(
+        PaperData paper,
+        IReadOnlyList<PaperItem> before)
+    {
+        if (_windows.TryGetValue(paper.Id, out var window))
+        {
+            window.RecordExternalTodoMutationAsUndoStep(before);
+        }
+    }
+
     internal void RunExternalPostCommitUi(Action update) =>
         RunMcpPostCommitUi(update);
 
@@ -137,10 +147,20 @@ public sealed partial class AppController
 
     internal void QueuePluginPaperStateDeletion(string paperId)
     {
-        if (!string.IsNullOrWhiteSpace(paperId))
+        if (string.IsNullOrWhiteSpace(paperId))
         {
-            _pendingPluginPaperStateDeletes.Add(paperId);
+            return;
         }
+
+        // Both user and external deletion reach this point only after the Paper has left the
+        // authoritative state (and external deletion has already saved successfully). A deleted
+        // Paper id must not survive only inside a live Todo window's undo/redo snapshots.
+        foreach (var window in _windows.Values)
+        {
+            window.PruneDeletedLinkedPaperFromTodoHistory(paperId);
+        }
+
+        _pendingPluginPaperStateDeletes.Add(paperId);
     }
 
     internal void TryFlushPendingPluginPaperStateDeletes()

--- a/src/PaperCommandService.cs
+++ b/src/PaperCommandService.cs
@@ -203,6 +203,7 @@ internal sealed partial class PaperCommandService
                 throw SaveFailed();
             }
 
+            _controller.RecordExternalTodoMutationUndoStep(paper, snapshot.ToItems());
             _controller.RunExternalPostCommitUi(
                 () => _controller.RefreshExternalTodoPaper(paper));
         }
@@ -334,6 +335,7 @@ internal sealed partial class PaperCommandService
                 throw SaveFailed();
             }
 
+            _controller.RecordExternalTodoMutationUndoStep(paper, snapshot.ToItems());
             _controller.RunExternalPostCommitUi(() =>
             {
                 _controller.RefreshExternalTodoPaper(paper);
@@ -395,6 +397,7 @@ internal sealed partial class PaperCommandService
                 throw SaveFailed();
             }
 
+            _controller.RecordExternalTodoMutationUndoStep(paper, snapshot.ToItems());
             _controller.RunExternalPostCommitUi(
                 () => _controller.RefreshExternalTodoPaper(paper));
         }
@@ -503,6 +506,7 @@ internal sealed partial class PaperCommandService
                 throw SaveFailed();
             }
 
+            _controller.RecordExternalTodoMutationUndoStep(paper, snapshot.ToItems());
             _controller.RunExternalPostCommitUi(() =>
             {
                 _controller.RefreshExternalTodoPaper(paper);
@@ -907,6 +911,9 @@ internal sealed partial class PaperCommandService
         public static TodoPaperSnapshot Capture(PaperData paper) =>
             new(paper.Items.Select(PaperItemSnapshot.Capture).ToList());
 
+        public IReadOnlyList<PaperItem> ToItems() =>
+            _items.Select(item => item.ToItem()).ToArray();
+
         public void Restore(PaperData paper)
         {
             paper.Items.Clear();
@@ -940,6 +947,24 @@ internal sealed partial class PaperCommandService
                 item.LinkedPathIsDirectory,
                 item.ReminderAt,
                 item.ReminderTriggered);
+
+        public PaperItem ToItem()
+        {
+            var copy = new PaperItem
+            {
+                Id = Item.Id,
+                Text = Text,
+                Done = Done,
+                Order = Order,
+                ReminderAt = ReminderAt,
+                ReminderTriggered = ReminderTriggered
+            };
+            copy.RestoreQuickLaunch(
+                LinkedPaperId,
+                LinkedPath,
+                LinkedPathIsDirectory);
+            return copy;
+        }
 
         public void Restore()
         {

--- a/src/PaperWindow.ExternalTodoMutation.cs
+++ b/src/PaperWindow.ExternalTodoMutation.cs
@@ -2,6 +2,66 @@ namespace PaperTodo;
 
 public sealed partial class PaperWindow
 {
+    internal void RecordExternalTodoMutationAsUndoStep(
+        IReadOnlyList<PaperItem> before)
+    {
+        if (_paper.Type != PaperTypes.Todo)
+        {
+            return;
+        }
+
+        var editing = before.FirstOrDefault(item => item.Id == _activeOriginalItemId);
+        if (editing != null &&
+            _activeOriginalText != null &&
+            editing.Text != _activeOriginalText)
+        {
+            // A focused human edit has not reached the paper-level history yet. Record it
+            // before the external snapshot so undo order stays human edit -> external write.
+            var original = TodoRules.CloneAll(before);
+            original.First(item => item.Id == editing.Id).Text = _activeOriginalText;
+            _undoStack.Add(original);
+        }
+
+        _undoStack.Add(TodoRules.CloneAll(before));
+        while (_undoStack.Count > MaxUndoDepth)
+        {
+            _undoStack.RemoveAt(0);
+        }
+        _redoStack.Clear();
+        _activeOriginalItemId = null;
+        _activeOriginalText = null;
+    }
+
+    internal void PruneDeletedLinkedPaperFromTodoHistory(string deletedPaperId)
+    {
+        if (_paper.Type != PaperTypes.Todo || string.IsNullOrWhiteSpace(deletedPaperId))
+        {
+            return;
+        }
+
+        PruneDeletedLinkedPaper(_undoStack, deletedPaperId);
+        PruneDeletedLinkedPaper(_redoStack, deletedPaperId);
+    }
+
+    private static void PruneDeletedLinkedPaper(
+        IEnumerable<List<PaperItem>> history,
+        string deletedPaperId)
+    {
+        foreach (var snapshot in history)
+        {
+            foreach (var item in snapshot)
+            {
+                if (string.Equals(
+                        item.LinkedPaperId,
+                        deletedPaperId,
+                        StringComparison.Ordinal))
+                {
+                    item.ClearQuickLaunch();
+                }
+            }
+        }
+    }
+
     internal void RefreshTodoRowsForExternalMutation()
     {
         if (_paper.Type != PaperTypes.Todo)
@@ -9,12 +69,9 @@ public sealed partial class PaperWindow
             return;
         }
 
-        // Undo/redo stores whole-paper snapshots. Once MCP or a plugin mutates the paper,
-        // those snapshots are no longer safe to replay because they can overwrite the
-        // externally committed state. Also suppress the focused editor's LostFocus handler
-        // from recreating a stale undo snapshot while the rows are rebuilt.
-        _undoStack.Clear();
-        _redoStack.Clear();
+        // A post-commit UI retry can run after another human edit. Settle that edit before
+        // rebuilding rows, but do not record the already-committed external mutation again.
+        CommitFocusedTextIfNeeded();
         _activeOriginalItemId = null;
         _activeOriginalText = null;
 


### PR DESCRIPTION
## 问题
主线在插件 / MCP 成功修改待办后会直接清空当前纸片的撤销 / 重做历史。

只删除 `Clear()` 也不正确：外部写入本身不会形成撤销步骤，而旧的整纸片快照仍可能在 `Ctrl+Z` 时把刚写入的内容一起覆盖掉。

## 方案
把插件 / MCP 对待办的修改视为普通待办修改：

- `AppendTodos` / `UpdateTodo` / `SetTodoReminder` / `DeleteTodo` 继续复用保存失败回滚时已有的修改前快照。
- 只有同步保存成功后，才把修改前快照压入该纸片的撤销栈，并像普通编辑一样清空重做栈。
- 保存失败仍先恢复内存快照并返回失败，不改变撤销 / 重做历史。
- 外部写入后的 UI 刷新不再清空历史，也不会在刷新重试时重复记录外部操作。
- 如果外部调用发生时用户正在输入、这次输入还没有形成纸片级撤销步骤，先按“修改前快照 + 输入前文本”结算人工输入，再记录外部写入。
- 删除 Paper 是唯一保留的跨纸片生命周期边界：普通 UI 删除和插件 / MCP 删除成功后都会经过同一个 `QueuePluginPaperStateDeletion()` 入口，并只清理 live Todo 撤销 / 重做快照中指向**这个被删 Paper ID** 的 `LinkedPaperId`。即使关联只存在于旧历史、当前 Todo 已经不再关联，也不会被后续撤销复活；不投影文本、顺序、完成状态等其他变化。
- 该跨纸片历史清理发生在删除生命周期本身，不再放进可重试的 post-commit UI 刷新回调。

因此：

`A → 插件加 X → 人工 A 改 B`

撤销顺序为：

`B+X → A+X → A`

## 本次明确删除
- `TodoHistoryRebase`
- 通用“后台变化投影进人工历史”
- 字段冲突合并
- “后台写入视为正常写入”设置与双模式
- 为上述复杂设计新增的专用测试工程 / CI

## 范围
最终只改 3 个源码文件；除“已删除 Paper 的关系不能从 live Todo 历史复活”这个跨纸片不变量外，不建立任何第二套历史语义。`PaperCommandService` 既有的保存、失败回滚、事件与 post-commit UI 边界不变；Note 撤销不在本次范围内。

## 验证
当前 HEAD：`dce44bf`。

- Pull request build：通过（Release build、Markdown semantic、Markdown editing、Todo navigation、Threading regression）。
- Persistence Checks：通过。
- Plugin samples：通过。
- PR Test Debug：按 `[ci]` 提交规则跳过。