### PR TITLE
修复待办搜索命中不显示高亮

### DIFF
--- a/src/TodoTextBox.cs
+++ b/src/TodoTextBox.cs
@@ -84,6 +84,15 @@ public sealed class TodoTextBox : TextBox
         }
     }
 
+    protected override void OnIsKeyboardFocusWithinChanged(DependencyPropertyChangedEventArgs e)
+    {
+        base.OnIsKeyboardFocusWithinChanged(e);
+        if (_transientFindHighlightEnabled)
+        {
+            InvalidateVisual();
+        }
+    }
+
     protected override void OnRender(DrawingContext drawingContext)
     {
         if (ActualWidth > 0 && ActualHeight > 0)

--- a/src/TodoTextBox.cs
+++ b/src/TodoTextBox.cs
@@ -63,6 +63,15 @@ public sealed class TodoTextBox : TextBox
             DrawSweepSelection(drawingContext);
         }
 
+        if (IsInactiveSelectionHighlightEnabled &&
+            !IsKeyboardFocusWithin &&
+            SelectionLength > 0 &&
+            ActualWidth > 0 &&
+            ActualHeight > 0)
+        {
+            DrawInactiveSelectionHighlight(drawingContext);
+        }
+
         base.OnRender(drawingContext);
 
         if (!IsDone || ActualWidth <= 0 || ActualHeight <= 0)
@@ -149,6 +158,106 @@ public sealed class TodoTextBox : TextBox
 
                 var startRect = CharacterRectOrEmpty(start, trailingEdge: false);
                 var endRect = CharacterRectOrEmpty(endExclusive - 1, trailingEdge: true);
+                if (!IsUsableRect(startRect) || !IsUsableRect(endRect))
+                {
+                    continue;
+                }
+
+                var left = Math.Max(0, startRect.Left);
+                var top = Math.Max(0, Math.Min(startRect.Top, endRect.Top));
+                var right = Math.Min(ActualWidth, endRect.Right);
+                var bottom = Math.Min(ActualHeight, Math.Max(startRect.Bottom, endRect.Bottom));
+                if (right > left && bottom > top)
+                {
+                    drawingContext.DrawRectangle(
+                        selectionBrush,
+                        null,
+                        new Rect(left, top, right - left, bottom - top));
+                }
+            }
+        }
+        finally
+        {
+            drawingContext.Pop();
+        }
+    }
+
+    private void DrawInactiveSelectionHighlight(DrawingContext drawingContext)
+    {
+        var text = Text ?? "";
+        if (text.Length == 0)
+        {
+            return;
+        }
+
+        var selectionStart = Math.Clamp(SelectionStart, 0, text.Length);
+        var selectionEnd = Math.Clamp(
+            selectionStart + SelectionLength,
+            selectionStart,
+            text.Length);
+        if (selectionEnd <= selectionStart)
+        {
+            return;
+        }
+
+        var selectionBrush = SelectionBrush ?? SystemColors.HighlightBrush;
+        var opacity = IsFinite(SelectionOpacity)
+            ? Math.Clamp(SelectionOpacity, 0, 1)
+            : 1;
+        if (opacity <= 0)
+        {
+            return;
+        }
+
+        int lineCount;
+        try
+        {
+            lineCount = Math.Max(1, LineCount);
+        }
+        catch
+        {
+            return;
+        }
+
+        drawingContext.PushOpacity(opacity);
+        try
+        {
+            for (var lineIndex = 0; lineIndex < lineCount; lineIndex++)
+            {
+                int lineStart;
+                int lineLength;
+                try
+                {
+                    lineStart = GetCharacterIndexFromLineIndex(lineIndex);
+                    lineLength = GetLineLength(lineIndex);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (lineStart < 0 || lineStart >= text.Length)
+                {
+                    continue;
+                }
+
+                var visibleLineEnd = Math.Min(
+                    lineStart + Math.Max(0, lineLength),
+                    text.Length);
+                while (visibleLineEnd > lineStart && IsLineBreak(text[visibleLineEnd - 1]))
+                {
+                    visibleLineEnd--;
+                }
+
+                var segmentStart = Math.Max(selectionStart, lineStart);
+                var segmentEnd = Math.Min(selectionEnd, visibleLineEnd);
+                if (segmentEnd <= segmentStart)
+                {
+                    continue;
+                }
+
+                var startRect = CharacterRectOrEmpty(segmentStart, trailingEdge: false);
+                var endRect = CharacterRectOrEmpty(segmentEnd - 1, trailingEdge: true);
                 if (!IsUsableRect(startRect) || !IsUsableRect(endRect))
                 {
                     continue;

--- a/src/TodoTextBox.cs
+++ b/src/TodoTextBox.cs
@@ -15,6 +15,7 @@ public sealed class TodoTextBox : TextBox
     private const double StrikeInset = 3;
     private const double StrikeThickness = 1.35;
     private const double StrikeVerticalRatio = 0.56;
+    private bool _transientFindHighlightEnabled;
 
     public static readonly DependencyProperty IsDoneProperty =
         DependencyProperty.Register(
@@ -42,6 +43,24 @@ public sealed class TodoTextBox : TextBox
         set => SetValue(IsSweepSelectedProperty, value);
     }
 
+    // PaperWindow.Find uses this flag only for its transient search selection. Keep the
+    // state on TodoTextBox instead of enabling WPF's native inactive selection renderer,
+    // which is unreliable across the separate search Popup HWND and can double-paint.
+    internal new bool IsInactiveSelectionHighlightEnabled
+    {
+        get => _transientFindHighlightEnabled;
+        set
+        {
+            if (_transientFindHighlightEnabled == value)
+            {
+                return;
+            }
+
+            _transientFindHighlightEnabled = value;
+            InvalidateVisual();
+        }
+    }
+
     protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
     {
         base.OnPreviewMouseLeftButtonDown(e);
@@ -56,20 +75,30 @@ public sealed class TodoTextBox : TextBox
         e.Handled = true;
     }
 
+    protected override void OnSelectionChanged(RoutedEventArgs e)
+    {
+        base.OnSelectionChanged(e);
+        if (_transientFindHighlightEnabled)
+        {
+            InvalidateVisual();
+        }
+    }
+
     protected override void OnRender(DrawingContext drawingContext)
     {
-        if (IsSweepSelected && ActualWidth > 0 && ActualHeight > 0)
+        if (ActualWidth > 0 && ActualHeight > 0)
         {
-            DrawSweepSelection(drawingContext);
-        }
+            if (IsSweepSelected)
+            {
+                DrawSelectionRange(drawingContext, 0, (Text ?? "").Length);
+            }
 
-        if (IsInactiveSelectionHighlightEnabled &&
-            !IsKeyboardFocusWithin &&
-            SelectionLength > 0 &&
-            ActualWidth > 0 &&
-            ActualHeight > 0)
-        {
-            DrawInactiveSelectionHighlight(drawingContext);
+            if (_transientFindHighlightEnabled &&
+                !IsKeyboardFocusWithin &&
+                SelectionLength > 0)
+            {
+                DrawSelectionRange(drawingContext, SelectionStart, SelectionLength);
+            }
         }
 
         base.OnRender(drawingContext);
@@ -97,102 +126,17 @@ public sealed class TodoTextBox : TextBox
             new Point(Math.Max(StrikeInset, ActualWidth - StrikeInset), y));
     }
 
-    private void DrawSweepSelection(DrawingContext drawingContext)
+    private void DrawSelectionRange(DrawingContext drawingContext, int requestedStart, int requestedLength)
     {
         var text = Text ?? "";
-        if (text.Length == 0)
+        if (text.Length == 0 || requestedLength <= 0)
         {
             return;
         }
 
-        var selectionBrush = SelectionBrush ?? SystemColors.HighlightBrush;
-        var opacity = IsFinite(SelectionOpacity)
-            ? Math.Clamp(SelectionOpacity, 0, 1)
-            : 1;
-        if (opacity <= 0)
-        {
-            return;
-        }
-
-        int lineCount;
-        try
-        {
-            lineCount = Math.Max(1, LineCount);
-        }
-        catch
-        {
-            return;
-        }
-
-        drawingContext.PushOpacity(opacity);
-        try
-        {
-            for (var lineIndex = 0; lineIndex < lineCount; lineIndex++)
-            {
-                int start;
-                int length;
-                try
-                {
-                    start = GetCharacterIndexFromLineIndex(lineIndex);
-                    length = GetLineLength(lineIndex);
-                }
-                catch
-                {
-                    continue;
-                }
-
-                if (start < 0 || start >= text.Length)
-                {
-                    continue;
-                }
-
-                var endExclusive = Math.Min(start + Math.Max(0, length), text.Length);
-                while (endExclusive > start && IsLineBreak(text[endExclusive - 1]))
-                {
-                    endExclusive--;
-                }
-                if (endExclusive <= start)
-                {
-                    continue;
-                }
-
-                var startRect = CharacterRectOrEmpty(start, trailingEdge: false);
-                var endRect = CharacterRectOrEmpty(endExclusive - 1, trailingEdge: true);
-                if (!IsUsableRect(startRect) || !IsUsableRect(endRect))
-                {
-                    continue;
-                }
-
-                var left = Math.Max(0, startRect.Left);
-                var top = Math.Max(0, Math.Min(startRect.Top, endRect.Top));
-                var right = Math.Min(ActualWidth, endRect.Right);
-                var bottom = Math.Min(ActualHeight, Math.Max(startRect.Bottom, endRect.Bottom));
-                if (right > left && bottom > top)
-                {
-                    drawingContext.DrawRectangle(
-                        selectionBrush,
-                        null,
-                        new Rect(left, top, right - left, bottom - top));
-                }
-            }
-        }
-        finally
-        {
-            drawingContext.Pop();
-        }
-    }
-
-    private void DrawInactiveSelectionHighlight(DrawingContext drawingContext)
-    {
-        var text = Text ?? "";
-        if (text.Length == 0)
-        {
-            return;
-        }
-
-        var selectionStart = Math.Clamp(SelectionStart, 0, text.Length);
+        var selectionStart = Math.Clamp(requestedStart, 0, text.Length);
         var selectionEnd = Math.Clamp(
-            selectionStart + SelectionLength,
+            selectionStart + requestedLength,
             selectionStart,
             text.Length);
         if (selectionEnd <= selectionStart)


### PR DESCRIPTION
## 问题

内置全文搜索在待办中可以正确命中、跳转并选中文字，但搜索框拿走键盘焦点后，待办的 `TextBox` 没有可靠显示 inactive selection，高亮视觉因此缺失；Markdown 正文则有自己的 selection reveal 路径，所以表现不一致。

## 修改

- 保留现有搜索匹配、`Select(offset, length)`、跨纸片跳转和清理逻辑不变
- `TodoTextBox` 自己维护搜索期间的临时高亮状态，不再启用 WPF 原生 inactive-selection 绘制，避免 Popup 焦点场景下失效或双层叠色
- 临时高亮开关、`SelectionChanged`、`IsKeyboardFocusWithin` 变化都会主动 `InvalidateVisual()`，保证首次打开、Enter 切换命中、跨待办跳转和关闭搜索都能刷新
- 使用现有 `SelectionBrush` / `SelectionOpacity`，不另造搜索配色
- 把原有整条拖选和搜索命中的逐行矩形计算合并到同一个 `DrawSelectionRange`，减少重复实现
- 按视觉行计算字符矩形，兼容自动折行和跨行选区
- 普通获得焦点后的文本选择仍交给 WPF 原生绘制

## 范围

只修改 `src/TodoTextBox.cs`，不改变搜索算法、全局结果顺序、Markdown 渲染或待办数据。

## 验证

当前分支相对创建 PR 时的 `main` 仍只修改 1 个文件，净 diff 为 +77 / -15。已针对审查发现的“Selection 变化不保证外层 OnRender 重绘”和“可能与 WPF 原生 inactive selection 重复绘制”两个问题补齐显式刷新与独立临时状态。Windows 构建及仓库检查由 CI 验证；当前环境不能进行 WPF 窗口交互手测。