### PR TITLE
收窄外部提交后的界面刷新与设置重建

### DIFF
--- a/src/AppController.Mcp.cs
+++ b/src/AppController.Mcp.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using System.Windows;
@@ -72,38 +73,42 @@ public sealed partial class AppController
         try
         {
             update();
+            return;
         }
-        catch
+        catch (Exception ex)
         {
-            var dispatcher = Application.Current?.Dispatcher;
-            if (dispatcher == null || IsExiting)
-            {
-                return;
-            }
+            Trace.WriteLine($"PaperTodo post-commit UI refresh failed; retrying at ContextIdle: {ex}");
+        }
 
-            try
-            {
-                _ = dispatcher.BeginInvoke(
-                    (Action)(() =>
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null || IsExiting)
+        {
+            return;
+        }
+
+        try
+        {
+            _ = dispatcher.BeginInvoke(
+                (Action)(() =>
+                {
+                    if (IsExiting) return;
+                    try
                     {
-                        if (IsExiting) return;
-                        try
-                        {
-                            update();
-                        }
-                        catch
-                        {
-                            try
-                            {
-                                ArrangeDeepCapsules(animate: false);
-                                RefreshTrayMenu();
-                            }
-                            catch { }
-                        }
-                    }),
-                    DispatcherPriority.ContextIdle);
-            }
-            catch { }
+                        update();
+                    }
+                    catch (Exception ex)
+                    {
+                        // The business mutation is already persisted. Keep that success result,
+                        // but do not turn an arbitrary UI exception into a global capsule/tray
+                        // rebuild that can hide the real failing surface.
+                        Trace.WriteLine($"PaperTodo post-commit UI retry failed: {ex}");
+                    }
+                }),
+                DispatcherPriority.ContextIdle);
+        }
+        catch (Exception ex)
+        {
+            Trace.WriteLine($"PaperTodo could not schedule post-commit UI retry: {ex}");
         }
     }
 
@@ -142,7 +147,6 @@ public sealed partial class AppController
             window.RefreshTodoRowsForExternalMutation();
         }
         NotifyTodoReminderCollectionChanged();
-        RefreshTrayMenu();
         RefreshCapsuleEligibilityForLinkedPapers(
             paper.Items.Select(item => item.LinkedPaperId));
     }
@@ -171,8 +175,9 @@ public sealed partial class AppController
         {
             window.RefreshNoteForExternalChange();
         }
+        // Note content can change whether a linked paper behaves as a script capsule, so linked
+        // Todo rows still need reconciliation even though the tray title itself does not.
         RefreshTodoRowsForLinkedPaper(paper.Id);
-        RefreshTrayMenu();
     }
 
     internal void FinalizeMcpPaperDeletion(

--- a/src/AppController.Settings.GeneralPage.cs
+++ b/src/AppController.Settings.GeneralPage.cs
@@ -44,7 +44,9 @@ public sealed partial class AppController
                 ToggleAnimations),
             "TipEnableAnimations"));
 
-        leftColumn.Children.Add(CreateAnonymousUsageStatisticsSettingsRow());
+        leftColumn.Children.Add(BuildSettingsLiveRegion(
+            "general.telemetry",
+            CreateAnonymousUsageStatisticsSettingsRow));
 
         if (State.AdvancedSettingsMode)
         {

--- a/src/AppController.TelemetrySettings.cs
+++ b/src/AppController.TelemetrySettings.cs
@@ -17,6 +17,6 @@ public sealed partial class AppController
         State.TelemetryEnabled = !State.TelemetryEnabled;
         SaveNow();
         TelemetryService.SetEnabled(State.TelemetryEnabled);
-        RefreshSettingsWindowContent();
+        RefreshSettingsRegions("general.telemetry");
     }
 }


### PR DESCRIPTION
## 目标
把这轮审查里确认属于“无差别兜底 / 大刷新”的部分收窄，但不为了精准化再建立第二套状态或 change-set 系统。

## 改动
- `RunMcpPostCommitUi`：仍保留一次 `ContextIdle` 重试，保证已持久化的业务成功不会因为 UI reconcile 失败而向插件 / MCP 报失败；但第二次失败后不再无条件 `ArrangeDeepCapsules(false) + RefreshTrayMenu()`，改为保留原成功结果并写入 `Trace` 诊断。
- Todo 外部修改：不再刷新托盘菜单。Todo 文本、完成状态、提醒、关联变化都不会改变普通 Paper 的托盘标题；提醒调度与关联 Paper 胶囊资格刷新仍保留。
- Note 外部正文修改：不再刷新托盘菜单；仍保留 `RefreshTodoRowsForLinkedPaper`，因为正文变化确实可能改变“关联脚本胶囊”的行为。
- “帮助改进”开关：从整页 `RefreshSettingsWindowContent()` 改为现有 `BuildSettingsLiveRegion` / `RefreshSettingsRegions` 局部刷新。

## 刻意不做
- 不碰 Markdown 跨行 full redraw：现有 WPF 回归测试明确覆盖了这个 fallback，没有新的等价局部重绘证据前不删。
- 不碰 D-026 的 legacy HTML compatibility：这是当前 Accepted 的 Markdown 决策。
- 不为 Todo 的 reminder/link 刷新新增复杂的 mutation change-set；目前只删能直接证明不需要的托盘刷新。
- `MarkAdvancedSetting` 虽然是空壳，但纯属源码清理；本 PR 不为删一个无行为 wrapper 扩大到更多设置文件。

## 范围
3 个源码文件，1 个提交；不改变持久化、命令权限、事件发布或外部 API。

## 验证
当前 HEAD：`19938eb`。

- Pull request build：通过（Release build、Markdown semantic、Markdown editing、Todo navigation、Threading regression）。
- Persistence Checks：通过。
- PR Test Debug：按 `[ci]` 提交规则跳过。
- Plugin samples 工作流未因本次 3 个文件触发。