### PR TITLE
feat: 主胶囊始终显示准确数量并固定两位宽度

### DIFF
--- a/src/MasterCapsuleWindow.cs
+++ b/src/MasterCapsuleWindow.cs
@@ -38,13 +38,14 @@ public sealed class MasterCapsuleWindow : Window
     private const int WmDpiChanged = 0x02E0;
     private const int WmNcHitTest = 0x0084;
     private static readonly IntPtr HtTransparent = new(-1);
-    // Compact internal metrics controlling how tightly the glyph + optional count sit inside the pill.
+    // Compact internal metrics controlling how tightly the glyph + stable count sit inside the pill.
     // The master owns exactly the width it renders; no full pill is hidden outside its HWND.
     private const double WindowChromeMargin = EdgeCapsuleLayout.WindowChromeMargin;
     private const double MasterLeftPadding = 5;
     private const double MasterGlyphGap = 4;
     private const double MasterRightPadding = 3;
     private const double MasterInteriorBorderThickness = 1;
+    private const string MasterTwoDigitCountSample = "88";
 
     private readonly AppController _controller;
     private readonly DeepCapsuleContextMenuSession _contextMenuSession;
@@ -224,13 +225,13 @@ public sealed class MasterCapsuleWindow : Window
 
         _label = new TextBlock
         {
-            Text = string.Empty,
-            Visibility = Visibility.Collapsed,
+            Text = "0",
             Foreground = Theme.WeakTextBrush,
             FontFamily = MasterLabelFontFamily,
             FontSize = MasterLabelFontSize,
             FontWeight = MasterLabelFontWeight,
             Margin = new Thickness(MasterGlyphGap, 0, 0, 0),
+            TextAlignment = TextAlignment.Center,
             VerticalAlignment = VerticalAlignment.Center
         };
         AppTypography.ApplyTextRendering(_label);
@@ -441,12 +442,7 @@ public sealed class MasterCapsuleWindow : Window
     private void ApplyStateVisuals()
     {
         _glyph.Text = _active ? "▸" : "▾";
-        _label.Text = _active
-            ? _count.ToString(UiLanguages.EffectiveCulture)
-            : string.Empty;
-        _label.Visibility = _active
-            ? Visibility.Visible
-            : Visibility.Collapsed;
+        _label.Text = _count.ToString(UiLanguages.EffectiveCulture);
         _pill.ToolTip = _active
             ? Strings.Get("CapsuleCollapseAllCollapsedTip")
             : Strings.Get("CapsuleCollapseAllExpandedTip");
@@ -505,24 +501,31 @@ public sealed class MasterCapsuleWindow : Window
 
     private double MasterDockedWidth(double pixelsPerDip)
     {
-        // Keep the arrow slot stable across ▾/▸ so toggling does not introduce a one-glyph width
-        // wobble. The optional count is the only content allowed to extend the master pill.
+        // Keep the arrow slot stable across ▾/▸ and reserve a compact two-digit count slot. This
+        // prevents normal state/count changes from resizing the master while still allowing 100+
+        // to grow rather than clipping the exact count.
         var glyphWidth = Math.Max(
             MeasureText("▾", MasterGlyphFontSize, FontWeights.SemiBold, AppTypography.SymbolFontFamily, pixelsPerDip),
             MeasureText("▸", MasterGlyphFontSize, FontWeights.SemiBold, AppTypography.SymbolFontFamily, pixelsPerDip));
-        var countWidth = _active
-            ? MeasureText(
+        var twoDigitCountWidth = MeasureText(
+            MasterTwoDigitCountSample,
+            MasterLabelFontSize,
+            MasterLabelFontWeight,
+            MasterLabelFontFamily,
+            pixelsPerDip);
+        var countWidth = Math.Max(
+            twoDigitCountWidth,
+            MeasureText(
                 _count.ToString(UiLanguages.EffectiveCulture),
                 MasterLabelFontSize,
                 MasterLabelFontWeight,
                 MasterLabelFontFamily,
-                pixelsPerDip)
-            : 0;
-        var countGap = _active ? MasterGlyphGap : 0;
+                pixelsPerDip));
+        _label.MinWidth = twoDigitCountWidth;
         var bodyWidth = Math.Ceiling(
             MasterLeftPadding +
             glyphWidth +
-            countGap +
+            MasterGlyphGap +
             countWidth +
             MasterRightPadding +
             MasterInteriorBorderThickness);


### PR DESCRIPTION
## 改动
- 主胶囊在展开和收起状态下都始终显示真实数量
- 为数量区域保留两位数字的紧凑固定宽度，避免 1 位 / 2 位数字切换时胶囊左右伸缩
- 单位数在预留的两位数字槽内居中
- 箭头 `▾ / ▸` 切换不再改变主胶囊宽度
- 100+ 仍显示准确数量，并按实际宽度扩展，避免裁切

## 范围
- 仅修改 `src/MasterCapsuleWindow.cs`
- 不改动胶囊队列、拖拽和折叠状态机

## 验证重点
- 1 → 9 → 10 → 99 时主胶囊宽度保持稳定
- 展开 / 收起切换时数字持续可见且宽度不抖动
- 100+ 数量完整显示