### PR TITLE
fix(ui): 失焦隐藏标题栏后保留纸片圆角顶部

### DIFF
--- a/src/InactiveTitleBarMask.cs
+++ b/src/InactiveTitleBarMask.cs
@@ -10,15 +10,18 @@ namespace PaperTodo;
 internal sealed class InactiveTitleBarMask
 {
     private readonly SolidColorBrush _headerOpacity = new(Colors.Black);
-    private readonly RectangleGeometry _header = new();
-    private readonly RectangleGeometry _body = new();
+    private readonly RectangleGeometry _fadeRegion = new();
+    private readonly RectangleGeometry _bodyTop = new();
+    private readonly RectangleGeometry _bodyLower = new();
     private int _animationGeneration;
+    private double _headerBottom;
 
     internal InactiveTitleBarMask()
     {
         var drawing = new DrawingGroup();
-        drawing.Children.Add(new GeometryDrawing(_headerOpacity, null, _header));
-        drawing.Children.Add(new GeometryDrawing(Brushes.Black, null, _body));
+        drawing.Children.Add(new GeometryDrawing(_headerOpacity, null, _fadeRegion));
+        drawing.Children.Add(new GeometryDrawing(Brushes.Black, null, _bodyTop));
+        drawing.Children.Add(new GeometryDrawing(Brushes.Black, null, _bodyLower));
         MaskBrush = new DrawingBrush(drawing)
         {
             ViewboxUnits = BrushMappingMode.Absolute,
@@ -30,23 +33,60 @@ internal sealed class InactiveTitleBarMask
 
     internal DrawingBrush MaskBrush { get; }
     internal double HeaderOpacity => _headerOpacity.Opacity;
-    internal double HeaderBottom => _header.Rect.IsEmpty ? 0 : _header.Rect.Bottom;
+    internal double HeaderBottom => _headerBottom;
 
-    internal void UpdateBounds(Size size, double headerBottom)
+    internal void UpdateBounds(
+        Size size,
+        double headerBottom,
+        Rect chromeBounds,
+        double topCornerRadius)
     {
-        if (size.Width <= 0 || size.Height <= 0 || !double.IsFinite(headerBottom))
+        if (size.Width <= 0 || size.Height <= 0 ||
+            !double.IsFinite(headerBottom) ||
+            !double.IsFinite(chromeBounds.Left) ||
+            !double.IsFinite(chromeBounds.Right) ||
+            !double.IsFinite(topCornerRadius))
         {
             return;
         }
+
         headerBottom = Math.Clamp(headerBottom, 0, size.Height);
-        var header = new Rect(0, 0, size.Width, headerBottom);
-        var body = new Rect(0, headerBottom, size.Width, size.Height - headerBottom);
-        if (_header.Rect == header && _body.Rect == body)
+        var chromeLeft = Math.Clamp(chromeBounds.Left, 0, size.Width);
+        var chromeRight = Math.Clamp(chromeBounds.Right, chromeLeft, size.Width);
+        var bodyHeight = size.Height - headerBottom;
+        var maxRadius = Math.Max(0, Math.Min((chromeRight - chromeLeft) / 2, bodyHeight / 2));
+        var radius = Math.Clamp(topCornerRadius, 0, maxRadius);
+        var roundedBandBottom = Math.Min(size.Height, headerBottom + radius);
+
+        // The fading region extends one radius below the title boundary. The opaque rounded
+        // body overlaps its center, so title restore still reconstructs a full rectangular
+        // mask while title hide smoothly exposes a new rounded paper top instead of a hard cut.
+        var fadeRegion = new Rect(0, 0, size.Width, roundedBandBottom);
+        var bodyTop = radius > 0
+            ? new Rect(chromeLeft, headerBottom, chromeRight - chromeLeft, radius * 2)
+            : Rect.Empty;
+        var bodyLower = new Rect(
+            0,
+            roundedBandBottom,
+            size.Width,
+            size.Height - roundedBandBottom);
+
+        if (_fadeRegion.Rect == fadeRegion &&
+            _bodyTop.Rect == bodyTop &&
+            _bodyLower.Rect == bodyLower &&
+            _bodyTop.RadiusX == radius &&
+            _bodyTop.RadiusY == radius &&
+            _headerBottom == headerBottom)
         {
             return;
         }
-        _header.Rect = header;
-        _body.Rect = body;
+
+        _headerBottom = headerBottom;
+        _fadeRegion.Rect = fadeRegion;
+        _bodyTop.Rect = bodyTop;
+        _bodyTop.RadiusX = radius;
+        _bodyTop.RadiusY = radius;
+        _bodyLower.Rect = bodyLower;
         MaskBrush.Viewbox = MaskBrush.Viewport = new Rect(size);
     }
 

--- a/src/PaperWindow.ExperimentalFocusPresentation.cs
+++ b/src/PaperWindow.ExperimentalFocusPresentation.cs
@@ -140,9 +140,17 @@ public sealed partial class PaperWindow
 
         var boundary = _shell.TransformToAncestor(_windowHost).Transform(
             new Point(0, _shell.RowDefinitions[0].ActualHeight)).Y;
+        var chromeBounds = _paperChrome.TransformToAncestor(_windowHost).TransformBounds(
+            new Rect(_paperChrome.RenderSize));
+        var topCornerRadius = Math.Min(
+            _paperChrome.CornerRadius.TopLeft,
+            _paperChrome.CornerRadius.TopRight);
         var dpi = System.Windows.Media.VisualTreeHelper.GetDpi(this).DpiScaleY;
         _inactiveTitleBarMask.UpdateBounds(
-            _windowHost.RenderSize, Math.Round(boundary * dpi) / dpi);
+            _windowHost.RenderSize,
+            Math.Round(boundary * dpi) / dpi,
+            chromeBounds,
+            topCornerRadius);
         _windowHost.OpacityMask = _inactiveTitleBarMask.MaskBrush;
     }
 }

--- a/tests/PaperTodo.ThreadingChecks/InactiveTitleBarChecks.cs
+++ b/tests/PaperTodo.ThreadingChecks/InactiveTitleBarChecks.cs
@@ -39,8 +39,11 @@ internal static partial class Program
             host.UpdateLayout();
             var bodyPosition = body.TranslatePoint(new Point(), host);
             var bodySize = body.RenderSize;
+            var paperPosition = paper.TranslatePoint(new Point(), host);
+            var paperBounds = new Rect(paperPosition, paper.RenderSize);
             var cutoff = Math.Round(bodyPosition.Y * scale) / scale;
-            mask.UpdateBounds(size, cutoff);
+            var cornerRadius = paper.CornerRadius.TopLeft;
+            mask.UpdateBounds(size, cutoff, paperBounds, cornerRadius);
             host.OpacityMask = null;
             var original = Render();
             host.OpacityMask = mask.MaskBrush;
@@ -53,11 +56,22 @@ internal static partial class Program
             for (var x = 0; x < width; x++)
                 Assert(hidden[(y * width + x) * 4 + 3] == 0, "hidden title/background/shadow still has alpha");
 
-            // During the fade, body and shadow pixels stay exactly fixed. Attaching the
-            // extra mask surface may round a translucent edge by one alpha/color unit at
-            // fractional pixel sizes; fully opaque body content must still match exactly.
-            var start = ((int)Math.Round(cutoff * scale) + 1) * width * 4;
-            Assert(hidden.AsSpan(start).SequenceEqual(shown.AsSpan(start)), "body pixels changed during the fade");
+            // The hidden body now owns a rounded top aligned to the paper chrome rather than
+            // exposing a full-width rectangular cross-section at the title boundary.
+            Assert(mask.HeaderBottom == cutoff, "title hit-test boundary moved with rounded mask");
+            var cornerX = (int)Math.Round((paperBounds.Left + 1) * scale);
+            var topY = (int)Math.Round((cutoff + 1) * scale);
+            var centerX = (int)Math.Round(size.Width * scale / 2);
+            Assert(hidden[(topY * width + cornerX) * 4 + 3] == 0,
+                "hidden title left a square paper corner");
+            Assert(hidden[(topY * width + centerX) * 4 + 3] > 0,
+                "rounded hidden paper top removed body center pixels");
+
+            // Only the new rounded-corner band is allowed to differ. Below one corner radius,
+            // body and side/bottom shadow pixels remain exactly fixed, and layout never moves.
+            var stableY = (int)Math.Round((cutoff + cornerRadius + 1) * scale);
+            var start = Math.Min(stableY, (int)Math.Ceiling(size.Height * scale) - 1) * width * 4;
+            Assert(hidden.AsSpan(start).SequenceEqual(shown.AsSpan(start)), "body pixels changed below rounded title cutout");
             for (var index = start; index < hidden.Length; index++)
             {
                 var alpha = original[index - index % 4 + 3];


### PR DESCRIPTION
修复失焦隐藏标题栏后纸片顶部被整条矩形遮罩直接截平的问题。

原因：`InactiveTitleBarMask` 之前把标题栏以下区域定义成全宽矩形，标题栏 alpha 归零后，原纸片顶部圆角和阴影也一起被切掉，露出的正文区域自然是一条直边。

这版保留现有“HWND/正文布局不动 + 透明标题区可穿透”的方案，只调整遮罩形状：
- 依据 `_paperChrome` 的实际边界和顶部圆角生成新的圆角正文顶部；
- 标题淡出区域向下覆盖一个圆角半径，并与不透明正文遮罩重叠，使失焦/回焦过程中从完整纸片平滑过渡到圆角截口，不在动画结束时突然跳边；
- `HeaderBottom` 继续保存原标题栏命中边界，不改变正文位置、窗口尺寸和穿透范围；
- 更新 WPF 渲染检查，覆盖“标题区全透明、正文中心保留、顶部角不再方切、圆角带以下像素不移动”。

需要真人桌面重点看一下不同 DPI 下顶部圆角和阴影的观感；逻辑上不再对正文做重排或窗口 resize。