### PR TITLE
修复失焦隐藏标题栏闪烁并恢复动画

### DIFF
--- a/src/PaperWindow.ExperimentalFocusPresentation.cs
+++ b/src/PaperWindow.ExperimentalFocusPresentation.cs
@@ -1,14 +1,22 @@
 using System;
 using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
 
 namespace PaperTodo;
 
 public sealed partial class PaperWindow
 {
+    private const int ExperimentalInactiveTitleBarTransitionMilliseconds = 120;
     private bool _experimentalFocusPresentationInitialized;
     private bool _experimentalInactiveTitleBarCollapsed;
     private double _experimentalInactiveTitleBarExtent;
     private double _experimentalInactiveTitleBarExpandedMinHeight;
+    private int _experimentalInactiveTitleBarAnimationGeneration;
+    private bool? _experimentalInactiveTitleBarAnimationTargetCollapsed;
+    private TranslateTransform? _experimentalInactiveTitleBarTranslate;
+    private bool _experimentalInactiveTitleBarShellHeightLocked;
+    private double _experimentalInactiveTitleBarShellBaseHeight = double.NaN;
 
     internal void UpdateExperimentalFocusPresentationSettings()
     {
@@ -18,7 +26,7 @@ public sealed partial class PaperWindow
 
     internal void RestoreExperimentalInactiveTitleBarGeometry()
     {
-        ExpandExperimentalInactiveTitleBar();
+        ExpandExperimentalInactiveTitleBar(animate: false);
     }
 
     private bool BeginExperimentalInactiveTitleBarLayoutChange()
@@ -28,7 +36,7 @@ public sealed partial class PaperWindow
             return false;
         }
 
-        ExpandExperimentalInactiveTitleBar();
+        ExpandExperimentalInactiveTitleBar(animate: false);
         return true;
     }
 
@@ -76,11 +84,11 @@ public sealed partial class PaperWindow
             CanUseExperimentalInactiveTitleBarGeometry();
         if (hideTitleBar)
         {
-            CollapseExperimentalInactiveTitleBar();
+            CollapseExperimentalInactiveTitleBar(animate);
         }
         else
         {
-            ExpandExperimentalInactiveTitleBar();
+            ExpandExperimentalInactiveTitleBar(animate);
         }
 
         if (_topBarActionButtonsHost != null)
@@ -142,111 +150,311 @@ public sealed partial class PaperWindow
         return Math.Max(1, TitleBarHeight);
     }
 
-    private void CollapseExperimentalInactiveTitleBar()
+    private TranslateTransform ExperimentalInactiveTitleBarTranslate()
     {
-        if (_experimentalInactiveTitleBarCollapsed ||
-            _topBarHost == null ||
-            _shell.RowDefinitions.Count == 0)
+        if (_experimentalInactiveTitleBarTranslate == null)
+        {
+            _experimentalInactiveTitleBarTranslate = new TranslateTransform();
+            _shell.RenderTransform = _experimentalInactiveTitleBarTranslate;
+            _shell.RenderTransformOrigin = new Point(0, 0);
+        }
+        return _experimentalInactiveTitleBarTranslate;
+    }
+
+    private void CollapseExperimentalInactiveTitleBar(bool animate = true)
+    {
+        if (_experimentalInactiveTitleBarAnimationTargetCollapsed == true)
+        {
+            if (!animate)
+            {
+                TransitionExperimentalInactiveTitleBar(collapsed: true, animate: false);
+            }
+            return;
+        }
+
+        if (_experimentalInactiveTitleBarCollapsed &&
+            _experimentalInactiveTitleBarAnimationTargetCollapsed == null)
         {
             return;
         }
 
+        if (!_experimentalInactiveTitleBarCollapsed)
+        {
+            _experimentalInactiveTitleBarExtent = ExperimentalTitleBarExtent();
+            _experimentalInactiveTitleBarExpandedMinHeight = MinHeight;
+        }
+        TransitionExperimentalInactiveTitleBar(collapsed: true, animate);
+    }
+
+    private void ExpandExperimentalInactiveTitleBar(bool animate = true)
+    {
+        if (_experimentalInactiveTitleBarAnimationTargetCollapsed == false)
+        {
+            if (!animate)
+            {
+                TransitionExperimentalInactiveTitleBar(collapsed: false, animate: false);
+            }
+            return;
+        }
+
+        if (!_experimentalInactiveTitleBarCollapsed &&
+            _experimentalInactiveTitleBarAnimationTargetCollapsed == null)
+        {
+            NormalizeExperimentalInactiveTitleBarExpandedVisual();
+            return;
+        }
+        TransitionExperimentalInactiveTitleBar(collapsed: false, animate);
+    }
+
+    private void TransitionExperimentalInactiveTitleBar(
+        bool collapsed,
+        bool animate)
+    {
+        if (_topBarHost == null || _shell.RowDefinitions.Count == 0)
+        {
+            return;
+        }
+
+        var extent = Math.Max(1, _experimentalInactiveTitleBarExtent);
+        var translate = ExperimentalInactiveTitleBarTranslate();
+        var expandingFromCollapsed =
+            !collapsed &&
+            _experimentalInactiveTitleBarAnimationTargetCollapsed == null;
+
+        var currentTop = Top;
         var currentHeight =
             double.IsFinite(Height) && Height > 0
                 ? Height
                 : ActualHeight;
-        if (!double.IsFinite(Top) ||
+        if (!double.IsFinite(currentTop) ||
             !double.IsFinite(currentHeight) ||
             currentHeight <= 1)
         {
             return;
         }
 
-        var extent = Math.Min(
-            ExperimentalTitleBarExtent(),
-            Math.Max(1, currentHeight - 1));
-        var bottom = Top + currentHeight;
-        var targetHeight = Math.Max(1, currentHeight - extent);
-        var targetTop = bottom - targetHeight;
+        LockExperimentalInactiveTitleBarShellHeight(
+            extent,
+            expandingFromCollapsed);
 
-        _experimentalInactiveTitleBarExtent = extent;
-        _experimentalInactiveTitleBarExpandedMinHeight = MinHeight;
-        _experimentalInactiveTitleBarCollapsed = true;
+        // A fully-collapsed layout has no row to animate back from. Restore the row while
+        // counter-translating the fixed-height shell so the body stays at the same screen position.
+        if (expandingFromCollapsed)
+        {
+            _topBarHost.Visibility = Visibility.Visible;
+            _shell.RowDefinitions[0].Height = GridLength.Auto;
+            translate.Y = -extent;
+            _topBarHost.Opacity = 0;
+            _shell.UpdateLayout();
+        }
 
+        var currentTranslate = translate.Y;
+        var currentOpacity = _topBarHost.Opacity;
+        var hidden = Math.Clamp(-currentTranslate, 0, extent);
+        var targetHidden = collapsed ? extent : 0;
+        var delta = targetHidden - hidden;
+        var bottom = currentTop + currentHeight;
+        var targetHeight = RoundToDevicePixelY(
+            Math.Max(1, currentHeight - delta));
+        var targetTop = RoundToDevicePixelY(bottom - targetHeight);
+        var targetTranslate = -targetHidden;
+        var targetOpacity = collapsed ? 0.0 : 1.0;
+
+        // Preserve the current animated values before cancelling a reversed transition.
+        Top = currentTop;
+        Height = currentHeight;
+        translate.Y = currentTranslate;
+        _topBarHost.Opacity = currentOpacity;
+        BeginAnimation(TopProperty, null);
+        BeginAnimation(HeightProperty, null);
+        translate.BeginAnimation(TranslateTransform.YProperty, null);
         _topBarHost.BeginAnimation(OpacityProperty, null);
-        _topBarHost.Opacity = 0;
-        _topBarHost.IsHitTestVisible = false;
-        _topBarHost.Visibility = Visibility.Collapsed;
-        _shell.RowDefinitions[0].Height = new GridLength(0);
-        _shell.UpdateLayout();
 
-        MoveWindowWithoutGeometrySave(() =>
+        _experimentalInactiveTitleBarCollapsed = true; // suppress geometry persistence until expanded
+        _experimentalInactiveTitleBarAnimationTargetCollapsed = collapsed;
+        _topBarHost.IsHitTestVisible = !collapsed;
+        if (collapsed)
         {
             MinHeight = Math.Max(
                 1,
                 _experimentalInactiveTitleBarExpandedMinHeight - extent);
-            Top = RoundToDevicePixelY(targetTop);
-            Height = RoundToDevicePixelY(targetHeight);
-        });
+        }
+
+        var shouldAnimate =
+            animate &&
+            _controller.State.EnableAnimations &&
+            IsVisible &&
+            Math.Abs(delta) > 0.5;
+        var generation = ++_experimentalInactiveTitleBarAnimationGeneration;
+        if (!shouldAnimate)
+        {
+            Top = targetTop;
+            Height = targetHeight;
+            translate.Y = targetTranslate;
+            _topBarHost.Opacity = targetOpacity;
+            CompleteExperimentalInactiveTitleBarTransition(collapsed, generation);
+            return;
+        }
+
+        var duration = Math.Max(
+            40,
+            ExperimentalInactiveTitleBarTransitionMilliseconds *
+            Math.Abs(delta) / extent);
+
+        BeginAnimation(
+            TopProperty,
+            ExperimentalInactiveTitleBarAnimation(currentTop, targetTop, duration));
+        var heightAnimation = ExperimentalInactiveTitleBarAnimation(
+            currentHeight,
+            targetHeight,
+            duration);
+        heightAnimation.Completed += (_, _) =>
+            CompleteExperimentalInactiveTitleBarTransition(
+                collapsed,
+                generation,
+                targetTop,
+                targetHeight,
+                targetTranslate,
+                targetOpacity);
+        BeginAnimation(HeightProperty, heightAnimation);
+        translate.BeginAnimation(
+            TranslateTransform.YProperty,
+            ExperimentalInactiveTitleBarAnimation(
+                currentTranslate,
+                targetTranslate,
+                duration));
+        _topBarHost.BeginAnimation(
+            OpacityProperty,
+            ExperimentalInactiveTitleBarAnimation(
+                currentOpacity,
+                targetOpacity,
+                duration));
     }
 
-    private void ExpandExperimentalInactiveTitleBar()
+    private void LockExperimentalInactiveTitleBarShellHeight(
+        double extent,
+        bool expandingFromCollapsed)
     {
-        if (!_experimentalInactiveTitleBarCollapsed)
-        {
-            if (_topBarHost != null)
-            {
-                _topBarHost.BeginAnimation(OpacityProperty, null);
-                _topBarHost.Opacity = 1;
-                _topBarHost.Visibility = Visibility.Visible;
-                _topBarHost.IsHitTestVisible = true;
-            }
-            return;
-        }
-
-        var extent = Math.Max(1, _experimentalInactiveTitleBarExtent);
-        var currentHeight =
-            double.IsFinite(Height) && Height > 0
-                ? Height
-                : ActualHeight;
-        if (!double.IsFinite(Top) ||
-            !double.IsFinite(currentHeight) ||
-            currentHeight <= 0)
+        if (_experimentalInactiveTitleBarShellHeightLocked)
         {
             return;
         }
 
-        if (_topBarHost != null)
+        var currentShellHeight = _shell.ActualHeight;
+        if (!double.IsFinite(currentShellHeight) || currentShellHeight <= 0.5)
         {
-            _topBarHost.Visibility = Visibility.Visible;
-            _topBarHost.IsHitTestVisible = true;
+            return;
         }
-        if (_shell.RowDefinitions.Count > 0)
+
+        _experimentalInactiveTitleBarShellBaseHeight = _shell.Height;
+        _shell.Height = currentShellHeight +
+            (expandingFromCollapsed ? extent : 0);
+        _experimentalInactiveTitleBarShellHeightLocked = true;
+    }
+
+    private void ReleaseExperimentalInactiveTitleBarShellHeight()
+    {
+        if (!_experimentalInactiveTitleBarShellHeightLocked)
         {
-            _shell.RowDefinitions[0].Height = GridLength.Auto;
+            return;
+        }
+
+        _shell.Height = _experimentalInactiveTitleBarShellBaseHeight;
+        _experimentalInactiveTitleBarShellBaseHeight = double.NaN;
+        _experimentalInactiveTitleBarShellHeightLocked = false;
+    }
+
+    private static DoubleAnimation ExperimentalInactiveTitleBarAnimation(
+        double from,
+        double to,
+        double duration) =>
+        new(from, to, TimeSpan.FromMilliseconds(duration))
+        {
+            EasingFunction = AnimationHelper.QuickEase,
+            FillBehavior = FillBehavior.HoldEnd
+        };
+
+    private void CompleteExperimentalInactiveTitleBarTransition(
+        bool collapsed,
+        int generation,
+        double? targetTop = null,
+        double? targetHeight = null,
+        double? targetTranslate = null,
+        double? targetOpacity = null)
+    {
+        if (generation != _experimentalInactiveTitleBarAnimationGeneration)
+        {
+            return;
+        }
+
+        var translate = ExperimentalInactiveTitleBarTranslate();
+        if (targetTop.HasValue)
+        {
+            Top = targetTop.Value;
+        }
+        if (targetHeight.HasValue)
+        {
+            Height = targetHeight.Value;
+        }
+        if (targetTranslate.HasValue)
+        {
+            translate.Y = targetTranslate.Value;
+        }
+        if (targetOpacity.HasValue && _topBarHost != null)
+        {
+            _topBarHost.Opacity = targetOpacity.Value;
+        }
+
+        BeginAnimation(TopProperty, null);
+        BeginAnimation(HeightProperty, null);
+        translate.BeginAnimation(TranslateTransform.YProperty, null);
+        _topBarHost?.BeginAnimation(OpacityProperty, null);
+        _experimentalInactiveTitleBarAnimationTargetCollapsed = null;
+
+        if (_topBarHost == null || _shell.RowDefinitions.Count == 0)
+        {
+            ReleaseExperimentalInactiveTitleBarShellHeight();
+            return;
+        }
+
+        if (collapsed)
+        {
+            _topBarHost.Opacity = 0;
+            _topBarHost.IsHitTestVisible = false;
+            _topBarHost.Visibility = Visibility.Collapsed;
+            _shell.RowDefinitions[0].Height = new GridLength(0);
+            translate.Y = 0;
+            ReleaseExperimentalInactiveTitleBarShellHeight();
+            _experimentalInactiveTitleBarCollapsed = true;
+        }
+        else
+        {
+            NormalizeExperimentalInactiveTitleBarExpandedVisual();
+            MinHeight = Math.Max(1, _experimentalInactiveTitleBarExpandedMinHeight);
+            _experimentalInactiveTitleBarCollapsed = false;
+            _experimentalInactiveTitleBarExtent = 0;
+            _experimentalInactiveTitleBarExpandedMinHeight = 0;
         }
         _shell.UpdateLayout();
+    }
 
-        var bottom = Top + currentHeight;
-        var targetHeight = currentHeight + extent;
-        var targetTop = bottom - targetHeight;
-        MoveWindowWithoutGeometrySave(() =>
+    private void NormalizeExperimentalInactiveTitleBarExpandedVisual()
+    {
+        if (_topBarHost == null || _shell.RowDefinitions.Count == 0)
         {
-            Top = RoundToDevicePixelY(targetTop);
-            Height = RoundToDevicePixelY(targetHeight);
-            MinHeight = Math.Max(
-                1,
-                _experimentalInactiveTitleBarExpandedMinHeight);
-        });
-
-        if (_topBarHost != null)
-        {
-            _topBarHost.BeginAnimation(OpacityProperty, null);
-            _topBarHost.Opacity = 1;
+            ReleaseExperimentalInactiveTitleBarShellHeight();
+            return;
         }
 
-        _experimentalInactiveTitleBarCollapsed = false;
-        _experimentalInactiveTitleBarExtent = 0;
-        _experimentalInactiveTitleBarExpandedMinHeight = 0;
+        _topBarHost.BeginAnimation(OpacityProperty, null);
+        _topBarHost.Opacity = 1;
+        _topBarHost.Visibility = Visibility.Visible;
+        _topBarHost.IsHitTestVisible = true;
+        _shell.RowDefinitions[0].Height = GridLength.Auto;
+        if (_experimentalInactiveTitleBarTranslate != null)
+        {
+            _experimentalInactiveTitleBarTranslate.Y = 0;
+        }
+        ReleaseExperimentalInactiveTitleBarShellHeight();
     }
 }


### PR DESCRIPTION
## 问题

“失焦隐藏标题栏”当前会先直接折叠标题栏布局，再瞬间修改 PaperWindow 的 Top/Height，导致整张纸片出现一帧闪烁；同时 8 月改成“真实收短”后，旧的标题栏过渡动画也丢失了。

## 修改

- 保留“真实收短窗口”的现有产品语义，不退回只淡出但保留空白的旧方案。
- 收起/展开时用 120ms 快速过渡同步改变窗口 Top/Height、标题栏透明度和 shell 位移。
- shell 反向位移与窗口顶部移动量保持一致，让正文与底边在屏幕上的位置保持不动。
- 动画结束后才真正把标题栏行折叠为 0；展开时反向处理。
- 支持激活/失焦快速反转；布局/胶囊转换需要恢复标题栏时仍走无动画立即恢复，避免和已有形态转换叠加。

## 范围

只修改 `src/PaperWindow.ExperimentalFocusPresentation.cs`，不改胶囊、材质、全局动画框架或持久化协议。

普通局部 UI bugfix，不涉及架构/Decision 变化，因此不更新架构文档。