### PR TITLE
feat: 支持跨笔记全文搜索

### DIFF
--- a/src/AppController.Find.cs
+++ b/src/AppController.Find.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PaperTodo;
+
+public sealed partial class AppController
+{
+    internal readonly record struct MarkdownFindSource(string PaperId, string Text);
+
+    internal IReadOnlyList<MarkdownFindSource> GetMarkdownFindSources()
+    {
+        var sources = new List<MarkdownFindSource>();
+        foreach (var paper in State.Papers)
+        {
+            if (!IsMarkdownFindPaper(paper))
+            {
+                continue;
+            }
+
+            var text = paper.Content ?? string.Empty;
+            if (_windows.TryGetValue(paper.Id, out var window) &&
+                !window.IsClosed &&
+                window.TryGetMarkdownFindText(out var liveText))
+            {
+                text = liveText;
+            }
+
+            sources.Add(new MarkdownFindSource(paper.Id, text));
+        }
+        return sources;
+    }
+
+    internal PaperWindow? OpenMarkdownFindTarget(string paperId)
+    {
+        var paper = State.Papers.FirstOrDefault(candidate =>
+            string.Equals(candidate.Id, paperId, StringComparison.Ordinal));
+        if (paper == null || !IsMarkdownFindPaper(paper))
+        {
+            return null;
+        }
+
+        // Search navigation is an explicit open. Reuse the same programmatic expansion path
+        // as other paper retrieval flows so ordinary and deep capsules hand off correctly,
+        // but do not move the target beside the source paper or toggle it on repeated opens.
+        if (_windows.TryGetValue(paper.Id, out var window) && !window.IsClosed)
+        {
+            window.RestoreExperimentalTetherPresentationForExplicitShow();
+            paper.IsVisible = true;
+            RescuePaperIfOffScreen(paper, State.Papers.IndexOf(paper));
+            window.CancelPendingVisibilityTransitions();
+
+            if (paper.IsCollapsed)
+            {
+                window.ExpandForProgrammaticOpen();
+            }
+            else if (!window.HasVisibleSurface)
+            {
+                RestoreExistingPaperWindowSurface(paper, window);
+            }
+
+            ForceWindowToFront(window);
+            RefreshTrayMenu();
+            MarkDirty();
+            return window;
+        }
+
+        SetPaperCollapsedRuntime(
+            paper,
+            collapsed: false,
+            animate: false,
+            saveGeometry: false);
+        ShowPaper(paper);
+
+        if (!_windows.TryGetValue(paper.Id, out window) || window.IsClosed)
+        {
+            return null;
+        }
+
+        ForceWindowToFront(window);
+        return window;
+    }
+
+    private static bool IsMarkdownFindPaper(PaperData paper) =>
+        paper.Type == PaperTypes.Note &&
+        (string.IsNullOrWhiteSpace(paper.BodyProviderId) ||
+         string.Equals(
+             paper.BodyProviderId,
+             PaperBodyProviderIds.Markdown,
+             StringComparison.Ordinal));
+}

--- a/src/PaperWindow.Find.cs
+++ b/src/PaperWindow.Find.cs
@@ -666,13 +666,15 @@ public sealed partial class PaperWindow
             ? current
             : (PaperFindMatch?)null;
 
+        var query = _findInput.Text ?? string.Empty;
         _findMatches.Clear();
-        _findMatches.AddRange(ScanFindMatches(_findInput.Text ?? string.Empty));
+        _findMatches.AddRange(ScanFindMatches(query));
 
         if (_findMatches.Count == 0)
         {
             _findMatchIndex = -1;
             ClearAppliedFindSelection();
+            SynchronizeGlobalNoteFindState(query);
             UpdateFindCount();
             return;
         }
@@ -698,6 +700,7 @@ public sealed partial class PaperWindow
             _findAppliedMatch = null;
             ReleaseTodoInactiveFindSelection();
         }
+        SynchronizeGlobalNoteFindState(query);
         UpdateFindCount();
     }
 
@@ -756,6 +759,11 @@ public sealed partial class PaperWindow
     private void MoveFindMatch(int direction)
     {
         if (_findInput == null || string.IsNullOrEmpty(_findInput.Text))
+        {
+            return;
+        }
+
+        if (TryMoveGlobalNoteFindMatch(direction))
         {
             return;
         }
@@ -921,9 +929,9 @@ public sealed partial class PaperWindow
         var current = _findMatchIndex >= 0 && _findMatches.Count > 0
             ? _findMatchIndex + 1
             : 0;
-        _findCountText.Text = $"{current} / {_findMatches.Count}";
+        _findCountText.Text = BuiltInFindCountText(current, _findMatches.Count);
 
-        var enabled = _findMatches.Count > 0;
+        var enabled = HasBuiltInFindNavigationTarget();
         if (_findPreviousButton != null)
         {
             _findPreviousButton.IsEnabled = enabled;

--- a/src/PaperWindow.GlobalFind.cs
+++ b/src/PaperWindow.GlobalFind.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Threading;
+
+namespace PaperTodo;
+
+public sealed partial class PaperWindow
+{
+    private readonly record struct GlobalNoteFindMatch(
+        string PaperId,
+        int Offset,
+        int Length);
+
+    private readonly List<GlobalNoteFindMatch> _globalNoteFindMatches = [];
+    private int _globalNoteFindIndex = -1;
+
+    private bool UsesGlobalNoteFind =>
+        _paper.Type == PaperTypes.Note && IsCurrentBodyProviderMarkdown;
+
+    internal bool TryGetMarkdownFindText(out string text)
+    {
+        if (!UsesGlobalNoteFind || _noteBox == null)
+        {
+            text = string.Empty;
+            return false;
+        }
+
+        text = _noteBox.Text ?? string.Empty;
+        return true;
+    }
+
+    private void SynchronizeGlobalNoteFindState(string query)
+    {
+        if (!UsesGlobalNoteFind)
+        {
+            _globalNoteFindMatches.Clear();
+            _globalNoteFindIndex = -1;
+            return;
+        }
+
+        _globalNoteFindMatches.Clear();
+        _globalNoteFindMatches.AddRange(ScanGlobalNoteFindMatches(query));
+        _globalNoteFindIndex = ResolveCurrentGlobalNoteFindIndex();
+    }
+
+    private List<GlobalNoteFindMatch> ScanGlobalNoteFindMatches(string query)
+    {
+        var matches = new List<GlobalNoteFindMatch>();
+        if (string.IsNullOrEmpty(query))
+        {
+            return matches;
+        }
+
+        foreach (var source in _controller.GetMarkdownFindSources())
+        {
+            var searchFrom = 0;
+            var text = source.Text ?? string.Empty;
+            while (searchFrom <= text.Length - query.Length)
+            {
+                var offset = text.IndexOf(
+                    query,
+                    searchFrom,
+                    StringComparison.OrdinalIgnoreCase);
+                if (offset < 0)
+                {
+                    break;
+                }
+
+                matches.Add(new GlobalNoteFindMatch(
+                    source.PaperId,
+                    offset,
+                    query.Length));
+                searchFrom = offset + query.Length;
+            }
+        }
+
+        return matches;
+    }
+
+    private int ResolveCurrentGlobalNoteFindIndex()
+    {
+        if (!TryGetCurrentFindMatch(out var local) || !local.IsNote)
+        {
+            return -1;
+        }
+
+        return _globalNoteFindMatches.FindIndex(match =>
+            string.Equals(match.PaperId, _paper.Id, StringComparison.Ordinal) &&
+            match.Offset == local.Offset &&
+            match.Length == local.Length);
+    }
+
+    private bool TryMoveGlobalNoteFindMatch(int direction)
+    {
+        if (!UsesGlobalNoteFind ||
+            _findInput == null ||
+            string.IsNullOrEmpty(_findInput.Text))
+        {
+            return false;
+        }
+
+        var query = _findInput.Text;
+        _globalNoteFindMatches.Clear();
+        _globalNoteFindMatches.AddRange(ScanGlobalNoteFindMatches(query));
+        _globalNoteFindIndex = ResolveCurrentGlobalNoteFindIndex();
+
+        if (_globalNoteFindMatches.Count == 0)
+        {
+            _findMatches.Clear();
+            _findMatchIndex = -1;
+            ClearAppliedFindSelection();
+            UpdateFindCount();
+            return true;
+        }
+
+        var targetIndex = _globalNoteFindIndex < 0
+            ? direction >= 0 ? 0 : _globalNoteFindMatches.Count - 1
+            : (_globalNoteFindIndex + direction + _globalNoteFindMatches.Count) %
+              _globalNoteFindMatches.Count;
+        var target = _globalNoteFindMatches[targetIndex];
+
+        if (string.Equals(target.PaperId, _paper.Id, StringComparison.Ordinal))
+        {
+            _findMatches.Clear();
+            _findMatches.AddRange(ScanFindMatches(query));
+            _findMatchIndex = _findMatches.FindIndex(match =>
+                match.IsNote &&
+                match.Offset == target.Offset &&
+                match.Length == target.Length);
+            _globalNoteFindIndex = targetIndex;
+
+            if (_findMatchIndex >= 0)
+            {
+                ApplyCurrentFindMatch();
+            }
+            else
+            {
+                ClearAppliedFindSelection();
+            }
+            UpdateFindCount();
+            return true;
+        }
+
+        ClearAppliedFindSelection();
+        HideBuiltInFind(restoreFocus: false);
+        var targetWindow = _controller.OpenMarkdownFindTarget(target.PaperId);
+        if (targetWindow == null)
+        {
+            return true;
+        }
+
+        targetWindow.ShowBuiltInFindAtGlobalMatch(query, target);
+        if (!IsActive)
+        {
+            ScheduleExperimentalAutoCollapse(blockedAtDeactivation: false);
+        }
+        return true;
+    }
+
+    private void ShowBuiltInFindAtGlobalMatch(
+        string query,
+        GlobalNoteFindMatch target)
+    {
+        EnsureBuiltInFindPopup();
+        if (_findPopup == null || _findInput == null)
+        {
+            return;
+        }
+
+        SetBuiltInFindQuery(
+            query,
+            new PaperFindMatch(null, target.Offset, target.Length));
+        UpdateBuiltInFindVisuals();
+        _findPopup.IsOpen = true;
+        SynchronizeBuiltInFindOwnerState(refreshMatches: false);
+        _findInput.Focus();
+        _findInput.SelectAll();
+
+        _ = Dispatcher.BeginInvoke((Action)(() =>
+        {
+            if (!IsBuiltInFindOpen)
+            {
+                return;
+            }
+            ApplyCurrentFindMatch();
+            SynchronizeGlobalNoteFindState(query);
+            UpdateFindCount();
+            RepositionBuiltInFindPopup();
+        }), DispatcherPriority.Background);
+    }
+
+    private string BuiltInFindCountText(int localCurrent, int localTotal)
+    {
+        if (!UsesGlobalNoteFind)
+        {
+            return $"{localCurrent} / {localTotal}";
+        }
+
+        var globalCurrent = _globalNoteFindIndex >= 0 &&
+                            _globalNoteFindIndex < _globalNoteFindMatches.Count
+            ? _globalNoteFindIndex + 1
+            : 0;
+        return $"{localCurrent}/{localTotal} | {globalCurrent}/{_globalNoteFindMatches.Count}";
+    }
+
+    private bool HasBuiltInFindNavigationTarget() =>
+        UsesGlobalNoteFind
+            ? _globalNoteFindMatches.Count > 0
+            : _findMatches.Count > 0;
+}


### PR DESCRIPTION
## 改动
- Markdown 笔记的内置 `Ctrl+F` 扩展为全部 Markdown 笔记搜索
- 计数显示为 `当前笔记命中/当前笔记总数 | 全局位置/全局总数`
- `Enter` / ↓ 与 `Shift+Enter` / ↑ 可跨笔记循环跳转
- 隐藏、折叠、深度胶囊中的 Markdown 笔记也参与搜索；跳转时复用现有显示/展开逻辑，不主动重排纸片位置
- 打开的笔记使用实时编辑内容，未打开的笔记直接搜索持久化 Markdown 正文
- Todo 仍保持当前纸片查找；插件正文不纳入“全部笔记”
- 不增加结果列表、正则或替换，继续保留给高级搜索插件

## 交互
例如：

`搜索词    2/2 | 18/30   ↑ ↓ ×`

左侧表示当前笔记命中位置，右侧表示所有 Markdown 笔记中的全局位置。

当前笔记有命中时从当前命中继续；走到当前笔记末尾后再跨到下一张匹配笔记。当前笔记无命中时显示 `0/0 | 0/N`，按下一项后进入首个全局命中。

## 实现范围
- 原有 `PaperWindow.Find.cs` 仅做少量接线
- 全局扫描与跨纸片导航分别放在独立 partial 文件中
- 不引入索引、数据库或新的搜索框架
- 跨纸片打开复用既有程序化展开路径，保持普通胶囊/深度胶囊的状态切换语义一致

## 验证
开发提交的 Windows CI 已通过 Release 编译、Markdown 语义/编辑、Todo 导航、Edge title 与线程回归检查；后续修正继续由 PR CI 验证。